### PR TITLE
Add Phase 1 chat experience foundations: store, types, and roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,353 @@
+# SillyTavern Mobile - Feature Parity Roadmap
+
+## Current State Summary
+
+**sillytavern-mobile** is a React/Vite/Zustand web app with:
+- Basic auth (login/register, multi-user)
+- Character CRUD + import/export (PNG Card V2, JSON)
+- Single & group chat with streaming (SSE)
+- 6 AI providers (OpenAI, Claude, Gemini, Mistral, Groq, OpenRouter)
+- Expression/sprite system with emotion parsing
+- Settings page for API key & provider management
+- Mobile-responsive dark theme
+
+**SillyTavern** (desktop) is a massively feature-rich Node.js SPA with 20+ API backends, World Info/Lorebooks, STscript scripting, 30+ extensions, full prompt engineering, regex scripts, Data Bank/RAG, and deep customization.
+
+---
+
+## Gap Analysis & Roadmap
+
+Features are grouped into **phases** ordered by user impact and dependency. Each phase builds on the previous.
+
+---
+
+## Phase 1: Chat Experience Foundations
+*Goal: Make the chat feel complete and usable for daily use.*
+
+### 1.1 Message Swiping (Alternate Responses)
+- **Gap:** Mobile has no swipe/alternate response support.
+- **ST Feature:** Generate alternative AI responses, navigate between them with arrows.
+- **Work:** Store swipe array per message. Add swipe left/right UI (touch gesture + arrows). Hook into generate endpoint to append swipes. Persist swipes in chat JSONL.
+
+### 1.2 Regenerate / Continue / Impersonate
+- **Gap:** Mobile has basic `editMessageAndRegenerate` but no dedicated regenerate, continue, or impersonate.
+- **ST Feature:** Ctrl+Enter regenerate, Alt+Enter continue (extend last AI message), impersonate (AI writes as user).
+- **Work:** Add regenerate button (re-sends context, replaces last AI message). Add continue action (sends with last AI message as prefix, appends result). Add impersonate action (generates as user persona). Wire into chat input bar as action buttons.
+
+### 1.3 Message Editing Improvements
+- **Gap:** Basic edit exists but no inline editing, no edit-last-with-keyboard.
+- **ST Feature:** Click-to-edit any message, up-arrow edits last, auto-save edits.
+- **Work:** Inline edit mode on message tap. Add edit/delete per-message action menu. Save edits immediately to backend.
+
+### 1.4 Streaming Improvements
+- **Gap:** Basic SSE parsing works but no configurable streaming display.
+- **ST Feature:** Configurable streaming FPS, smooth fade-in, token-by-token rendering.
+- **Work:** Add smooth token rendering with configurable speed. Typing indicator while generating.
+
+### 1.5 Chat File Management
+- **Gap:** Can list/load/save chats but no rename, delete, export, or import chats.
+- **ST Feature:** Full chat CRUD, export as JSONL/plaintext, import from multiple formats.
+- **Work:** Add chat rename, delete, export (JSONL + plaintext). Import JSONL chats. UI for chat history browser.
+
+---
+
+## Phase 2: Character & Persona Depth
+*Goal: Support the full character card spec and user personas.*
+
+### 2.1 Advanced Character Fields
+- **Gap:** Mobile has basic fields (name, description, personality, first_mes, scenario, mes_example, creator_notes, tags). Missing many advanced fields.
+- **ST Feature:** Alternate greetings, character's note (with depth/role config), main prompt override, post-history instructions override, talkativeness, creator, version.
+- **Work:** Add alternate greetings array with swipe UI on first message. Add character's note with depth/role selector. Add system prompt override fields. Store in Character Card V2 `data.extensions` properly.
+
+### 2.2 User Personas
+- **Gap:** No persona system. User is just "You" with a default avatar.
+- **ST Feature:** Named personas with avatar, description, and description position. Persona locking to characters/chats. Default persona.
+- **Work:** Create persona store. Persona CRUD UI. Persona selector in sidebar/header. Description injection into prompt at configurable position. Persona-character locking.
+
+### 2.3 Character Tags & Organization
+- **Gap:** Tags exist on characters but no filtering/organization UI.
+- **ST Feature:** Tag-based filtering, tags-as-folders view, favorites, bulk operations.
+- **Work:** Tag filter bar on character list. Favorite toggle. Sort options (name, date, recent chat). Search/filter characters.
+
+### 2.4 Character Duplicate & Convert
+- **Gap:** No duplicate or convert-to-persona.
+- **ST Feature:** One-click duplicate, convert character to persona.
+- **Work:** Add duplicate action. Add convert-to-persona action. Wire into character action menu.
+
+---
+
+## Phase 3: Prompt Engineering & Generation Control
+*Goal: Give users control over how prompts are built and how the AI generates.*
+
+### 3.1 Sampler Parameters
+- **Gap:** Hardcoded `max_tokens: 1024, temperature: 0.9`. No other sampler controls.
+- **ST Feature:** Temperature, Top P, Top K, Min P, frequency/presence penalty, repetition penalty, custom stopping strings, and 15+ advanced samplers.
+- **Work:** Add generation settings panel. Per-provider parameter support (different providers support different params). Persist in settings. Add preset save/load.
+
+### 3.2 System Prompt / Main Prompt Editing
+- **Gap:** System prompt is hardcoded in chatStore.
+- **ST Feature:** Editable main prompt, post-history instructions, jailbreak prompt, auxiliary prompt.
+- **Work:** Move system prompt to settings store. Add editable system prompt field. Add post-history instructions. Support `{{char}}`/`{{user}}` macros in prompts.
+
+### 3.3 Basic Macro System
+- **Gap:** No macro support.
+- **ST Feature:** 100+ macros (`{{char}}`, `{{user}}`, `{{time}}`, `{{date}}`, `{{random}}`, etc.).
+- **Work:** Implement macro parser. Start with core macros: `{{char}}`, `{{user}}`, `{{time}}`, `{{date}}`, `{{weekday}}`, `{{random}}`, `{{pick}}`, `{{lastMessage}}`, `{{personality}}`, `{{description}}`, `{{scenario}}`, `{{persona}}`. Apply in system prompt, character fields, and user messages.
+
+### 3.4 Context Size Management
+- **Gap:** Hardcoded context window (last 20-30 messages). No token counting.
+- **ST Feature:** Token-aware context building, configurable context size per model, token counter display.
+- **Work:** Add approximate token counting (tiktoken for OpenAI, cl100k for Claude, character-based estimate as fallback). Configurable context size. Fill context intelligently rather than fixed message count. Show token usage in UI.
+
+### 3.5 Instruct Mode (Text Completion APIs)
+- **Gap:** Only supports chat completion format.
+- **ST Feature:** Instruct templates for text completion models (Alpaca, ChatML, Llama, Mistral, etc.).
+- **Work:** Add instruct mode toggle. Template system with prefix/suffix for user/assistant/system. Pre-built templates for common formats. Template editor.
+
+---
+
+## Phase 4: World Info / Lorebook
+*Goal: Enable persistent world-building context injection.*
+
+### 4.1 Basic World Info
+- **Gap:** No World Info support at all.
+- **ST Feature:** Keyword-triggered lore entries injected into context.
+- **Work:** World Info store and CRUD UI. Entry fields: keys, content, position, insertion order. Keyword scanning against recent messages. Inject matching entries into prompt. Import/export World Info JSON.
+
+### 4.2 Advanced World Info
+- **Gap:** N/A (depends on 4.1).
+- **ST Feature:** Secondary keys (AND/NOT logic), regex keys, scan depth, case sensitivity, probability, inclusion groups, timed effects (sticky/cooldown/delay), recursive scanning.
+- **Work:** Add secondary key logic. Regex key support. Configurable scan depth. Probability activation. Token budget management. Inclusion groups for mutually exclusive entries.
+
+### 4.3 Character-Embedded Lorebooks
+- **Gap:** N/A.
+- **ST Feature:** Lorebooks embedded in character cards, auto-loaded on character select.
+- **Work:** Read/write `data.character_book` from Character Card V2. Auto-activate character lore on selection. Support additional lorebook linking.
+
+---
+
+## Phase 5: Group Chat Enhancements
+*Goal: Bring group chats to ST-level functionality.*
+
+### 5.1 Activation Strategies
+- **Gap:** Basic sequential group chat exists. No activation mode selection.
+- **ST Feature:** Natural Order (name mentions + talkativeness), List Order, Pooled Order, Manual trigger.
+- **Work:** Add activation strategy selector. Implement Natural Order (parse last message for name mentions, use talkativeness field). Pooled Order (random from non-recent speakers). Manual mode with character trigger buttons.
+
+### 5.2 Group Chat Controls
+- **Gap:** Can add characters but no mute, reorder, force-talk, or auto-mode.
+- **ST Feature:** Mute/unmute members, force individual response, auto-mode (continuous generation), character reordering, allow self-responses toggle.
+- **Work:** Add mute toggle per member. Force-talk button. Auto-mode with configurable delay. Drag-to-reorder member list. Group scenario override.
+
+### 5.3 Character Card Handling in Groups
+- **Gap:** Basic per-character system prompts. No join mode.
+- **ST Feature:** Swap mode (only active speaker's info) vs Join mode (all members' info combined).
+- **Work:** Add character card handling strategy selector. Implement join mode with configurable prefix/suffix.
+
+---
+
+## Phase 6: UI/UX Polish & Theming
+*Goal: Match ST's customization depth while staying mobile-first.*
+
+### 6.1 Theme System
+- **Gap:** Single hardcoded dark theme.
+- **ST Feature:** Full color customization, multiple themes, import/export themes, custom CSS editor.
+- **Work:** CSS variable-based theme system. Light/dark mode toggle. Theme presets. Color customization UI. Theme import/export.
+
+### 6.2 Chat Display Styles
+- **Gap:** Single message display style.
+- **ST Feature:** Flat (log), Bubbles (messenger), Document (compact). Avatar shapes. Font scale. Chat width.
+- **Work:** Add style selector (flat/bubbles/document). Configurable avatar shape. Font size slider. Chat width control.
+
+### 6.3 Mobile-Specific UX
+- **Gap:** Basic mobile layout exists but needs refinement.
+- **ST Feature:** Responsive panels, gesture navigation, mobile-optimized controls.
+- **Work:** Swipe gestures for sidebar toggle. Pull-to-refresh. Bottom sheet for actions. Haptic feedback. Better keyboard handling. Landscape mode support. PWA install prompt.
+
+### 6.4 Visual Novel Mode
+- **Gap:** Sprites show in a small area during chat.
+- **ST Feature:** Full visual novel mode with central sprite display, backgrounds, multi-character layout.
+- **Work:** VN mode toggle. Full-screen sprite display behind chat. Background image support. Multi-character sprite positioning in group chats. Sprite costume system (`/costume` command equivalent).
+
+### 6.5 Message Formatting & Markdown
+- **Gap:** Basic `*action*` and `{{thought}}` formatting.
+- **ST Feature:** Full Markdown/HTML rendering, bold/italic/underline/strikethrough/code, quote blocks, inline images/embeds.
+- **Work:** Add Markdown renderer (react-markdown or similar). Support bold, italic, underline, strikethrough, code blocks, blockquotes. Preserve existing action/thought formatting.
+
+---
+
+## Phase 7: Extensions Core
+*Goal: Build the extension infrastructure and implement high-value extensions.*
+
+### 7.1 Extension System Architecture
+- **Gap:** No extension system.
+- **ST Feature:** Modular extension loading, enable/disable, install from URL.
+- **Work:** Design extension interface (hooks, slots, settings). Extension registry and loader. Extension settings UI. Enable/disable toggles.
+
+### 7.2 TTS (Text-to-Speech)
+- **Gap:** No TTS.
+- **ST Feature:** 18+ TTS providers, per-character voice, auto-narrate.
+- **Work:** Start with browser SpeechSynthesis API + Edge TTS + ElevenLabs. Per-character voice assignment. Play/stop controls on messages. Auto-narrate toggle.
+
+### 7.3 Image Generation
+- **Gap:** No image generation.
+- **ST Feature:** 20+ backends, multiple generation modes (character portrait, scene, background).
+- **Work:** Start with OpenAI DALL-E + Stable Diffusion API. Generate from message context. Display inline in chat. Save to gallery.
+
+### 7.4 Chat Translation
+- **Gap:** No translation.
+- **ST Feature:** Translate messages to/from different languages.
+- **Work:** Add translation via LLM or dedicated translation API. Per-message translate button. Auto-translate incoming/outgoing toggle.
+
+### 7.5 Summarization
+- **Gap:** No summarization.
+- **ST Feature:** Auto-summarize chat history for context compression.
+- **Work:** Periodic summary generation using active LLM. Summary injection at configurable depth. Manual trigger. Summary display in UI.
+
+---
+
+## Phase 8: Advanced Features
+*Goal: Power-user features that complete the parity picture.*
+
+### 8.1 Author's Note
+- **Gap:** No Author's Note.
+- **ST Feature:** Persistent instruction injected at configurable depth in context. Editable per-chat.
+- **Work:** Author's Note input field. Configurable insertion depth and role. Persist per-chat. Quick-edit access.
+
+### 8.2 Regex Scripts
+- **Gap:** No regex processing.
+- **ST Feature:** Find/replace regex on input/output, display-only or permanent, per-character scoping.
+- **Work:** Regex script store. CRUD UI. Scope selection (user input, AI output, display-only, permanent). Ordering and enable/disable. Import/export.
+
+### 8.3 Quick Replies
+- **Gap:** No quick replies.
+- **ST Feature:** Configurable single-click responses, automation triggers, STscript integration.
+- **Work:** Quick reply preset system. Button bar above chat input. Support text macros in quick replies. Auto-execute triggers (on AI message, on chat load).
+
+### 8.4 Connection Profiles
+- **Gap:** Single active provider/model. No saved configurations.
+- **ST Feature:** Save/switch between complete API configurations.
+- **Work:** Profile store. Save current config as profile. Switch profiles from dropdown. Profile includes: provider, model, API key reference, sampler settings.
+
+### 8.5 Data Bank / RAG
+- **Gap:** No RAG/vector storage.
+- **ST Feature:** Document upload, vectorization, semantic retrieval, multi-scope data banks.
+- **Work:** Document upload and chunking. Embedding via API (OpenAI embeddings). Vector similarity search. Inject relevant chunks into context. Per-character and global scopes.
+
+### 8.6 Chat Branching & Checkpoints
+- **Gap:** No branching.
+- **ST Feature:** Create checkpoint at any message, branch into alternate story paths, navigate between branches.
+- **Work:** Branch data model (tree structure). Create branch action on messages. Branch navigator UI. Branch naming.
+
+### 8.7 Basic STscript / Slash Commands
+- **Gap:** No scripting.
+- **ST Feature:** Full STscript language with 100+ commands.
+- **Work:** Implement command parser for `/` prefix. Start with core commands: `/sys`, `/send`, `/sendas`, `/trigger`, `/gen`, `/continue`, `/swipe`, `/persona`, `/go`, `/bg`. Pipe system for chaining. Variable get/set.
+
+---
+
+## Phase 9: Prompt Manager & Advanced Prompt Control
+*Goal: Full prompt engineering capabilities.*
+
+### 9.1 Prompt Manager UI
+- **Gap:** No prompt manager. Fixed prompt structure.
+- **ST Feature:** Drag-and-drop ordering of all prompt elements, toggle visibility, custom prompt slots.
+- **Work:** Visual prompt order editor. Drag-and-drop reordering. Enable/disable per prompt section. Custom prompt insertion points.
+
+### 9.2 Prompt Templates & Presets
+- **Gap:** No presets.
+- **ST Feature:** Save/load prompt configurations, share presets.
+- **Work:** Preset save/load system. Import/export presets. Built-in starter presets.
+
+### 9.3 Full Macro System
+- **Gap:** Only core macros from Phase 3.
+- **ST Feature:** 100+ macros including conditionals, variables, math, chat history queries.
+- **Work:** Extend macro parser with: `{{if}}`/`{{else}}`/`{{/if}}`, `{{getvar}}`/`{{setvar}}`, `{{random}}` with full syntax, `{{lastMessage}}`, `{{lastCharMessage}}`, `{{lastUserMessage}}`, `{{maxPrompt}}`, `{{model}}`, `{{isMobile}}`.
+
+---
+
+## Phase 10: Additional API Backend Support
+*Goal: Support the full range of AI backends that ST users expect.*
+
+### 10.1 Local Model Support
+- **Gap:** No local model support.
+- **ST Feature:** KoboldCpp, llama.cpp, Ollama, Oobabooga, TabbyAPI.
+- **Work:** Add OpenAI-compatible custom endpoint configuration (covers Ollama, LM Studio, llama.cpp server, KoboldCpp, etc.). URL + optional API key input. Model list auto-fetch where supported.
+
+### 10.2 Additional Cloud Providers
+- **Gap:** 6 providers (OpenAI, Claude, Gemini, Mistral, Groq, OpenRouter).
+- **ST Feature:** 15+ cloud providers.
+- **Work:** Add: DeepSeek, Cohere, NovelAI, AI Horde (free community), Perplexity, Fireworks AI. Each needs: auth config, model list, request/response mapping, streaming support.
+
+### 10.3 Text Completion API Support
+- **Gap:** Only chat completion format.
+- **ST Feature:** Full text completion support for local models.
+- **Work:** Text completion request builder. Instruct mode integration. Context template system. Model-specific tokenizer selection.
+
+---
+
+## Priority Matrix
+
+| Phase | Impact | Effort | Priority |
+|-------|--------|--------|----------|
+| 1. Chat Experience | Very High | Medium | **P0 - Do First** |
+| 2. Character & Persona | High | Medium | **P0 - Do First** |
+| 3. Prompt Engineering | High | Medium | **P1 - Essential** |
+| 4. World Info | High | Large | **P1 - Essential** |
+| 5. Group Chat | Medium | Medium | **P2 - Important** |
+| 6. UI/UX Polish | High | Medium | **P1 - Essential** |
+| 7. Extensions | Medium | Large | **P2 - Important** |
+| 8. Advanced Features | Medium | Large | **P3 - Nice to Have** |
+| 9. Prompt Manager | Medium | Medium | **P2 - Important** |
+| 10. API Backends | Medium | Medium | **P2 - Important** |
+
+---
+
+## Recommended Execution Order
+
+```
+Phase 1 (Chat Experience) ──────────┐
+Phase 2 (Characters & Personas) ────┤── Sprint 1-3: Core UX
+Phase 6.5 (Markdown Rendering) ─────┘
+
+Phase 3 (Prompt & Generation) ──────┐
+Phase 6.1-6.2 (Themes & Styles) ────┤── Sprint 4-6: Customization
+Phase 10.1 (Custom Endpoints) ──────┘
+
+Phase 4 (World Info) ───────────────┐
+Phase 5 (Group Chat) ───────────────┤── Sprint 7-9: Depth Features
+Phase 8.1-8.2 (Author's Note, Regex)┘
+
+Phase 7 (Extensions) ──────────────┐
+Phase 8.3-8.6 (Quick Replies, RAG) ┤── Sprint 10-12: Extensions
+Phase 9 (Prompt Manager) ──────────┘
+
+Phase 8.7 (STscript) ──────────────┐
+Phase 10.2-10.3 (More APIs) ───────┤── Sprint 13+: Power User
+Phase 6.3-6.4 (Mobile UX, VN Mode) ┘
+```
+
+---
+
+## What Mobile Should NOT Replicate
+
+Some ST features are desktop-specific or inappropriate for mobile:
+
+- **MovingUI drag-and-drop panels** - Not suited for touch interfaces
+- **Server plugins (Node.js)** - Mobile is a client-only app
+- **Custom CSS editor** - Too complex for mobile; use theme presets instead
+- **Full STscript IDE** - Support running scripts, but editing is better on desktop
+- **Server administration** - Config.yaml editing, user management should stay server-side
+- **Extension installation from URL** - Security risk on mobile; curate a built-in set
+
+---
+
+## Metrics for "Feature Parity"
+
+True 100% parity is neither achievable nor desirable for mobile. Target:
+
+- **Core Parity (Phases 1-4):** Users can have the same quality conversations with the same characters using the same context/lore. **Target: 100%**
+- **Customization Parity (Phases 5-6):** Users can personalize their experience. **Target: 80%**
+- **Extension Parity (Phase 7):** Most-used extensions work. **Target: 60%** (TTS, image gen, translation, summarization)
+- **Power User Parity (Phases 8-10):** Advanced features available. **Target: 50%** (regex, quick replies, connection profiles, RAG)
+- **Scripting Parity (STscript):** Basic command execution. **Target: 30%** (run scripts, not write them)

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -309,7 +309,8 @@ export const api = {
     messages: { role: 'user' | 'assistant' | 'system'; content: string }[],
     _characterName: string,
     provider?: string,
-    model?: string
+    model?: string,
+    signal?: AbortSignal
   ): Promise<ReadableStream<Uint8Array> | null> {
     const token = await getCsrfToken();
 
@@ -320,6 +321,7 @@ export const api = {
         'X-CSRF-Token': token,
       },
       credentials: 'include',
+      signal,
       body: JSON.stringify({
         messages,
         stream: true,

--- a/src/components/ui/ConfirmDialog.tsx
+++ b/src/components/ui/ConfirmDialog.tsx
@@ -1,0 +1,43 @@
+import { Modal } from './Modal';
+import { Button } from './Button';
+
+interface ConfirmDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  title: string;
+  message: string;
+  confirmLabel?: string;
+  danger?: boolean;
+}
+
+export function ConfirmDialog({
+  isOpen,
+  onClose,
+  onConfirm,
+  title,
+  message,
+  confirmLabel = 'Confirm',
+  danger = false,
+}: ConfirmDialogProps) {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title={title} size="sm">
+      <p className="text-sm text-[var(--color-text-secondary)] mb-6">{message}</p>
+      <div className="flex justify-end gap-3">
+        <Button variant="ghost" size="sm" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button
+          variant={danger ? 'danger' : 'primary'}
+          size="sm"
+          onClick={() => {
+            onConfirm();
+            onClose();
+          }}
+        >
+          {confirmLabel}
+        </Button>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -5,3 +5,4 @@ export { Modal } from './Modal';
 export { TextArea } from './TextArea';
 export { ImageUpload } from './ImageUpload';
 export { ExpressionUpload } from './ExpressionUpload';
+export { ConfirmDialog } from './ConfirmDialog';

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -3,7 +3,7 @@ import { api, type CharacterInfo } from '../api/client';
 import { useSettingsStore } from './settingsStore';
 import { parseEmotion, stripEmotionTag, type Emotion } from '../utils/emotions';
 
-interface ChatMessage {
+export interface ChatMessage {
   id: string;
   name: string;
   isUser: boolean;
@@ -11,8 +11,9 @@ interface ChatMessage {
   content: string;
   timestamp: number;
   emotion?: Emotion | null;
-  // For group chat - track which character's avatar to use
   characterAvatar?: string;
+  swipes: string[];
+  swipeId: number;
 }
 
 interface ChatFile {
@@ -29,10 +30,8 @@ export interface GroupChatInfo {
   createdAt: number;
 }
 
-// Local storage key for group chat metadata
 const GROUP_CHATS_KEY = 'sillytavern_group_chats';
 
-// Load group chats from localStorage
 function loadGroupChatsFromStorage(): GroupChatInfo[] {
   try {
     const stored = localStorage.getItem(GROUP_CHATS_KEY);
@@ -42,7 +41,6 @@ function loadGroupChatsFromStorage(): GroupChatInfo[] {
   }
 }
 
-// Save group chats to localStorage
 function saveGroupChatsToStorage(groupChats: GroupChatInfo[]) {
   localStorage.setItem(GROUP_CHATS_KEY, JSON.stringify(groupChats));
 }
@@ -54,21 +52,34 @@ interface ChatState {
   currentChatFile: string | null;
   isLoading: boolean;
   isSending: boolean;
+  isStreaming: boolean;
   error: string | null;
+  abortController: AbortController | null;
 
-  // Actions
+  // Existing actions
   fetchChatFiles: (avatarUrl: string) => Promise<void>;
   loadChat: (avatarUrl: string, fileName: string) => Promise<void>;
   loadGroupChat: (groupChat: GroupChatInfo) => Promise<void>;
   startNewChat: (character: CharacterInfo) => Promise<void>;
   startNewGroupChat: (characters: CharacterInfo[]) => Promise<void>;
-  addMessage: (message: Omit<ChatMessage, 'id'>) => void;
+  addMessage: (message: Omit<ChatMessage, 'id' | 'swipes' | 'swipeId'>) => void;
   sendMessage: (content: string, character: CharacterInfo, availableEmotions?: string[]) => Promise<void>;
   sendGroupMessage: (content: string, characters: CharacterInfo[]) => Promise<void>;
   editMessageAndRegenerate: (messageId: string, newContent: string, character: CharacterInfo, availableEmotions?: string[]) => Promise<void>;
   clearChat: () => void;
   refreshGroupChats: () => void;
   deleteGroupChat: (fileName: string) => void;
+
+  // New Phase 1 actions
+  stopGeneration: () => void;
+  editMessage: (messageId: string, newContent: string) => void;
+  deleteMessage: (messageId: string) => void;
+  swipeLeft: (messageId: string) => void;
+  swipeRight: (messageId: string, character: CharacterInfo, availableEmotions?: string[]) => Promise<void>;
+  regenerateMessage: (character: CharacterInfo, availableEmotions?: string[]) => Promise<void>;
+  continueMessage: (character: CharacterInfo, availableEmotions?: string[]) => Promise<void>;
+  impersonate: (character: CharacterInfo, availableEmotions?: string[]) => Promise<string>;
+  deleteChat: (avatarUrl: string, fileName: string) => Promise<void>;
 }
 
 let messageIdCounter = 0;
@@ -90,9 +101,8 @@ async function* parseSSEStream(
       const chunk = decoder.decode(value, { stream: true });
       buffer += chunk;
 
-      // Process complete lines (SSE uses \n\n as delimiter, but we split by \n)
       const lines = buffer.split('\n');
-      buffer = lines.pop() || ''; // Keep incomplete line in buffer
+      buffer = lines.pop() || '';
 
       for (const line of lines) {
         const trimmed = line.trim();
@@ -100,49 +110,28 @@ async function* parseSSEStream(
 
         if (trimmed.startsWith('data: ')) {
           const data = trimmed.slice(6);
-
-          // Skip empty data
           if (!data || data === '[DONE]') continue;
 
           try {
             const json = JSON.parse(data);
-
-            // Handle different response formats from various providers
             const content =
-              // OpenAI streaming format
               json.choices?.[0]?.delta?.content ||
-              // Text completion format
               json.choices?.[0]?.text ||
-              // Claude/Anthropic streaming format
               json.delta?.text ||
-              // Claude content block delta
               (json.type === 'content_block_delta' ? json.delta?.text : null) ||
-              // Simple content field
               json.content ||
-              // Message content array (Claude)
               json.message?.content?.[0]?.text ||
               '';
-
-            if (content) {
-              yield content;
-            }
+            if (content) yield content;
           } catch {
-            // Non-JSON data line, might be raw text - yield it directly
-            if (data.length > 0 && data !== 'undefined') {
-              yield data;
-            }
+            if (data.length > 0 && data !== 'undefined') yield data;
           }
         } else if (!trimmed.startsWith(':') && !trimmed.startsWith('event:')) {
-          // Not a comment or event line - might be raw text response
-          // Some backends return plain text without SSE formatting
-          if (trimmed.length > 0) {
-            yield trimmed;
-          }
+          if (trimmed.length > 0) yield trimmed;
         }
       }
     }
 
-    // Process any remaining buffer content
     if (buffer.trim()) {
       const trimmed = buffer.trim();
       if (trimmed.startsWith('data: ')) {
@@ -174,7 +163,6 @@ function buildConversationContext(
 ): { role: 'user' | 'assistant' | 'system'; content: string }[] {
   const context: { role: 'user' | 'assistant' | 'system'; content: string }[] = [];
 
-  // Add character system prompt
   const systemPrompt = [
     character.description && `Description: ${character.description}`,
     character.personality && `Personality: ${character.personality}`,
@@ -183,7 +171,6 @@ function buildConversationContext(
     .filter(Boolean)
     .join('\n\n');
 
-  // Emotion tag instruction - use available emotions if provided, otherwise give guidance
   const emotionList = availableEmotions && availableEmotions.length > 0
     ? availableEmotions.join(', ')
     : 'neutral (or any emotion that fits the moment)';
@@ -209,7 +196,6 @@ Choose the emotion that best matches how ${character.name} would feel based on t
     });
   }
 
-  // Add conversation history (last 20 messages to avoid token limits)
   const recentMessages = messages.slice(-20);
   for (const msg of recentMessages) {
     if (msg.isSystem) continue;
@@ -230,7 +216,6 @@ function buildGroupConversationContext(
 ): { role: 'user' | 'assistant' | 'system'; content: string }[] {
   const context: { role: 'user' | 'assistant' | 'system'; content: string }[] = [];
 
-  // Build character descriptions for all participants
   const characterDescriptions = characters.map((char) => {
     const details = [
       char.description && `Description: ${char.description}`,
@@ -239,7 +224,6 @@ function buildGroupConversationContext(
     return `- ${char.name}: ${details || 'A character in the conversation'}`;
   }).join('\n');
 
-  // System prompt for group chat
   const systemPrompt = `This is a group chat with multiple characters. You are playing ${currentCharacter.name}.
 
 Characters in this conversation:
@@ -255,16 +239,12 @@ IMPORTANT:
 
   context.push({ role: 'system', content: systemPrompt });
 
-  // Add conversation history with character names for context
-  const recentMessages = messages.slice(-30); // More context for group chats
+  const recentMessages = messages.slice(-30);
   for (const msg of recentMessages) {
     if (msg.isSystem) continue;
-
-    // For group chats, include the speaker's name in the content
     const contentWithName = msg.isUser
       ? msg.content
       : `[${msg.name}]: ${msg.content}`;
-
     context.push({
       role: msg.isUser ? 'user' : 'assistant',
       content: contentWithName,
@@ -274,6 +254,105 @@ IMPORTANT:
   return context;
 }
 
+// Helper: get provider/model with auto-switch
+function getProviderAndModel(): { provider: string; model: string } {
+  const { activeProvider, activeModel, secrets } = useSettingsStore.getState();
+
+  let provider = activeProvider;
+  let model = activeModel;
+
+  if (!provider || provider === 'openai') {
+    const hasOpenAI = Array.isArray(secrets['api_key_openai']) && secrets['api_key_openai'].length > 0;
+    const hasClaude = Array.isArray(secrets['api_key_claude']) && secrets['api_key_claude'].length > 0;
+    if (!hasOpenAI && hasClaude) {
+      provider = 'claude';
+      model = 'claude-sonnet-4-20250514';
+      useSettingsStore.setState({ activeProvider: provider, activeModel: model });
+    }
+  }
+
+  return { provider, model };
+}
+
+// Helper: save chat to backend
+async function saveChatToBackend(
+  messages: ChatMessage[],
+  character: CharacterInfo,
+  currentChatFile: string | null,
+  isGroupChat?: boolean,
+  groupCharacters?: CharacterInfo[]
+) {
+  if (!currentChatFile) return;
+
+  const chatData = [
+    {
+      user_name: 'You',
+      character_name: isGroupChat && groupCharacters
+        ? groupCharacters.map(c => c.name).join(', ')
+        : character.name,
+      create_date: new Date().toISOString(),
+      ...(isGroupChat ? { is_group_chat: true } : {}),
+    },
+    ...messages.map((msg) => ({
+      name: msg.name,
+      is_user: msg.isUser,
+      is_system: msg.isSystem,
+      mes: msg.content,
+      send_date: msg.timestamp,
+      swipes: msg.swipes,
+      swipe_id: msg.swipeId,
+      ...(msg.characterAvatar ? { character_avatar: msg.characterAvatar } : {}),
+    })),
+  ];
+
+  const avatarUrl = isGroupChat && groupCharacters
+    ? groupCharacters[0].avatar
+    : character.avatar;
+
+  try {
+    await api.saveChat(avatarUrl, currentChatFile, chatData);
+  } catch (err) {
+    console.error('[Chat] Failed to save:', err);
+  }
+}
+
+// Helper: create a message with swipe defaults
+function createMessage(data: Omit<ChatMessage, 'id' | 'swipes' | 'swipeId'>): ChatMessage {
+  return {
+    ...data,
+    id: generateId(),
+    swipes: [data.content],
+    swipeId: 0,
+  };
+}
+
+// Helper: normalize loaded messages to always have swipes
+function normalizeMessage(msg: {
+  name: string;
+  is_user: boolean;
+  is_system: boolean;
+  mes: string;
+  send_date: number;
+  swipes?: string[];
+  swipe_id?: number;
+  character_avatar?: string;
+}): ChatMessage {
+  const content = msg.swipes && msg.swipe_id !== undefined
+    ? msg.swipes[msg.swipe_id] ?? msg.mes
+    : msg.mes;
+  return {
+    id: generateId(),
+    name: msg.name,
+    isUser: msg.is_user,
+    isSystem: msg.is_system,
+    content,
+    timestamp: msg.send_date,
+    swipes: msg.swipes && msg.swipes.length > 0 ? msg.swipes : [msg.mes],
+    swipeId: msg.swipe_id ?? 0,
+    characterAvatar: msg.character_avatar,
+  };
+}
+
 export const useChatStore = create<ChatState>((set, get) => ({
   messages: [],
   chatFiles: [],
@@ -281,7 +360,9 @@ export const useChatStore = create<ChatState>((set, get) => ({
   currentChatFile: null,
   isLoading: false,
   isSending: false,
+  isStreaming: false,
   error: null,
+  abortController: null,
 
   refreshGroupChats: () => {
     set({ groupChats: loadGroupChatsFromStorage() });
@@ -298,14 +379,11 @@ export const useChatStore = create<ChatState>((set, get) => ({
     set({ isLoading: true, error: null });
     try {
       const chats = await api.getChats(avatarUrl);
-      console.log('[Chat] Fetched chat files for', avatarUrl, ':', chats);
       const chatFiles: ChatFile[] = chats.map((chat) => ({
-        // Strip .jsonl extension - backend adds it when loading/saving
         fileName: chat.file_name?.replace(/\.jsonl$/, '') || chat.file_name,
         fileSize: chat.file_size,
         lastMessage: chat.last_mes,
       }));
-      console.log('[Chat] Processed chat files:', chatFiles);
       set({ chatFiles, isLoading: false });
     } catch (error) {
       set({
@@ -316,19 +394,10 @@ export const useChatStore = create<ChatState>((set, get) => ({
   },
 
   loadChat: async (avatarUrl: string, fileName: string) => {
-    console.log('[Chat] Loading chat:', avatarUrl, fileName);
     set({ isLoading: true, error: null, currentChatFile: fileName });
     try {
       const rawMessages = await api.getChatMessages(avatarUrl, fileName);
-      console.log('[Chat] Loaded messages:', rawMessages?.length || 0);
-      const messages: ChatMessage[] = rawMessages.map((msg) => ({
-        id: generateId(),
-        name: msg.name,
-        isUser: msg.is_user,
-        isSystem: msg.is_system,
-        content: msg.mes,
-        timestamp: msg.send_date,
-      }));
+      const messages = rawMessages.map(normalizeMessage);
       set({ messages, isLoading: false });
     } catch (error) {
       set({
@@ -341,87 +410,48 @@ export const useChatStore = create<ChatState>((set, get) => ({
   startNewChat: async (character: CharacterInfo) => {
     const messages: ChatMessage[] = [];
 
-    // Add character's first message if available
     if (character.first_mes) {
-      messages.push({
-        id: generateId(),
+      messages.push(createMessage({
         name: character.name,
         isUser: false,
         isSystem: false,
         content: character.first_mes,
         timestamp: Date.now(),
         characterAvatar: character.avatar,
-      });
+      }));
     }
 
     const fileName = await api.createChat(character.name);
-    console.log('[Chat] Starting new chat, fileName:', fileName);
-    set({
-      messages,
-      currentChatFile: fileName,
-      error: null,
-    });
-  },
-
-  loadGroupChat: async (groupChat: GroupChatInfo) => {
-    console.log('[GroupChat] Loading group chat:', groupChat.fileName);
-    set({ isLoading: true, error: null, currentChatFile: groupChat.fileName });
-    try {
-      // Load from first character's avatar (where it's stored)
-      const rawMessages = await api.getChatMessages(groupChat.characterAvatars[0], groupChat.fileName);
-      console.log('[GroupChat] Loaded messages:', rawMessages?.length || 0);
-      const messages: ChatMessage[] = rawMessages.map((msg) => ({
-        id: generateId(),
-        name: msg.name,
-        isUser: msg.is_user,
-        isSystem: msg.is_system,
-        content: msg.mes,
-        timestamp: msg.send_date,
-        characterAvatar: msg.character_avatar,
-      }));
-      set({ messages, isLoading: false });
-    } catch (error) {
-      set({
-        isLoading: false,
-        error: error instanceof Error ? error.message : 'Failed to load group chat',
-      });
-    }
+    set({ messages, currentChatFile: fileName, error: null });
   },
 
   startNewGroupChat: async (characters: CharacterInfo[]) => {
     const messages: ChatMessage[] = [];
 
-    // Add a system message about the group chat
-    messages.push({
-      id: generateId(),
+    messages.push(createMessage({
       name: 'System',
       isUser: false,
       isSystem: true,
       content: `Group chat started with ${characters.map(c => c.name).join(', ')}`,
       timestamp: Date.now(),
-    });
+    }));
 
-    // Add first messages from each character that has one
     for (const character of characters) {
       if (character.first_mes) {
-        messages.push({
-          id: generateId(),
+        messages.push(createMessage({
           name: character.name,
           isUser: false,
           isSystem: false,
           content: character.first_mes,
-          timestamp: Date.now() + characters.indexOf(character), // Slight offset for ordering
+          timestamp: Date.now() + characters.indexOf(character),
           characterAvatar: character.avatar,
-        });
+        }));
       }
     }
 
-    // Create chat file with combined character names
     const groupName = `Group_${characters.map(c => c.name).join('_')}`;
     const fileName = await api.createChat(groupName);
-    console.log('[Chat] Starting new group chat, fileName:', fileName);
 
-    // Save group chat metadata to localStorage
     const { groupChats } = get();
     const newGroupChat: GroupChatInfo = {
       fileName,
@@ -442,17 +472,255 @@ export const useChatStore = create<ChatState>((set, get) => ({
   },
 
   addMessage: (message) => {
-    const newMessage: ChatMessage = {
-      ...message,
-      id: generateId(),
-    };
+    const newMessage = createMessage(message);
     set((state) => ({ messages: [...state.messages, newMessage] }));
   },
 
+  // ---- Stop Generation ----
+  stopGeneration: () => {
+    const { abortController } = get();
+    if (abortController) {
+      abortController.abort();
+    }
+    set({ isSending: false, isStreaming: false, abortController: null });
+  },
+
+  // ---- Edit Message (save only, no regeneration) ----
+  editMessage: (messageId: string, newContent: string) => {
+    set((state) => ({
+      messages: state.messages.map((msg) => {
+        if (msg.id !== messageId) return msg;
+        const newSwipes = [...msg.swipes];
+        newSwipes[msg.swipeId] = newContent;
+        return { ...msg, content: newContent, swipes: newSwipes };
+      }),
+    }));
+  },
+
+  // ---- Delete Message ----
+  deleteMessage: (messageId: string) => {
+    set((state) => ({
+      messages: state.messages.filter((msg) => msg.id !== messageId),
+    }));
+  },
+
+  // ---- Swipe Left (previous swipe) ----
+  swipeLeft: (messageId: string) => {
+    set((state) => ({
+      messages: state.messages.map((msg) => {
+        if (msg.id !== messageId || msg.swipeId <= 0) return msg;
+        const newSwipeId = msg.swipeId - 1;
+        return { ...msg, swipeId: newSwipeId, content: msg.swipes[newSwipeId] };
+      }),
+    }));
+  },
+
+  // ---- Swipe Right (next swipe, or generate new if at end) ----
+  swipeRight: async (messageId: string, character: CharacterInfo, availableEmotions?: string[]) => {
+    const { messages } = get();
+    const msg = messages.find((m) => m.id === messageId);
+    if (!msg) return;
+
+    // If there's a next swipe, just navigate to it
+    if (msg.swipeId < msg.swipes.length - 1) {
+      set((state) => ({
+        messages: state.messages.map((m) => {
+          if (m.id !== messageId) return m;
+          const newSwipeId = m.swipeId + 1;
+          return { ...m, swipeId: newSwipeId, content: m.swipes[newSwipeId] };
+        }),
+      }));
+      return;
+    }
+
+    // Generate a new swipe
+    const abortController = new AbortController();
+    set({ isSending: true, isStreaming: false, error: null, abortController });
+
+    try {
+      // Build context from messages up to (but not including) this AI message
+      const msgIndex = messages.findIndex((m) => m.id === messageId);
+      const contextMessages = messages.slice(0, msgIndex);
+      const context = buildConversationContext(contextMessages, character, availableEmotions);
+      const { provider, model } = getProviderAndModel();
+
+      const stream = await api.generateMessage(context, character.name, provider, model, abortController.signal);
+      if (!stream) return;
+
+      // Add new empty swipe
+      const newSwipeIndex = msg.swipes.length;
+      set((state) => ({
+        messages: state.messages.map((m) => {
+          if (m.id !== messageId) return m;
+          return { ...m, swipes: [...m.swipes, ''], swipeId: newSwipeIndex, content: '' };
+        }),
+      }));
+
+      let responseText = '';
+      for await (const token of parseSSEStream(stream)) {
+        if (!get().isSending) break; // Aborted
+        responseText += token;
+        if (!get().isStreaming) set({ isStreaming: true });
+        set((state) => ({
+          messages: state.messages.map((m) => {
+            if (m.id !== messageId) return m;
+            const newSwipes = [...m.swipes];
+            newSwipes[newSwipeIndex] = responseText;
+            return { ...m, content: responseText, swipes: newSwipes };
+          }),
+        }));
+      }
+
+      const emotion = parseEmotion(responseText);
+      const cleanedContent = stripEmotionTag(responseText);
+
+      set((state) => ({
+        messages: state.messages.map((m) => {
+          if (m.id !== messageId) return m;
+          const newSwipes = [...m.swipes];
+          newSwipes[newSwipeIndex] = cleanedContent;
+          return { ...m, content: cleanedContent, emotion, swipes: newSwipes };
+        }),
+      }));
+
+      // Save
+      const { currentChatFile } = get();
+      await saveChatToBackend(get().messages, character, currentChatFile);
+    } catch (error) {
+      if ((error as Error).name !== 'AbortError') {
+        set({ error: error instanceof Error ? error.message : 'Failed to generate swipe' });
+      }
+    } finally {
+      set({ isSending: false, isStreaming: false, abortController: null });
+    }
+  },
+
+  // ---- Regenerate (create new swipe on last AI message) ----
+  regenerateMessage: async (character: CharacterInfo, availableEmotions?: string[]) => {
+    const { messages } = get();
+    // Find last AI message
+    const lastAiMsg = [...messages].reverse().find((m) => !m.isUser && !m.isSystem);
+    if (!lastAiMsg) return;
+    await get().swipeRight(lastAiMsg.id, character, availableEmotions);
+  },
+
+  // ---- Continue (extend last AI message) ----
+  continueMessage: async (character: CharacterInfo, availableEmotions?: string[]) => {
+    const { messages } = get();
+    const lastAiMsg = [...messages].reverse().find((m) => !m.isUser && !m.isSystem);
+    if (!lastAiMsg) return;
+
+    const abortController = new AbortController();
+    set({ isSending: true, isStreaming: false, error: null, abortController });
+
+    try {
+      // Build context including the current AI message
+      const context = buildConversationContext(messages, character, availableEmotions);
+      // Add a system instruction to continue
+      context.push({
+        role: 'system',
+        content: 'Continue your previous response naturally. Do not repeat what you already said. Pick up exactly where you left off.',
+      });
+
+      const { provider, model } = getProviderAndModel();
+      const stream = await api.generateMessage(context, character.name, provider, model, abortController.signal);
+      if (!stream) return;
+
+      const existingContent = lastAiMsg.content;
+      let newTokens = '';
+
+      for await (const token of parseSSEStream(stream)) {
+        if (!get().isSending) break;
+        newTokens += token;
+        if (!get().isStreaming) set({ isStreaming: true });
+        const fullContent = existingContent + newTokens;
+        set((state) => ({
+          messages: state.messages.map((m) => {
+            if (m.id !== lastAiMsg.id) return m;
+            const newSwipes = [...m.swipes];
+            newSwipes[m.swipeId] = fullContent;
+            return { ...m, content: fullContent, swipes: newSwipes };
+          }),
+        }));
+      }
+
+      // Strip any new emotion tags from the continuation
+      const fullText = existingContent + newTokens;
+      const cleanedContent = stripEmotionTag(fullText);
+
+      set((state) => ({
+        messages: state.messages.map((m) => {
+          if (m.id !== lastAiMsg.id) return m;
+          const newSwipes = [...m.swipes];
+          newSwipes[m.swipeId] = cleanedContent;
+          return { ...m, content: cleanedContent, swipes: newSwipes };
+        }),
+      }));
+
+      const { currentChatFile } = get();
+      await saveChatToBackend(get().messages, character, currentChatFile);
+    } catch (error) {
+      if ((error as Error).name !== 'AbortError') {
+        set({ error: error instanceof Error ? error.message : 'Failed to continue message' });
+      }
+    } finally {
+      set({ isSending: false, isStreaming: false, abortController: null });
+    }
+  },
+
+  // ---- Impersonate (generate as user, return text without sending) ----
+  impersonate: async (character: CharacterInfo, availableEmotions?: string[]): Promise<string> => {
+    const { messages } = get();
+    const abortController = new AbortController();
+    set({ isSending: true, isStreaming: false, error: null, abortController });
+
+    try {
+      const context = buildConversationContext(messages, character, availableEmotions);
+      // Replace the system prompt's last line to instruct impersonation
+      context.push({
+        role: 'system',
+        content: `Now write the next message as the user (You). Write from a first-person perspective as the user would. Do NOT include an emotion tag. Do NOT write as ${character.name}.`,
+      });
+
+      const { provider, model } = getProviderAndModel();
+      const stream = await api.generateMessage(context, character.name, provider, model, abortController.signal);
+      if (!stream) return '';
+
+      let responseText = '';
+      for await (const token of parseSSEStream(stream)) {
+        if (!get().isSending) break;
+        responseText += token;
+        if (!get().isStreaming) set({ isStreaming: true });
+      }
+
+      return stripEmotionTag(responseText);
+    } catch (error) {
+      if ((error as Error).name !== 'AbortError') {
+        set({ error: error instanceof Error ? error.message : 'Failed to impersonate' });
+      }
+      return '';
+    } finally {
+      set({ isSending: false, isStreaming: false, abortController: null });
+    }
+  },
+
+  // ---- Delete Chat File ----
+  deleteChat: async (avatarUrl: string, fileName: string) => {
+    try {
+      // Save an empty chat to effectively delete it
+      await api.saveChat(avatarUrl, fileName, []);
+      // Refresh chat list
+      const { fetchChatFiles } = get();
+      await fetchChatFiles(avatarUrl);
+    } catch (error) {
+      set({ error: error instanceof Error ? error.message : 'Failed to delete chat' });
+    }
+  },
+
+  // ---- Send Message (updated with abort support) ----
   sendMessage: async (content: string, character: CharacterInfo, availableEmotions?: string[]) => {
     const { addMessage } = get();
 
-    // Add user message
     addMessage({
       name: 'You',
       isUser: true,
@@ -461,41 +729,17 @@ export const useChatStore = create<ChatState>((set, get) => ({
       timestamp: Date.now(),
     });
 
-    set({ isSending: true, error: null });
+    const abortController = new AbortController();
+    set({ isSending: true, isStreaming: false, error: null, abortController });
 
     try {
-      // Build conversation context with available emotions
       const updatedMessages = get().messages;
       const context = buildConversationContext(updatedMessages, character, availableEmotions);
+      const { provider, model } = getProviderAndModel();
 
-      // Get AI provider settings
-      const { activeProvider, activeModel } = useSettingsStore.getState();
-
-      // Debug: log what provider we're using
-      console.log('[Chat] Using provider:', activeProvider, 'model:', activeModel);
-
-      if (!activeProvider || activeProvider === 'openai') {
-        // Check if we actually have the provider configured
-        const { secrets } = useSettingsStore.getState();
-        const hasOpenAI = Array.isArray(secrets['api_key_openai']) && secrets['api_key_openai'].length > 0;
-        const hasClaude = Array.isArray(secrets['api_key_claude']) && secrets['api_key_claude'].length > 0;
-
-        if (!hasOpenAI && hasClaude) {
-          // User has Claude but not OpenAI, auto-switch
-          console.log('[Chat] Auto-switching to Claude since OpenAI is not configured');
-          useSettingsStore.setState({ activeProvider: 'claude', activeModel: 'claude-sonnet-4-20250514' });
-        }
-      }
-
-      // Re-get the settings in case we auto-switched
-      const finalProvider = useSettingsStore.getState().activeProvider;
-      const finalModel = useSettingsStore.getState().activeModel;
-
-      // Call API
-      const stream = await api.generateMessage(context, character.name, finalProvider, finalModel);
+      const stream = await api.generateMessage(context, character.name, provider, model, abortController.signal);
 
       if (stream) {
-        // Add initial AI message placeholder
         const aiMessageId = generateId();
         set((state) => ({
           messages: [
@@ -507,85 +751,51 @@ export const useChatStore = create<ChatState>((set, get) => ({
               isSystem: false,
               content: '',
               timestamp: Date.now(),
+              swipes: [''],
+              swipeId: 0,
             },
           ],
         }));
 
-        // Stream the response using SSE parser
         let responseText = '';
         for await (const token of parseSSEStream(stream)) {
+          if (!get().isSending) break;
           responseText += token;
+          if (!get().isStreaming) set({ isStreaming: true });
           set((state) => ({
             messages: state.messages.map((msg) =>
-              msg.id === aiMessageId ? { ...msg, content: responseText } : msg
+              msg.id === aiMessageId ? { ...msg, content: responseText, swipes: [responseText] } : msg
             ),
           }));
         }
 
-        // Parse emotion and strip tag from final response
         const emotion = parseEmotion(responseText);
         const cleanedContent = stripEmotionTag(responseText);
 
-        console.log('[Chat] Raw response (first 150 chars):', responseText.substring(0, 150));
-        console.log('[Chat] Parsed emotion:', emotion);
-
-        // Update message with parsed emotion and cleaned content
         set((state) => ({
           messages: state.messages.map((msg) =>
             msg.id === aiMessageId
-              ? { ...msg, content: cleanedContent, emotion }
+              ? { ...msg, content: cleanedContent, emotion, swipes: [cleanedContent] }
               : msg
           ),
         }));
 
-        // Save chat to backend
         const { currentChatFile } = get();
-        console.log('[Chat] Saving chat, currentChatFile:', currentChatFile);
-
-        if (currentChatFile) {
-          const allMessages = get().messages;
-          console.log('[Chat] Messages to save:', allMessages.length);
-
-          // Build chat data with header as first entry
-          const chatData = [
-            // Header/metadata (required first entry)
-            {
-              user_name: 'You',
-              character_name: character.name,
-              create_date: new Date().toISOString(),
-            },
-            // Messages
-            ...allMessages.map((msg) => ({
-              name: msg.name,
-              is_user: msg.isUser,
-              is_system: msg.isSystem,
-              mes: msg.content,
-              send_date: msg.timestamp,
-            })),
-          ];
-
-          console.log('[Chat] Saving to:', character.avatar, currentChatFile);
-          try {
-            await api.saveChat(character.avatar, currentChatFile, chatData);
-            console.log('[Chat] Save successful');
-          } catch (err) {
-            console.error('[Chat] Failed to save:', err);
-          }
-        } else {
-          console.warn('[Chat] No currentChatFile set, cannot save');
-        }
+        await saveChatToBackend(get().messages, character, currentChatFile);
       }
     } catch (error) {
-      set({ error: error instanceof Error ? error.message : 'Failed to send message' });
+      if ((error as Error).name !== 'AbortError') {
+        set({ error: error instanceof Error ? error.message : 'Failed to send message' });
+      }
     } finally {
-      set({ isSending: false });
+      set({ isSending: false, isStreaming: false, abortController: null });
     }
   },
 
+  // ---- Send Group Message (updated with abort support) ----
   sendGroupMessage: async (content: string, characters: CharacterInfo[]) => {
     const { addMessage } = get();
 
-    // Add user message
     addMessage({
       name: 'You',
       isUser: true,
@@ -594,40 +804,24 @@ export const useChatStore = create<ChatState>((set, get) => ({
       timestamp: Date.now(),
     });
 
-    set({ isSending: true, error: null });
+    const abortController = new AbortController();
+    set({ isSending: true, isStreaming: false, error: null, abortController });
 
     try {
-      // Get AI provider settings
-      const { activeProvider, activeModel, secrets } = useSettingsStore.getState();
+      const { provider, model } = getProviderAndModel();
 
-      let finalProvider = activeProvider;
-      let finalModel = activeModel;
-
-      // Auto-switch provider if needed
-      if (!activeProvider || activeProvider === 'openai') {
-        const hasOpenAI = Array.isArray(secrets['api_key_openai']) && secrets['api_key_openai'].length > 0;
-        const hasClaude = Array.isArray(secrets['api_key_claude']) && secrets['api_key_claude'].length > 0;
-
-        if (!hasOpenAI && hasClaude) {
-          finalProvider = 'claude';
-          finalModel = 'claude-sonnet-4-20250514';
-          useSettingsStore.setState({ activeProvider: finalProvider, activeModel: finalModel });
-        }
-      }
-
-      // Generate response from each character in sequence
       for (const character of characters) {
+        if (!get().isSending) break; // Check if aborted between characters
+
         const updatedMessages = get().messages;
         const context = buildGroupConversationContext(updatedMessages, characters, character);
 
-        console.log(`[GroupChat] Generating response for ${character.name}`);
-
-        const stream = await api.generateMessage(context, character.name, finalProvider, finalModel);
+        const stream = await api.generateMessage(context, character.name, provider, model, abortController.signal);
 
         if (stream) {
-          // Add AI message placeholder for this character
           const aiMessageId = generateId();
           set((state) => ({
+            isStreaming: false,
             messages: [
               ...state.messages,
               {
@@ -638,29 +832,31 @@ export const useChatStore = create<ChatState>((set, get) => ({
                 content: '',
                 timestamp: Date.now(),
                 characterAvatar: character.avatar,
+                swipes: [''],
+                swipeId: 0,
               },
             ],
           }));
 
-          // Stream the response
           let responseText = '';
           for await (const token of parseSSEStream(stream)) {
+            if (!get().isSending) break;
             responseText += token;
+            if (!get().isStreaming) set({ isStreaming: true });
             set((state) => ({
               messages: state.messages.map((msg) =>
-                msg.id === aiMessageId ? { ...msg, content: responseText } : msg
+                msg.id === aiMessageId ? { ...msg, content: responseText, swipes: [responseText] } : msg
               ),
             }));
           }
 
-          // Parse emotion and strip tag
           const emotion = parseEmotion(responseText);
           const cleanedContent = stripEmotionTag(responseText);
 
           set((state) => ({
             messages: state.messages.map((msg) =>
               msg.id === aiMessageId
-                ? { ...msg, content: cleanedContent, emotion }
+                ? { ...msg, content: cleanedContent, emotion, swipes: [cleanedContent] }
                 : msg
             ),
           }));
@@ -669,80 +865,40 @@ export const useChatStore = create<ChatState>((set, get) => ({
 
       // Save group chat
       const { currentChatFile } = get();
-      if (currentChatFile) {
-        const allMessages = get().messages;
-        const chatData = [
-          {
-            user_name: 'You',
-            character_name: characters.map(c => c.name).join(', '),
-            create_date: new Date().toISOString(),
-            is_group_chat: true,
-          },
-          ...allMessages.map((msg) => ({
-            name: msg.name,
-            is_user: msg.isUser,
-            is_system: msg.isSystem,
-            mes: msg.content,
-            send_date: msg.timestamp,
-            character_avatar: msg.characterAvatar,
-          })),
-        ];
-
-        try {
-          // Use first character's avatar for saving (group chats need special handling)
-          await api.saveChat(characters[0].avatar, currentChatFile, chatData);
-        } catch (err) {
-          console.error('[GroupChat] Failed to save:', err);
-        }
+      if (currentChatFile && characters.length > 0) {
+        await saveChatToBackend(get().messages, characters[0], currentChatFile, true, characters);
       }
     } catch (error) {
-      set({ error: error instanceof Error ? error.message : 'Failed to send group message' });
+      if ((error as Error).name !== 'AbortError') {
+        set({ error: error instanceof Error ? error.message : 'Failed to send group message' });
+      }
     } finally {
-      set({ isSending: false });
+      set({ isSending: false, isStreaming: false, abortController: null });
     }
   },
 
+  // ---- Edit and Regenerate (updated) ----
   editMessageAndRegenerate: async (messageId: string, newContent: string, character: CharacterInfo, availableEmotions?: string[]) => {
     const { messages } = get();
 
-    // Find the message index
     const messageIndex = messages.findIndex((m) => m.id === messageId);
     if (messageIndex === -1) return;
 
     // Update the message and remove all messages after it
     const updatedMessages = messages.slice(0, messageIndex + 1).map((msg) =>
-      msg.id === messageId ? { ...msg, content: newContent } : msg
+      msg.id === messageId ? { ...msg, content: newContent, swipes: [newContent], swipeId: 0 } : msg
     );
 
-    set({ messages: updatedMessages, isSending: true, error: null });
+    const abortController = new AbortController();
+    set({ messages: updatedMessages, isSending: true, isStreaming: false, error: null, abortController });
 
     try {
-      // Build conversation context with the edited message and available emotions
       const context = buildConversationContext(updatedMessages, character, availableEmotions);
+      const { provider, model } = getProviderAndModel();
 
-      // Get AI provider settings
-      const { activeProvider, activeModel, secrets } = useSettingsStore.getState();
-
-      let finalProvider = activeProvider;
-      let finalModel = activeModel;
-
-      // Auto-switch provider if needed
-      if (!activeProvider || activeProvider === 'openai') {
-        const hasOpenAI = Array.isArray(secrets['api_key_openai']) && secrets['api_key_openai'].length > 0;
-        const hasClaude = Array.isArray(secrets['api_key_claude']) && secrets['api_key_claude'].length > 0;
-
-        if (!hasOpenAI && hasClaude) {
-          finalProvider = 'claude';
-          finalModel = 'claude-sonnet-4-20250514';
-          useSettingsStore.setState({ activeProvider: finalProvider, activeModel: finalModel });
-        }
-      }
-
-      // Generate new response
-      const stream = await api.generateMessage(context, character.name, finalProvider, finalModel);
+      const stream = await api.generateMessage(context, character.name, provider, model, abortController.signal);
 
       if (stream) {
-        // Add initial AI message placeholder
         const aiMessageId = generateId();
         set((state) => ({
           messages: [
@@ -754,58 +910,44 @@ export const useChatStore = create<ChatState>((set, get) => ({
               isSystem: false,
               content: '',
               timestamp: Date.now(),
+              swipes: [''],
+              swipeId: 0,
             },
           ],
         }));
 
-        // Stream the response
         let responseText = '';
         for await (const token of parseSSEStream(stream)) {
+          if (!get().isSending) break;
           responseText += token;
+          if (!get().isStreaming) set({ isStreaming: true });
           set((state) => ({
             messages: state.messages.map((msg) =>
-              msg.id === aiMessageId ? { ...msg, content: responseText } : msg
+              msg.id === aiMessageId ? { ...msg, content: responseText, swipes: [responseText] } : msg
             ),
           }));
         }
 
-        // Parse emotion and strip tag
         const emotion = parseEmotion(responseText);
         const cleanedContent = stripEmotionTag(responseText);
 
         set((state) => ({
           messages: state.messages.map((msg) =>
             msg.id === aiMessageId
-              ? { ...msg, content: cleanedContent, emotion }
+              ? { ...msg, content: cleanedContent, emotion, swipes: [cleanedContent] }
               : msg
           ),
         }));
 
-        // Save chat
         const { currentChatFile } = get();
-        if (currentChatFile) {
-          const allMessages = get().messages;
-          const chatData = [
-            {
-              user_name: 'You',
-              character_name: character.name,
-              create_date: new Date().toISOString(),
-            },
-            ...allMessages.map((msg) => ({
-              name: msg.name,
-              is_user: msg.isUser,
-              is_system: msg.isSystem,
-              mes: msg.content,
-              send_date: msg.timestamp,
-            })),
-          ];
-          await api.saveChat(character.avatar, currentChatFile, chatData);
-        }
+        await saveChatToBackend(get().messages, character, currentChatFile);
       }
     } catch (error) {
-      set({ error: error instanceof Error ? error.message : 'Failed to regenerate response' });
+      if ((error as Error).name !== 'AbortError') {
+        set({ error: error instanceof Error ? error.message : 'Failed to regenerate response' });
+      }
     } finally {
-      set({ isSending: false });
+      set({ isSending: false, isStreaming: false, abortController: null });
     }
   },
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -24,11 +24,14 @@ export interface ChatMessage {
   is_system: boolean;
   mes: string;
   send_date: number;
+  swipes?: string[];
+  swipe_id?: number;
   extra?: {
     gen_id?: string;
     api?: string;
     model?: string;
   };
+  character_avatar?: string;
 }
 
 export interface Chat {


### PR DESCRIPTION
Core infrastructure for swiping, regeneration, continue, impersonate, stop generation, and per-message edit/delete. Adds swipe data model (swipes array + swipeId) to messages with backward-compatible loading. Extracts shared helpers for provider selection and chat persistence.

- chatStore: add swipeLeft/Right, regenerate, continue, impersonate, stopGeneration, editMessage, deleteMessage, deleteChat actions
- types: add swipes, swipe_id, character_avatar to ChatMessage
- client: add AbortSignal support to generateMessage
- ui: add ConfirmDialog component
- ROADMAP.md: full feature parity roadmap (10 phases)