### PR TITLE
Wire Phase 1 UI: swipes, action bar, message menu, chat history

### DIFF
--- a/src/components/chat/ChatActionBar.tsx
+++ b/src/components/chat/ChatActionBar.tsx
@@ -1,0 +1,63 @@
+import { RefreshCw, ArrowRight, User, Square } from 'lucide-react';
+
+interface ChatActionBarProps {
+  onRegenerate: () => void;
+  onContinue: () => void;
+  onImpersonate: () => void;
+  onStop: () => void;
+  isSending: boolean;
+  hasAiMessage: boolean;
+  disabled?: boolean;
+}
+
+export function ChatActionBar({
+  onRegenerate,
+  onContinue,
+  onImpersonate,
+  onStop,
+  isSending,
+  hasAiMessage,
+  disabled,
+}: ChatActionBarProps) {
+  if (isSending) {
+    return (
+      <div className="flex items-center justify-center gap-2 px-4 py-2 border-t border-[var(--color-border)]">
+        <button
+          onClick={onStop}
+          className="flex items-center gap-2 px-4 py-1.5 rounded-full bg-red-500/10 border border-red-500/30 text-red-400 text-sm font-medium hover:bg-red-500/20 transition-colors"
+        >
+          <Square size={14} fill="currentColor" />
+          <span>Stop</span>
+        </button>
+      </div>
+    );
+  }
+
+  if (!hasAiMessage) return null;
+
+  const actions = [
+    { icon: RefreshCw, label: 'Regen', onClick: onRegenerate, title: 'Regenerate last response' },
+    { icon: ArrowRight, label: 'Continue', onClick: onContinue, title: 'Continue last response' },
+    { icon: User, label: 'Impersonate', onClick: onImpersonate, title: 'Write a reply as the user' },
+  ];
+
+  return (
+    <div className="flex items-center justify-center gap-1 px-4 py-1.5 border-t border-[var(--color-border)]">
+      {actions.map((action) => {
+        const Icon = action.icon;
+        return (
+          <button
+            key={action.label}
+            onClick={action.onClick}
+            disabled={disabled}
+            title={action.title}
+            className="flex items-center gap-1.5 px-3 py-1 rounded-full text-xs text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-tertiary)] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            <Icon size={12} />
+            <span className="hidden sm:inline">{action.label}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/chat/ChatHistoryPanel.tsx
+++ b/src/components/chat/ChatHistoryPanel.tsx
@@ -1,0 +1,155 @@
+import { useState, useEffect } from 'react';
+import { Plus, Trash2, MessageSquare, Download } from 'lucide-react';
+import { Modal, ConfirmDialog } from '../ui';
+import { useChatStore } from '../../stores/chatStore';
+import { useCharacterStore } from '../../stores/characterStore';
+
+interface ChatHistoryPanelProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function ChatHistoryPanel({ isOpen, onClose }: ChatHistoryPanelProps) {
+  const { selectedCharacter } = useCharacterStore();
+  const { chatFiles, currentChatFile, fetchChatFiles, loadChat, startNewChat, deleteChat } =
+    useChatStore();
+  const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (isOpen && selectedCharacter) {
+      fetchChatFiles(selectedCharacter.avatar);
+    }
+  }, [isOpen, selectedCharacter, fetchChatFiles]);
+
+  const handleLoadChat = async (fileName: string) => {
+    if (!selectedCharacter) return;
+    await loadChat(selectedCharacter.avatar, fileName);
+    onClose();
+  };
+
+  const handleNewChat = async () => {
+    if (!selectedCharacter) return;
+    await startNewChat(selectedCharacter);
+    onClose();
+  };
+
+  const handleDeleteChat = async (fileName: string) => {
+    if (!selectedCharacter) return;
+    await deleteChat(selectedCharacter.avatar, fileName);
+  };
+
+  const handleExportChat = async (fileName: string) => {
+    if (!selectedCharacter) return;
+    try {
+      const response = await fetch('/api/chats/get', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
+          file_name: fileName,
+          avatar_url: selectedCharacter.avatar,
+        }),
+      });
+      const data = await response.json();
+      const jsonl = Array.isArray(data)
+        ? data.map((entry) => JSON.stringify(entry)).join('\n')
+        : '';
+      const blob = new Blob([jsonl], { type: 'application/jsonl' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `${fileName}.jsonl`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      console.error('[Export] Failed:', err);
+    }
+  };
+
+  if (!selectedCharacter) return null;
+
+  return (
+    <>
+      <Modal isOpen={isOpen} onClose={onClose} title="Chat History" size="md">
+        <div className="flex flex-col gap-2">
+          <button
+            onClick={handleNewChat}
+            className="flex items-center gap-3 px-4 py-3 rounded-lg bg-[var(--color-primary)] text-white hover:opacity-90 transition-opacity"
+          >
+            <Plus size={18} />
+            <span className="font-medium">New Chat</span>
+          </button>
+
+          {chatFiles.length === 0 ? (
+            <div className="text-center py-8 text-sm text-[var(--color-text-secondary)]">
+              No saved chats yet
+            </div>
+          ) : (
+            <div className="flex flex-col gap-1 max-h-[60vh] overflow-y-auto">
+              {chatFiles.map((chat) => {
+                const isActive = chat.fileName === currentChatFile;
+                return (
+                  <div
+                    key={chat.fileName}
+                    className={`
+                      group flex items-center gap-2 px-3 py-2 rounded-lg transition-colors
+                      ${isActive
+                        ? 'bg-[var(--color-primary)]/20 border border-[var(--color-primary)]/40'
+                        : 'hover:bg-[var(--color-bg-tertiary)]'}
+                    `}
+                  >
+                    <button
+                      onClick={() => handleLoadChat(chat.fileName)}
+                      className="flex-1 flex items-center gap-3 min-w-0 text-left"
+                    >
+                      <MessageSquare
+                        size={16}
+                        className="text-[var(--color-text-secondary)] flex-shrink-0"
+                      />
+                      <div className="min-w-0 flex-1">
+                        <div className="text-sm font-medium text-[var(--color-text-primary)] truncate">
+                          {chat.fileName}
+                        </div>
+                        {chat.lastMessage && (
+                          <div className="text-xs text-[var(--color-text-secondary)] truncate">
+                            {chat.lastMessage}
+                          </div>
+                        )}
+                      </div>
+                    </button>
+                    <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                      <button
+                        onClick={() => handleExportChat(chat.fileName)}
+                        className="p-1.5 rounded hover:bg-[var(--color-bg-secondary)] text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]"
+                        title="Export as JSONL"
+                      >
+                        <Download size={14} />
+                      </button>
+                      <button
+                        onClick={() => setConfirmDelete(chat.fileName)}
+                        className="p-1.5 rounded hover:bg-red-500/20 text-[var(--color-text-secondary)] hover:text-red-400"
+                        title="Delete chat"
+                      >
+                        <Trash2 size={14} />
+                      </button>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </Modal>
+
+      <ConfirmDialog
+        isOpen={confirmDelete !== null}
+        onClose={() => setConfirmDelete(null)}
+        onConfirm={() => confirmDelete && handleDeleteChat(confirmDelete)}
+        title="Delete Chat"
+        message={`Delete "${confirmDelete}"? This cannot be undone.`}
+        confirmLabel="Delete"
+        danger
+      />
+    </>
+  );
+}

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -6,15 +6,28 @@ interface ChatInputProps {
   onSend: (message: string) => void;
   disabled?: boolean;
   placeholder?: string;
+  prefillText?: string;
+  prefillNonce?: number;
 }
 
 export function ChatInput({
   onSend,
   disabled = false,
   placeholder = 'Type a message...',
+  prefillText,
+  prefillNonce,
 }: ChatInputProps) {
   const [message, setMessage] = useState('');
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // Handle prefill text (e.g. from impersonate) - nonce lets parent trigger re-prefill
+  useEffect(() => {
+    if (prefillText !== undefined && prefillNonce !== undefined) {
+      setMessage(prefillText);
+      textareaRef.current?.focus();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [prefillNonce]);
 
   // Auto-resize textarea
   useEffect(() => {

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -1,6 +1,8 @@
 import { useState, useRef, useEffect, useMemo } from 'react';
-import { Pencil, Check, X } from 'lucide-react';
+import { MoreHorizontal, Check, X } from 'lucide-react';
 import { Avatar } from '../ui';
+import { MessageActionMenu } from './MessageActionMenu';
+import { SwipeControl } from './SwipeControl';
 
 interface ChatMessageProps {
   name: string;
@@ -9,9 +11,18 @@ interface ChatMessageProps {
   isSystem?: boolean;
   avatar?: string;
   timestamp?: number;
-  isEditable?: boolean;
-  onEdit?: (newContent: string) => void;
   disabled?: boolean;
+  // Swipe support (only for AI messages)
+  swipes?: string[];
+  swipeId?: number;
+  showSwipeControl?: boolean;
+  onSwipeLeft?: () => void;
+  onSwipeRight?: () => void;
+  // Actions
+  onEdit?: (newContent: string) => void;
+  onEditAndRegenerate?: (newContent: string) => void;
+  onDelete?: () => void;
+  onRegenerate?: () => void;
 }
 
 interface TextSegment {
@@ -19,67 +30,37 @@ interface TextSegment {
   content: string;
 }
 
-/**
- * Parse message content to separate dialogue from actions/thoughts
- * Actions are wrapped in *asterisks* or _underscores_
- * Thoughts can be in {{curly braces}} or (parentheses for inner thoughts)
- */
 function parseMessageContent(text: string): TextSegment[] {
   const segments: TextSegment[] = [];
-  // Match *action*, _action_, {{thought}}, or regular text
-  // Using a regex that captures asterisk/underscore wrapped text as actions
   const regex = /(\*[^*]+\*|_[^_]+_|\{\{[^}]+\}\})/g;
-
   let lastIndex = 0;
   let match;
 
   while ((match = regex.exec(text)) !== null) {
-    // Add any text before this match as dialogue
     if (match.index > lastIndex) {
       const dialogueText = text.slice(lastIndex, match.index);
-      if (dialogueText) {
-        segments.push({ type: 'dialogue', content: dialogueText });
-      }
+      if (dialogueText) segments.push({ type: 'dialogue', content: dialogueText });
     }
-
-    // Determine if it's an action or thought
     const matchedText = match[0];
     if (matchedText.startsWith('{{') && matchedText.endsWith('}}')) {
-      // Thought in curly braces - remove the braces
-      segments.push({
-        type: 'thought',
-        content: matchedText.slice(2, -2)
-      });
+      segments.push({ type: 'thought', content: matchedText.slice(2, -2) });
     } else {
-      // Action in asterisks or underscores - remove the markers
-      segments.push({
-        type: 'action',
-        content: matchedText.slice(1, -1)
-      });
+      segments.push({ type: 'action', content: matchedText.slice(1, -1) });
     }
-
     lastIndex = match.index + match[0].length;
   }
 
-  // Add any remaining text as dialogue
   if (lastIndex < text.length) {
     segments.push({ type: 'dialogue', content: text.slice(lastIndex) });
   }
-
-  // If no segments were created, return the whole text as dialogue
   if (segments.length === 0) {
     segments.push({ type: 'dialogue', content: text });
   }
-
   return segments;
 }
 
-/**
- * Render parsed message segments with appropriate styling
- */
 function FormattedContent({ content, isUser }: { content: string; isUser: boolean }) {
   const segments = useMemo(() => parseMessageContent(content), [content]);
-
   return (
     <>
       {segments.map((segment, index) => {
@@ -87,11 +68,7 @@ function FormattedContent({ content, isUser }: { content: string; isUser: boolea
           return (
             <span
               key={index}
-              className={`italic ${
-                isUser
-                  ? 'text-white/70'
-                  : 'text-amber-400/90'
-              }`}
+              className={`italic ${isUser ? 'text-white/70' : 'text-amber-400/90'}`}
             >
               {segment.content}
             </span>
@@ -101,17 +78,12 @@ function FormattedContent({ content, isUser }: { content: string; isUser: boolea
           return (
             <span
               key={index}
-              className={`italic ${
-                isUser
-                  ? 'text-white/60'
-                  : 'text-purple-400/80'
-              }`}
+              className={`italic ${isUser ? 'text-white/60' : 'text-purple-400/80'}`}
             >
               {segment.content}
             </span>
           );
         }
-        // Dialogue - default styling
         return <span key={index}>{segment.content}</span>;
       })}
     </>
@@ -125,15 +97,23 @@ export function ChatMessage({
   isSystem,
   avatar,
   timestamp,
-  isEditable,
-  onEdit,
   disabled,
+  swipes,
+  swipeId,
+  showSwipeControl,
+  onSwipeLeft,
+  onSwipeRight,
+  onEdit,
+  onEditAndRegenerate,
+  onDelete,
+  onRegenerate,
 }: ChatMessageProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [editContent, setEditContent] = useState(content);
+  const [showMenu, setShowMenu] = useState(false);
+  const [showEditOptions, setShowEditOptions] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-  // Focus and select text when entering edit mode
   useEffect(() => {
     if (isEditing && textareaRef.current) {
       textareaRef.current.focus();
@@ -141,7 +121,6 @@ export function ChatMessage({
     }
   }, [isEditing]);
 
-  // Auto-resize textarea
   useEffect(() => {
     if (textareaRef.current) {
       textareaRef.current.style.height = 'auto';
@@ -152,28 +131,51 @@ export function ChatMessage({
   const handleStartEdit = () => {
     setEditContent(content);
     setIsEditing(true);
+    setShowEditOptions(false);
   };
 
   const handleCancelEdit = () => {
     setEditContent(content);
     setIsEditing(false);
+    setShowEditOptions(false);
   };
 
-  const handleSaveEdit = () => {
+  const handleSaveOnly = () => {
     if (editContent.trim() && editContent !== content) {
       onEdit?.(editContent.trim());
     }
     setIsEditing(false);
+    setShowEditOptions(false);
+  };
+
+  const handleSaveAndRegenerate = () => {
+    if (editContent.trim() && onEditAndRegenerate) {
+      onEditAndRegenerate(editContent.trim());
+    }
+    setIsEditing(false);
+    setShowEditOptions(false);
+  };
+
+  const handleCopy = () => {
+    navigator.clipboard?.writeText(content).catch(() => {});
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Escape') {
       handleCancelEdit();
-    } else if (e.key === 'Enter' && !e.shiftKey) {
+    } else if (e.key === 'Enter' && !e.shiftKey && !isUser) {
       e.preventDefault();
-      handleSaveEdit();
+      handleSaveOnly();
+    } else if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+      e.preventDefault();
+      if (isUser && onEditAndRegenerate) {
+        handleSaveAndRegenerate();
+      } else {
+        handleSaveOnly();
+      }
     }
   };
+
   if (isSystem) {
     return (
       <div className="flex justify-center my-4">
@@ -186,16 +188,12 @@ export function ChatMessage({
 
   return (
     <div
-      className={`flex gap-3 px-4 py-3 group ${
-        isUser ? 'flex-row-reverse' : 'flex-row'
-      }`}
+      className={`flex gap-3 px-4 py-3 group ${isUser ? 'flex-row-reverse' : 'flex-row'}`}
     >
       <Avatar src={avatar} alt={name} size="md" className="flex-shrink-0" />
 
       <div
-        className={`flex flex-col max-w-[80%] md:max-w-[70%] ${
-          isUser ? 'items-end' : 'items-start'
-        }`}
+        className={`flex flex-col max-w-[80%] md:max-w-[70%] ${isUser ? 'items-end' : 'items-start'}`}
       >
         <div className="flex items-center gap-2 mb-1">
           <span className="text-xs font-medium text-[var(--color-text-secondary)]">
@@ -211,27 +209,37 @@ export function ChatMessage({
           )}
         </div>
 
-        <div className="flex items-start gap-2">
-          {/* Edit button - show on left for user messages */}
-          {isEditable && isUser && !isEditing && (
-            <button
-              onClick={handleStartEdit}
-              disabled={disabled}
-              className="p-1.5 rounded-lg text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-tertiary)] opacity-0 group-hover:opacity-100 transition-opacity disabled:opacity-50"
-              title="Edit message"
-            >
-              <Pencil size={14} />
-            </button>
+        <div className="flex items-start gap-2 relative">
+          {/* Action menu button */}
+          {!isEditing && (onEdit || onDelete) && (
+            <div className="relative">
+              <button
+                onClick={() => setShowMenu(!showMenu)}
+                disabled={disabled}
+                className="p-1.5 rounded-lg text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-tertiary)] opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity disabled:opacity-50"
+                aria-label="Message actions"
+              >
+                <MoreHorizontal size={16} />
+              </button>
+              <MessageActionMenu
+                isOpen={showMenu}
+                onClose={() => setShowMenu(false)}
+                onEdit={handleStartEdit}
+                onCopy={handleCopy}
+                onDelete={() => onDelete?.()}
+                onRegenerate={onRegenerate}
+                showRegenerate={!isUser && !!onRegenerate}
+                anchorRight={isUser}
+              />
+            </div>
           )}
 
           <div
             className={`
               px-4 py-2 rounded-2xl
-              ${
-                isUser
-                  ? 'bg-[var(--color-primary)] text-white rounded-br-md'
-                  : 'bg-[var(--color-bg-tertiary)] text-[var(--color-text-primary)] rounded-bl-md'
-              }
+              ${isUser
+                ? 'bg-[var(--color-primary)] text-white rounded-br-md'
+                : 'bg-[var(--color-bg-tertiary)] text-[var(--color-text-primary)] rounded-bl-md'}
               ${isEditing ? 'w-full' : ''}
             `}
           >
@@ -242,24 +250,52 @@ export function ChatMessage({
                   value={editContent}
                   onChange={(e) => setEditContent(e.target.value)}
                   onKeyDown={handleKeyDown}
-                  className="w-full bg-transparent text-sm resize-none outline-none min-h-[60px] text-white"
-                  placeholder="Enter your message..."
+                  className={`w-full bg-transparent text-sm resize-none outline-none min-h-[60px] ${isUser ? 'text-white' : 'text-[var(--color-text-primary)]'}`}
+                  placeholder="Enter message..."
                 />
                 <div className="flex justify-end gap-2">
                   <button
                     onClick={handleCancelEdit}
-                    className="p-1.5 rounded-lg bg-white/20 hover:bg-white/30 transition-colors"
+                    className={`p-1.5 rounded-lg transition-colors ${isUser ? 'bg-white/20 hover:bg-white/30' : 'bg-[var(--color-bg-secondary)] hover:bg-[var(--color-bg-primary)]'}`}
                     title="Cancel (Esc)"
                   >
                     <X size={14} />
                   </button>
-                  <button
-                    onClick={handleSaveEdit}
-                    className="p-1.5 rounded-lg bg-white/20 hover:bg-white/30 transition-colors"
-                    title="Save and regenerate (Enter)"
-                  >
-                    <Check size={14} />
-                  </button>
+                  {isUser && onEditAndRegenerate ? (
+                    <div className="relative">
+                      <button
+                        onClick={() => setShowEditOptions(!showEditOptions)}
+                        className={`p-1.5 rounded-lg transition-colors ${isUser ? 'bg-white/20 hover:bg-white/30' : 'bg-[var(--color-bg-secondary)] hover:bg-[var(--color-bg-primary)]'}`}
+                        title="Save options"
+                      >
+                        <Check size={14} />
+                      </button>
+                      {showEditOptions && (
+                        <div className="absolute right-0 top-full mt-1 z-20 min-w-[180px] bg-[var(--color-bg-secondary)] border border-[var(--color-border)] rounded-lg shadow-xl overflow-hidden">
+                          <button
+                            onClick={handleSaveOnly}
+                            className="w-full px-3 py-2 text-xs text-left text-[var(--color-text-primary)] hover:bg-[var(--color-bg-tertiary)] transition-colors"
+                          >
+                            Save only
+                          </button>
+                          <button
+                            onClick={handleSaveAndRegenerate}
+                            className="w-full px-3 py-2 text-xs text-left text-[var(--color-text-primary)] hover:bg-[var(--color-bg-tertiary)] transition-colors"
+                          >
+                            Save &amp; regenerate
+                          </button>
+                        </div>
+                      )}
+                    </div>
+                  ) : (
+                    <button
+                      onClick={handleSaveOnly}
+                      className={`p-1.5 rounded-lg transition-colors ${isUser ? 'bg-white/20 hover:bg-white/30' : 'bg-[var(--color-bg-secondary)] hover:bg-[var(--color-bg-primary)]'}`}
+                      title="Save (Enter)"
+                    >
+                      <Check size={14} />
+                    </button>
+                  )}
                 </div>
               </div>
             ) : (
@@ -269,6 +305,17 @@ export function ChatMessage({
             )}
           </div>
         </div>
+
+        {/* Swipe control for AI messages */}
+        {showSwipeControl && !isEditing && swipes && swipeId !== undefined && onSwipeLeft && onSwipeRight && swipes.length >= 1 && (
+          <SwipeControl
+            swipeId={swipeId}
+            swipesCount={swipes.length}
+            onSwipeLeft={onSwipeLeft}
+            onSwipeRight={onSwipeRight}
+            disabled={disabled}
+          />
+        )}
       </div>
     </div>
   );

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -4,6 +4,7 @@ import { useCharacterStore } from '../../stores/characterStore';
 import { useChatStore } from '../../stores/chatStore';
 import { ChatMessage } from './ChatMessage';
 import { ChatInput } from './ChatInput';
+import { ChatActionBar } from './ChatActionBar';
 import { useCharacterSprites } from '../../hooks/useCharacterSprites';
 import {
   getExpressionThumbnailUrl,
@@ -13,108 +14,102 @@ import {
 
 export function ChatView() {
   const { selectedCharacter, isGroupChatMode, groupChatCharacters, exitGroupChat } = useCharacterStore();
-  const { messages, isSending, error, sendMessage, sendGroupMessage, startNewChat, fetchChatFiles, loadChat, chatFiles, clearChat, editMessageAndRegenerate } = useChatStore();
+  const {
+    messages,
+    isSending,
+    isStreaming,
+    error,
+    sendMessage,
+    sendGroupMessage,
+    startNewChat,
+    fetchChatFiles,
+    loadChat,
+    chatFiles,
+    clearChat,
+    editMessageAndRegenerate,
+    editMessage,
+    deleteMessage,
+    swipeLeft,
+    swipeRight,
+    regenerateMessage,
+    continueMessage,
+    impersonate,
+    stopGeneration,
+  } = useChatStore();
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const lastCharacterRef = useRef<string | null>(null);
-  // Track failed expression images to avoid infinite retry loops
   const [failedExpressions, setFailedExpressions] = useState<Set<string>>(new Set());
+  const [prefillText, setPrefillText] = useState<string | undefined>(undefined);
+  const [prefillNonce, setPrefillNonce] = useState(0);
 
-  // Fetch actual sprite paths from API (hook extracts character name from avatar filename)
   const { getSpritePath, availableEmotions } = useCharacterSprites(selectedCharacter?.avatar);
 
-  // Get the latest character message's emotion for the portrait
   const latestEmotion = useMemo(() => {
     const characterMessages = messages.filter((m) => !m.isUser && !m.isSystem);
     if (characterMessages.length === 0) return null;
     return characterMessages[characterMessages.length - 1].emotion ?? null;
   }, [messages]);
 
-  // Find the last user message ID for edit functionality
-  const lastUserMessageId = useMemo(() => {
-    const userMessages = messages.filter((m) => m.isUser);
-    return userMessages.length > 0 ? userMessages[userMessages.length - 1].id : null;
+  // Find the last AI message id for swipe control display
+  const lastAiMessageId = useMemo(() => {
+    const aiMessages = messages.filter((m) => !m.isUser && !m.isSystem);
+    return aiMessages.length > 0 ? aiMessages[aiMessages.length - 1].id : null;
   }, [messages]);
+
+  const hasAiMessage = useMemo(
+    () => messages.some((m) => !m.isUser && !m.isSystem),
+    [messages]
+  );
 
   const getAvatarUrl = useCallback(
     (avatar: string, emotion?: Emotion | null) => {
-      // For group chat, use default avatar URL directly
-      if (isGroupChatMode) {
-        return getDefaultAvatarUrl(avatar);
-      }
-      // Try to use actual sprite path from API first
+      if (isGroupChatMode) return getDefaultAvatarUrl(avatar);
       if (emotion) {
         const spritePath = getSpritePath(emotion);
-        if (spritePath) {
-          return spritePath;
-        }
+        if (spritePath) return spritePath;
       }
-      // Fall back to thumbnail for default/neutral
       return getExpressionThumbnailUrl(avatar, emotion ?? null);
     },
     [getSpritePath, isGroupChatMode]
   );
 
-  // Get the full image URL using actual sprite paths from API
   const getFullImageUrl = useCallback(
     (avatar: string, emotion?: Emotion | null) => {
       const expressionKey = `${avatar}-${emotion}`;
-
-      // Check if this expression previously failed
       if (emotion && failedExpressions.has(expressionKey)) {
-        const fallback = getDefaultAvatarUrl(avatar);
-        console.log('[Expression] Using fallback for failed expression:', { emotion, fallback });
-        return fallback;
+        return getDefaultAvatarUrl(avatar);
       }
-
-      // Try to use actual sprite path from API
       if (emotion) {
         const spritePath = getSpritePath(emotion);
-        if (spritePath) {
-          console.log('[Expression] Using API sprite path:', { emotion, path: spritePath });
-          return spritePath;
-        }
+        if (spritePath) return spritePath;
       }
-
-      // Fall back to default avatar
-      const fallback = getDefaultAvatarUrl(avatar);
-      console.log('[Expression] No sprite found, using default:', { avatar, emotion, fallback });
-      return fallback;
+      return getDefaultAvatarUrl(avatar);
     },
     [getSpritePath, failedExpressions]
   );
 
-  // Load chat when character changes
   useEffect(() => {
     if (!selectedCharacter) return;
     if (lastCharacterRef.current === selectedCharacter.avatar) return;
 
-    // Clear old chat state before loading new character
     clearChat();
     lastCharacterRef.current = selectedCharacter.avatar;
-    // Reset failed expressions for new character
     setFailedExpressions(new Set());
-
-    // Fetch chat files for new character
     fetchChatFiles(selectedCharacter.avatar);
   }, [selectedCharacter, fetchChatFiles, clearChat]);
 
-  // When chat files are loaded, load the most recent or start new
   useEffect(() => {
     if (!selectedCharacter) return;
-    // Only run this effect when we have fresh data for this character
     if (lastCharacterRef.current !== selectedCharacter.avatar) return;
 
     if (chatFiles.length > 0) {
-      // Load most recent chat
       loadChat(selectedCharacter.avatar, chatFiles[0].fileName);
     } else if (messages.length === 0) {
-      // Start new chat with first_mes only if no messages loaded
       startNewChat(selectedCharacter);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [chatFiles]);
 
-  // Auto-scroll to bottom on new messages
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages]);
@@ -127,7 +122,37 @@ export function ChatView() {
     }
   };
 
-  // No character selected and not in group chat mode
+  const handleRegenerate = () => {
+    if (selectedCharacter && !isGroupChatMode) {
+      regenerateMessage(selectedCharacter, availableEmotions);
+    }
+  };
+
+  const handleContinue = () => {
+    if (selectedCharacter && !isGroupChatMode) {
+      continueMessage(selectedCharacter, availableEmotions);
+    }
+  };
+
+  const handleImpersonate = async () => {
+    if (!selectedCharacter || isGroupChatMode) return;
+    const text = await impersonate(selectedCharacter, availableEmotions);
+    if (text) {
+      setPrefillText(text);
+      setPrefillNonce((n) => n + 1);
+    }
+  };
+
+  const handleSwipeLeft = (messageId: string) => {
+    swipeLeft(messageId);
+  };
+
+  const handleSwipeRight = (messageId: string) => {
+    if (selectedCharacter && !isGroupChatMode) {
+      swipeRight(messageId, selectedCharacter, availableEmotions);
+    }
+  };
+
   if (!selectedCharacter && !isGroupChatMode) {
     return (
       <div className="h-full flex flex-col items-center justify-center text-center p-8">
@@ -143,16 +168,14 @@ export function ChatView() {
     );
   }
 
-  // Determine the display name and placeholder for input
   const displayName = isGroupChatMode
     ? groupChatCharacters.map((c) => c.name).join(', ')
     : selectedCharacter?.name ?? '';
 
   return (
     <div className="h-full flex flex-col overflow-hidden">
-      {/* Mobile Header - visible only on mobile */}
+      {/* Mobile Header */}
       {isGroupChatMode ? (
-        /* Group Chat Header */
         <div className="lg:hidden h-20 relative bg-gradient-to-b from-[var(--color-bg-tertiary)] to-[var(--color-bg-primary)] overflow-hidden px-4 py-3">
           <div className="flex items-center gap-3">
             <div className="w-12 h-12 rounded-full bg-[var(--color-primary)]/20 flex items-center justify-center">
@@ -175,33 +198,20 @@ export function ChatView() {
           </div>
         </div>
       ) : selectedCharacter ? (
-        /* Single Character Portrait */
         <div className="lg:hidden h-[30vh] min-h-[150px] max-h-[250px] relative bg-gradient-to-b from-[var(--color-bg-tertiary)] to-[var(--color-bg-primary)] overflow-hidden">
           <img
             key={`${selectedCharacter.avatar}-${latestEmotion ?? 'neutral'}`}
             src={getFullImageUrl(selectedCharacter.avatar, latestEmotion)}
             alt={selectedCharacter.name}
             className="w-full h-full object-cover object-top transition-opacity duration-300"
-            onLoad={(e) => {
-              console.log('[Expression] Image loaded successfully:', e.currentTarget.src);
-            }}
-            onError={(e) => {
-              // Log detailed error info for debugging
-              console.log('[Expression] Image load FAILED:', {
-                attempted: e.currentTarget.src,
-                emotion: latestEmotion,
-                character: selectedCharacter.avatar,
-              });
-              // Mark this expression as failed so we use fallback next time
+            onError={() => {
               if (latestEmotion) {
                 const expressionKey = `${selectedCharacter.avatar}-${latestEmotion}`;
                 setFailedExpressions((prev) => new Set(prev).add(expressionKey));
               }
             }}
           />
-          {/* Gradient overlay for text readability */}
           <div className="absolute inset-x-0 bottom-0 h-16 bg-gradient-to-t from-[var(--color-bg-primary)] to-transparent" />
-          {/* Character name and emotion overlay */}
           <div className="absolute bottom-2 left-4 right-4 flex items-center justify-between">
             <h2 className="text-lg font-semibold text-[var(--color-text-primary)] drop-shadow-lg">
               {selectedCharacter.name}
@@ -238,7 +248,6 @@ export function ChatView() {
         ) : (
           <div className="py-4">
             {messages.map((message) => {
-              // Get the avatar URL for this message
               const messageAvatar = message.isUser
                 ? undefined
                 : isGroupChatMode && message.characterAvatar
@@ -246,6 +255,10 @@ export function ChatView() {
                   : selectedCharacter
                     ? getAvatarUrl(selectedCharacter.avatar, message.emotion)
                     : undefined;
+
+              const isLastAiMessage = message.id === lastAiMessageId;
+              const showSwipeControl =
+                !isGroupChatMode && isLastAiMessage && !message.isUser && !message.isSystem;
 
               return (
                 <ChatMessage
@@ -256,26 +269,40 @@ export function ChatView() {
                   isSystem={message.isSystem}
                   avatar={messageAvatar}
                   timestamp={message.timestamp}
-                  isEditable={!isGroupChatMode && message.id === lastUserMessageId}
-                  onEdit={(newContent) => {
-                    if (selectedCharacter) {
-                      editMessageAndRegenerate(message.id, newContent, selectedCharacter, availableEmotions);
-                    }
-                  }}
                   disabled={isSending}
+                  swipes={message.swipes}
+                  swipeId={message.swipeId}
+                  showSwipeControl={showSwipeControl}
+                  onSwipeLeft={() => handleSwipeLeft(message.id)}
+                  onSwipeRight={() => handleSwipeRight(message.id)}
+                  onEdit={(newContent) => editMessage(message.id, newContent)}
+                  onEditAndRegenerate={
+                    message.isUser && selectedCharacter && !isGroupChatMode
+                      ? (newContent) =>
+                          editMessageAndRegenerate(
+                            message.id,
+                            newContent,
+                            selectedCharacter,
+                            availableEmotions
+                          )
+                      : undefined
+                  }
+                  onDelete={() => deleteMessage(message.id)}
+                  onRegenerate={
+                    isLastAiMessage && !isGroupChatMode ? handleRegenerate : undefined
+                  }
                 />
               );
             })}
 
-            {/* Error display */}
             {error && (
               <div className="mx-4 my-2 p-3 bg-red-500/10 border border-red-500/30 rounded-lg">
                 <p className="text-sm text-red-400">{error}</p>
               </div>
             )}
 
-            {/* Typing indicator */}
-            {isSending && (
+            {/* Typing indicator (only before first token) */}
+            {isSending && !isStreaming && (
               <div className="flex gap-3 px-4 py-3">
                 <div className="w-10 h-10 rounded-full bg-[var(--color-bg-tertiary)] flex items-center justify-center">
                   <div className="flex gap-1">
@@ -298,11 +325,26 @@ export function ChatView() {
         )}
       </div>
 
+      {/* Action Bar (regenerate/continue/impersonate/stop) */}
+      {!isGroupChatMode && (
+        <ChatActionBar
+          onRegenerate={handleRegenerate}
+          onContinue={handleContinue}
+          onImpersonate={handleImpersonate}
+          onStop={stopGeneration}
+          isSending={isSending}
+          hasAiMessage={hasAiMessage}
+          disabled={isSending}
+        />
+      )}
+
       {/* Input Area */}
       <ChatInput
         onSend={handleSend}
         disabled={isSending}
         placeholder={isGroupChatMode ? `Message the group...` : `Message ${displayName}...`}
+        prefillText={prefillText}
+        prefillNonce={prefillNonce}
       />
     </div>
   );

--- a/src/components/chat/MessageActionMenu.tsx
+++ b/src/components/chat/MessageActionMenu.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useRef } from 'react';
+import { Pencil, Copy, Trash2, RefreshCw } from 'lucide-react';
+
+interface MessageActionMenuProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onEdit: () => void;
+  onCopy: () => void;
+  onDelete: () => void;
+  onRegenerate?: () => void;
+  showRegenerate?: boolean;
+  anchorRight?: boolean;
+}
+
+export function MessageActionMenu({
+  isOpen,
+  onClose,
+  onEdit,
+  onCopy,
+  onDelete,
+  onRegenerate,
+  showRegenerate,
+  anchorRight,
+}: MessageActionMenuProps) {
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleClick = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+    const handleEsc = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    // Delay to avoid catching the triggering click
+    const timer = setTimeout(() => {
+      document.addEventListener('mousedown', handleClick);
+      document.addEventListener('keydown', handleEsc);
+    }, 0);
+    return () => {
+      clearTimeout(timer);
+      document.removeEventListener('mousedown', handleClick);
+      document.removeEventListener('keydown', handleEsc);
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  const actions = [
+    { icon: Pencil, label: 'Edit', onClick: onEdit },
+    { icon: Copy, label: 'Copy', onClick: onCopy },
+    ...(showRegenerate && onRegenerate
+      ? [{ icon: RefreshCw, label: 'Regenerate', onClick: onRegenerate }]
+      : []),
+    { icon: Trash2, label: 'Delete', onClick: onDelete, danger: true },
+  ];
+
+  return (
+    <div
+      ref={menuRef}
+      className={`
+        absolute z-20 min-w-[140px]
+        bg-[var(--color-bg-secondary)] border border-[var(--color-border)]
+        rounded-lg shadow-xl overflow-hidden
+        ${anchorRight ? 'right-0' : 'left-0'}
+      `}
+      style={{ top: '100%', marginTop: '4px' }}
+    >
+      {actions.map((action) => {
+        const Icon = action.icon;
+        return (
+          <button
+            key={action.label}
+            onClick={() => {
+              action.onClick();
+              onClose();
+            }}
+            className={`
+              w-full flex items-center gap-3 px-3 py-2 text-sm text-left
+              hover:bg-[var(--color-bg-tertiary)] transition-colors
+              ${action.danger ? 'text-red-400' : 'text-[var(--color-text-primary)]'}
+            `}
+          >
+            <Icon size={14} />
+            <span>{action.label}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/chat/SwipeControl.tsx
+++ b/src/components/chat/SwipeControl.tsx
@@ -1,0 +1,45 @@
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+
+interface SwipeControlProps {
+  swipeId: number;
+  swipesCount: number;
+  onSwipeLeft: () => void;
+  onSwipeRight: () => void;
+  disabled?: boolean;
+}
+
+export function SwipeControl({
+  swipeId,
+  swipesCount,
+  onSwipeLeft,
+  onSwipeRight,
+  disabled,
+}: SwipeControlProps) {
+  const canSwipeLeft = swipeId > 0 && !disabled;
+  const current = swipeId + 1;
+
+  return (
+    <div className="flex items-center gap-1 mt-1 text-[var(--color-text-secondary)]">
+      <button
+        onClick={onSwipeLeft}
+        disabled={!canSwipeLeft}
+        className="p-1 rounded hover:bg-[var(--color-bg-tertiary)] disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+        aria-label="Previous response"
+      >
+        <ChevronLeft size={16} />
+      </button>
+      <span className="text-xs font-medium min-w-[2.5rem] text-center tabular-nums">
+        {current}/{swipesCount}
+      </span>
+      <button
+        onClick={onSwipeRight}
+        disabled={disabled}
+        className="p-1 rounded hover:bg-[var(--color-bg-tertiary)] disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+        aria-label={swipeId === swipesCount - 1 ? 'Generate new response' : 'Next response'}
+        title={swipeId === swipesCount - 1 ? 'Generate new response' : 'Next response'}
+      >
+        <ChevronRight size={16} />
+      </button>
+    </div>
+  );
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react';
-import { Menu, Settings, LogOut, Pencil } from 'lucide-react';
+import { Menu, Settings, LogOut, Pencil, History } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useAuthStore } from '../../stores/authStore';
 import { useCharacterStore } from '../../stores/characterStore';
 import { Avatar, Button } from '../ui';
 import { CharacterEdit } from '../character/CharacterEdit';
+import { ChatHistoryPanel } from '../chat/ChatHistoryPanel';
 
 interface HeaderProps {
   onMenuClick: () => void;
@@ -13,8 +14,9 @@ interface HeaderProps {
 export function Header({ onMenuClick }: HeaderProps) {
   const navigate = useNavigate();
   const { currentUser, logout } = useAuthStore();
-  const { selectedCharacter } = useCharacterStore();
+  const { selectedCharacter, isGroupChatMode } = useCharacterStore();
   const [showEditModal, setShowEditModal] = useState(false);
+  const [showHistoryPanel, setShowHistoryPanel] = useState(false);
 
   const getAvatarUrl = (avatar: string) => `/thumbnail?type=avatar&file=${encodeURIComponent(avatar)}`;
 
@@ -60,6 +62,17 @@ export function Header({ onMenuClick }: HeaderProps) {
 
       {/* User Menu */}
       <div className="flex items-center gap-2">
+        {selectedCharacter && !isGroupChatMode && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="p-2"
+            aria-label="Chat history"
+            onClick={() => setShowHistoryPanel(true)}
+          >
+            <History size={20} />
+          </Button>
+        )}
         <Button
           variant="ghost"
           size="sm"
@@ -91,6 +104,12 @@ export function Header({ onMenuClick }: HeaderProps) {
           character={selectedCharacter}
         />
       )}
+
+      {/* Chat History Panel */}
+      <ChatHistoryPanel
+        isOpen={showHistoryPanel}
+        onClose={() => setShowHistoryPanel(false)}
+      />
     </header>
   );
 }


### PR DESCRIPTION
- SwipeControl: per-message swipe navigation with counter
- MessageActionMenu: edit/copy/delete/regenerate on any message
- ChatActionBar: regenerate/continue/impersonate + stop button
- ChatHistoryPanel: modal browser with new/load/delete/export
- ChatInput: prefill support for impersonate text
- ChatMessage: action menu + swipe control + save-vs-regen options
- ChatView: wired to all new store actions, typing indicator
- Header: history button next to edit pencil