### PR TITLE
Add Phase 2: character & persona depth features

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -63,14 +63,37 @@ export interface CharacterInfo {
   chat_size?: number;
   fav?: boolean;
   tags?: string[];
+  // Advanced Character Card V2 fields
+  alternate_greetings?: string[];
+  system_prompt?: string;
+  post_history_instructions?: string;
+  character_version?: string;
+  creator_notes?: string;
+  creator?: string;
   data?: {
     name?: string;
     description?: string;
     personality?: string;
     first_mes?: string;
     scenario?: string;
+    mes_example?: string;
     creator_notes?: string;
     creator?: string;
+    tags?: string[];
+    alternate_greetings?: string[];
+    system_prompt?: string;
+    post_history_instructions?: string;
+    character_version?: string;
+    extensions?: {
+      depth_prompt?: {
+        prompt?: string;
+        depth?: number;
+        role?: string;
+      };
+      talkativeness?: string;
+      fav?: boolean;
+      [key: string]: unknown;
+    };
   };
 }
 
@@ -84,6 +107,16 @@ export interface CharacterCreateData {
   creator_notes?: string;
   creator?: string;
   tags?: string;
+  // Advanced fields - sent via data object JSON string
+  alternate_greetings?: string[];
+  system_prompt?: string;
+  post_history_instructions?: string;
+  character_version?: string;
+  depth_prompt_prompt?: string;
+  depth_prompt_depth?: number;
+  depth_prompt_role?: string;
+  talkativeness?: string;
+  fav?: boolean;
 }
 
 export interface CharacterEditData extends CharacterCreateData {
@@ -191,16 +224,27 @@ export const api = {
     // Returns avatar filename like "CharacterName.png" as plain text
     const token = await getCsrfToken();
 
+    // Serialize arrays/numbers properly for backend
+    const serializedData: Record<string, string> = {};
+    Object.entries(data).forEach(([key, value]) => {
+      if (value === undefined) return;
+      if (Array.isArray(value)) {
+        serializedData[key] = JSON.stringify(value);
+      } else if (typeof value === 'number' || typeof value === 'boolean') {
+        serializedData[key] = String(value);
+      } else {
+        serializedData[key] = String(value);
+      }
+    });
+
     let response: Response;
 
     if (avatarFile) {
       // Use multipart form data when uploading an image
       const formData = new FormData();
       formData.append('avatar', avatarFile);
-      Object.entries(data).forEach(([key, value]) => {
-        if (value !== undefined) {
-          formData.append(key, String(value));
-        }
+      Object.entries(serializedData).forEach(([key, value]) => {
+        formData.append(key, value);
       });
 
       response = await fetch('/api/characters/create', {
@@ -244,16 +288,27 @@ export const api = {
     // Backend returns plain text "OK", not JSON
     const token = await getCsrfToken();
 
+    // Serialize arrays/numbers properly for backend
+    const serializedData: Record<string, string> = {};
+    Object.entries(data).forEach(([key, value]) => {
+      if (value === undefined) return;
+      if (Array.isArray(value)) {
+        serializedData[key] = JSON.stringify(value);
+      } else if (typeof value === 'number' || typeof value === 'boolean') {
+        serializedData[key] = String(value);
+      } else {
+        serializedData[key] = String(value);
+      }
+    });
+
     let response: Response;
 
     if (avatarFile) {
       // Use multipart form data when uploading an image
       const formData = new FormData();
       formData.append('avatar', avatarFile);
-      Object.entries(data).forEach(([key, value]) => {
-        if (value !== undefined) {
-          formData.append(key, String(value));
-        }
+      Object.entries(serializedData).forEach(([key, value]) => {
+        formData.append(key, value);
       });
 
       response = await fetch('/api/characters/edit', {
@@ -279,6 +334,34 @@ export const api = {
     if (!response.ok) {
       const errorText = await response.text();
       throw new Error(errorText || `HTTP ${response.status}`);
+    }
+  },
+
+  // Duplicate a character (server-side)
+  async duplicateCharacter(avatarUrl: string): Promise<string> {
+    const token = await getCsrfToken();
+    const response = await fetch('/api/characters/duplicate', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': token,
+      },
+      credentials: 'include',
+      body: JSON.stringify({ avatar_url: avatarUrl }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => 'Failed to duplicate');
+      throw new Error(errorText || `HTTP ${response.status}`);
+    }
+
+    // Backend returns JSON { path: 'newavatar.png' } or plain text
+    const text = await response.text();
+    try {
+      const data = JSON.parse(text);
+      return data.path || data.file_name || text;
+    } catch {
+      return text;
     }
   },
 

--- a/src/components/character/AlternateGreetingsEditor.tsx
+++ b/src/components/character/AlternateGreetingsEditor.tsx
@@ -1,0 +1,106 @@
+import { Plus, Trash2, ChevronLeft, ChevronRight } from 'lucide-react';
+import { useState } from 'react';
+import { Button, TextArea } from '../ui';
+
+interface AlternateGreetingsEditorProps {
+  greetings: string[];
+  onChange: (greetings: string[]) => void;
+}
+
+export function AlternateGreetingsEditor({ greetings, onChange }: AlternateGreetingsEditorProps) {
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  const handleAdd = () => {
+    const next = [...greetings, ''];
+    onChange(next);
+    setActiveIndex(next.length - 1);
+  };
+
+  const handleRemove = (index: number) => {
+    const next = greetings.filter((_, i) => i !== index);
+    onChange(next);
+    setActiveIndex(Math.max(0, Math.min(activeIndex, next.length - 1)));
+  };
+
+  const handleEdit = (index: number, value: string) => {
+    const next = greetings.map((g, i) => (i === index ? value : g));
+    onChange(next);
+  };
+
+  const count = greetings.length;
+
+  return (
+    <div className="w-full">
+      <div className="flex items-center justify-between mb-1.5">
+        <label className="block text-sm font-medium text-[var(--color-text-secondary)]">
+          Alternate Greetings {count > 0 && `(${count})`}
+        </label>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="py-1 px-2 text-xs"
+          onClick={handleAdd}
+        >
+          <Plus size={14} className="mr-1" />
+          Add
+        </Button>
+      </div>
+
+      {count === 0 ? (
+        <p className="text-xs text-[var(--color-text-secondary)] italic px-3 py-2 bg-[var(--color-bg-tertiary)] rounded-lg">
+          No alternate greetings yet. Users can swipe to pick a different opening message.
+        </p>
+      ) : (
+        <div className="space-y-2">
+          {/* Navigation */}
+          <div className="flex items-center justify-between gap-2">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="py-1 px-2"
+              onClick={() => setActiveIndex((i) => Math.max(0, i - 1))}
+              disabled={activeIndex === 0}
+            >
+              <ChevronLeft size={14} />
+            </Button>
+            <span className="text-xs text-[var(--color-text-secondary)]">
+              Greeting {activeIndex + 1} of {count}
+            </span>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="py-1 px-2"
+              onClick={() => setActiveIndex((i) => Math.min(count - 1, i + 1))}
+              disabled={activeIndex >= count - 1}
+            >
+              <ChevronRight size={14} />
+            </Button>
+          </div>
+
+          <div className="flex gap-2 items-start">
+            <div className="flex-1">
+              <TextArea
+                placeholder={`Alternate greeting ${activeIndex + 1}...`}
+                value={greetings[activeIndex] || ''}
+                onChange={(e) => handleEdit(activeIndex, e.target.value)}
+                rows={3}
+              />
+            </div>
+            <button
+              type="button"
+              onClick={() => handleRemove(activeIndex)}
+              className="p-2 mt-0.5 rounded-lg text-red-400 hover:bg-red-500/10"
+              aria-label="Remove greeting"
+              title="Remove this greeting"
+            >
+              <Trash2 size={16} />
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/character/CharacterCreation.tsx
+++ b/src/components/character/CharacterCreation.tsx
@@ -1,31 +1,53 @@
 import { useState } from 'react';
 import { useCharacterStore } from '../../stores/characterStore';
 import { Modal, Button, Input, TextArea, ImageUpload, ExpressionUpload } from '../ui';
+import { AlternateGreetingsEditor } from './AlternateGreetingsEditor';
 import { spritesApi } from '../../api/client';
 
 interface CharacterCreationProps {
   isOpen: boolean;
   onClose: () => void;
   onCreated?: (avatarUrl: string) => void;
+  initialData?: Partial<{
+    name: string;
+    description: string;
+    personality: string;
+    firstMessage: string;
+    scenario: string;
+    exampleMessages: string;
+    creatorNotes: string;
+    creator: string;
+    tags: string;
+  }>;
 }
 
-export function CharacterCreation({ isOpen, onClose, onCreated }: CharacterCreationProps) {
+export function CharacterCreation({ isOpen, onClose, onCreated, initialData }: CharacterCreationProps) {
   const { createCharacter, isCreating, error, clearError } = useCharacterStore();
 
   const [avatarFile, setAvatarFile] = useState<File | null>(null);
   const [expressionFiles, setExpressionFiles] = useState<Map<string, File>>(new Map());
   const [isUploadingExpressions, setIsUploadingExpressions] = useState(false);
   const [formData, setFormData] = useState({
-    name: '',
-    description: '',
-    personality: '',
-    firstMessage: '',
-    scenario: '',
-    exampleMessages: '',
-    creatorNotes: '',
-    creator: '',
-    tags: '',
+    name: initialData?.name || '',
+    description: initialData?.description || '',
+    personality: initialData?.personality || '',
+    firstMessage: initialData?.firstMessage || '',
+    scenario: initialData?.scenario || '',
+    exampleMessages: initialData?.exampleMessages || '',
+    creatorNotes: initialData?.creatorNotes || '',
+    creator: initialData?.creator || '',
+    tags: initialData?.tags || '',
   });
+
+  // Phase 2: Advanced character fields
+  const [alternateGreetings, setAlternateGreetings] = useState<string[]>([]);
+  const [characterVersion, setCharacterVersion] = useState('');
+  const [depthPromptPrompt, setDepthPromptPrompt] = useState('');
+  const [depthPromptDepth, setDepthPromptDepth] = useState(4);
+  const [depthPromptRole, setDepthPromptRole] = useState<'system' | 'user' | 'assistant'>('system');
+  const [systemPromptOverride, setSystemPromptOverride] = useState('');
+  const [postHistoryInstructions, setPostHistoryInstructions] = useState('');
+  const [talkativeness, setTalkativeness] = useState('0.5');
 
   const handleChange = (field: string) => (
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
@@ -52,6 +74,15 @@ export function CharacterCreation({ isOpen, onClose, onCreated }: CharacterCreat
         creator_notes: formData.creatorNotes.trim(),
         creator: formData.creator.trim(),
         tags: formData.tags.trim(),
+        // Advanced fields
+        alternate_greetings: alternateGreetings.filter((g) => g.trim()),
+        system_prompt: systemPromptOverride.trim() || undefined,
+        post_history_instructions: postHistoryInstructions.trim() || undefined,
+        character_version: characterVersion.trim() || undefined,
+        depth_prompt_prompt: depthPromptPrompt.trim() || undefined,
+        depth_prompt_depth: depthPromptPrompt.trim() ? depthPromptDepth : undefined,
+        depth_prompt_role: depthPromptPrompt.trim() ? depthPromptRole : undefined,
+        talkativeness: talkativeness || undefined,
       },
       avatarFile || undefined
     );
@@ -94,6 +125,14 @@ export function CharacterCreation({ isOpen, onClose, onCreated }: CharacterCreat
         creator: '',
         tags: '',
       });
+      setAlternateGreetings([]);
+      setCharacterVersion('');
+      setDepthPromptPrompt('');
+      setDepthPromptDepth(4);
+      setDepthPromptRole('system');
+      setSystemPromptOverride('');
+      setPostHistoryInstructions('');
+      setTalkativeness('0.5');
       onClose();
       onCreated?.(avatarUrl);
     }
@@ -150,6 +189,12 @@ export function CharacterCreation({ isOpen, onClose, onCreated }: CharacterCreat
           rows={4}
         />
 
+        {/* Alternate Greetings */}
+        <AlternateGreetingsEditor
+          greetings={alternateGreetings}
+          onChange={setAlternateGreetings}
+        />
+
         {/* Scenario */}
         <TextArea
           label="Scenario"
@@ -176,6 +221,95 @@ export function CharacterCreation({ isOpen, onClose, onCreated }: CharacterCreat
               value={formData.exampleMessages}
               onChange={handleChange('exampleMessages')}
               rows={4}
+            />
+
+            {/* Character's Note (Depth Prompt) */}
+            <div className="space-y-2">
+              <TextArea
+                label="Character's Note"
+                placeholder="Injected at a configurable depth in the chat to reinforce behavior..."
+                value={depthPromptPrompt}
+                onChange={(e) => setDepthPromptPrompt(e.target.value)}
+                rows={2}
+              />
+              {depthPromptPrompt && (
+                <div className="grid grid-cols-2 gap-2">
+                  <div>
+                    <label className="block text-xs font-medium text-[var(--color-text-secondary)] mb-1">
+                      Injection Depth
+                    </label>
+                    <input
+                      type="number"
+                      min={0}
+                      max={20}
+                      value={depthPromptDepth}
+                      onChange={(e) => setDepthPromptDepth(Number(e.target.value))}
+                      className="w-full px-3 py-2 bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] rounded-lg text-[var(--color-text-primary)] text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-xs font-medium text-[var(--color-text-secondary)] mb-1">
+                      Role
+                    </label>
+                    <select
+                      value={depthPromptRole}
+                      onChange={(e) =>
+                        setDepthPromptRole(e.target.value as 'system' | 'user' | 'assistant')
+                      }
+                      className="w-full px-3 py-2 bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] rounded-lg text-[var(--color-text-primary)] text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]"
+                    >
+                      <option value="system">System</option>
+                      <option value="user">User</option>
+                      <option value="assistant">Assistant</option>
+                    </select>
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {/* System Prompt Override */}
+            <TextArea
+              label="System Prompt Override"
+              placeholder="Overrides the main system prompt for this character..."
+              value={systemPromptOverride}
+              onChange={(e) => setSystemPromptOverride(e.target.value)}
+              rows={3}
+            />
+
+            {/* Post-History Instructions */}
+            <TextArea
+              label="Post-History Instructions"
+              placeholder="Instructions appended after the chat history..."
+              value={postHistoryInstructions}
+              onChange={(e) => setPostHistoryInstructions(e.target.value)}
+              rows={2}
+            />
+
+            {/* Talkativeness */}
+            <div>
+              <label className="block text-sm font-medium text-[var(--color-text-secondary)] mb-1.5">
+                Talkativeness ({talkativeness})
+              </label>
+              <input
+                type="range"
+                min={0}
+                max={1}
+                step={0.05}
+                value={talkativeness}
+                onChange={(e) => setTalkativeness(e.target.value)}
+                className="w-full"
+              />
+              <p className="text-xs text-[var(--color-text-secondary)] mt-1">
+                Used in group chats to control how often this character speaks.
+              </p>
+            </div>
+
+            {/* Character Version */}
+            <Input
+              label="Character Version"
+              placeholder="e.g., 1.0"
+              value={characterVersion}
+              onChange={(e) => setCharacterVersion(e.target.value)}
             />
 
             {/* Creator Notes */}

--- a/src/components/character/CharacterEdit.tsx
+++ b/src/components/character/CharacterEdit.tsx
@@ -1,18 +1,38 @@
 import { useState, useEffect } from 'react';
-import { Download, FileImage, FileJson } from 'lucide-react';
+import { Download, FileImage, FileJson, Copy, UserCircle } from 'lucide-react';
 import { useCharacterStore } from '../../stores/characterStore';
 import { spritesApi, type CharacterInfo } from '../../api/client';
 import { Modal, Button, Input, TextArea, ImageUpload, ExpressionUpload } from '../ui';
+import { AlternateGreetingsEditor } from './AlternateGreetingsEditor';
 
 interface CharacterEditProps {
   isOpen: boolean;
   onClose: () => void;
   character: CharacterInfo;
   onSaved?: () => void;
+  onDuplicated?: (newAvatarUrl: string) => void;
+  onConvertToPersona?: (character: CharacterInfo) => void;
 }
 
-export function CharacterEdit({ isOpen, onClose, character, onSaved }: CharacterEditProps) {
-  const { updateCharacter, isEditing, isExporting, error, clearError, exportCharacterAsPNG, exportCharacterAsJSON } = useCharacterStore();
+export function CharacterEdit({
+  isOpen,
+  onClose,
+  character,
+  onSaved,
+  onDuplicated,
+  onConvertToPersona,
+}: CharacterEditProps) {
+  const {
+    updateCharacter,
+    duplicateCharacter,
+    isEditing,
+    isExporting,
+    isDuplicating,
+    error,
+    clearError,
+    exportCharacterAsPNG,
+    exportCharacterAsJSON,
+  } = useCharacterStore();
   const [showExportMenu, setShowExportMenu] = useState(false);
 
   const [avatarFile, setAvatarFile] = useState<File | null>(null);
@@ -30,6 +50,16 @@ export function CharacterEdit({ isOpen, onClose, character, onSaved }: Character
     tags: '',
   });
 
+  // Phase 2: Advanced character fields
+  const [alternateGreetings, setAlternateGreetings] = useState<string[]>([]);
+  const [characterVersion, setCharacterVersion] = useState('');
+  const [depthPromptPrompt, setDepthPromptPrompt] = useState('');
+  const [depthPromptDepth, setDepthPromptDepth] = useState(4);
+  const [depthPromptRole, setDepthPromptRole] = useState<'system' | 'user' | 'assistant'>('system');
+  const [systemPromptOverride, setSystemPromptOverride] = useState('');
+  const [postHistoryInstructions, setPostHistoryInstructions] = useState('');
+  const [talkativeness, setTalkativeness] = useState('0.5');
+
   const getAvatarUrl = (avatar: string) => `/thumbnail?type=avatar&file=${encodeURIComponent(avatar)}`;
 
   // Populate form when character changes or modal opens
@@ -43,11 +73,35 @@ export function CharacterEdit({ isOpen, onClose, character, onSaved }: Character
         personality: character.personality || character.data?.personality || '',
         firstMessage: character.first_mes || character.data?.first_mes || '',
         scenario: character.scenario || character.data?.scenario || '',
-        exampleMessages: character.mes_example || '',
-        creatorNotes: character.data?.creator_notes || '',
-        creator: character.data?.creator || '',
-        tags: character.tags?.join(', ') || '',
+        exampleMessages: character.mes_example || character.data?.mes_example || '',
+        creatorNotes: character.creator_notes || character.data?.creator_notes || '',
+        creator: character.creator || character.data?.creator || '',
+        tags: (character.tags || character.data?.tags || []).join(', '),
       });
+
+      // Populate advanced fields
+      setAlternateGreetings(
+        character.alternate_greetings || character.data?.alternate_greetings || []
+      );
+      setCharacterVersion(
+        character.character_version || character.data?.character_version || ''
+      );
+      setSystemPromptOverride(
+        character.system_prompt || character.data?.system_prompt || ''
+      );
+      setPostHistoryInstructions(
+        character.post_history_instructions || character.data?.post_history_instructions || ''
+      );
+
+      const depthPrompt = character.data?.extensions?.depth_prompt;
+      setDepthPromptPrompt(depthPrompt?.prompt || '');
+      setDepthPromptDepth(depthPrompt?.depth ?? 4);
+      setDepthPromptRole(
+        (depthPrompt?.role as 'system' | 'user' | 'assistant') || 'system'
+      );
+
+      const charTalkativeness = character.data?.extensions?.talkativeness;
+      setTalkativeness(typeof charTalkativeness === 'string' ? charTalkativeness : '0.5');
     }
   }, [isOpen, character]);
 
@@ -89,6 +143,15 @@ export function CharacterEdit({ isOpen, onClose, character, onSaved }: Character
         tags: formData.tags.trim(),
         chat: character.create_date, // Preserve existing
         create_date: character.create_date, // Preserve existing
+        // Advanced fields
+        alternate_greetings: alternateGreetings.filter((g) => g.trim()),
+        system_prompt: systemPromptOverride.trim() || undefined,
+        post_history_instructions: postHistoryInstructions.trim() || undefined,
+        character_version: characterVersion.trim() || undefined,
+        depth_prompt_prompt: depthPromptPrompt.trim() || undefined,
+        depth_prompt_depth: depthPromptPrompt.trim() ? depthPromptDepth : undefined,
+        depth_prompt_role: depthPromptPrompt.trim() ? depthPromptRole : undefined,
+        talkativeness: talkativeness || undefined,
       },
       avatarFile || undefined
     );
@@ -127,6 +190,19 @@ export function CharacterEdit({ isOpen, onClose, character, onSaved }: Character
     onClose();
   };
 
+  const handleDuplicate = async () => {
+    const newAvatar = await duplicateCharacter(character.avatar);
+    if (newAvatar) {
+      onClose();
+      onDuplicated?.(newAvatar);
+    }
+  };
+
+  const handleConvertToPersona = () => {
+    onClose();
+    onConvertToPersona?.(character);
+  };
+
   return (
     <Modal isOpen={isOpen} onClose={handleClose} title={`Edit ${character.name}`} size="lg">
       <form onSubmit={handleSubmit} className="space-y-4">
@@ -137,54 +213,78 @@ export function CharacterEdit({ isOpen, onClose, character, onSaved }: Character
           label="Avatar"
         />
 
-        {/* Export Options */}
-        <div className="relative">
+        {/* Character Actions */}
+        <div className="grid grid-cols-3 gap-2">
           <Button
             type="button"
             variant="secondary"
-            className="w-full"
-            onClick={() => setShowExportMenu(!showExportMenu)}
-            disabled={isExporting}
+            size="sm"
+            onClick={handleDuplicate}
+            isLoading={isDuplicating}
+            title="Create a copy of this character"
           >
-            {isExporting ? (
-              <>
-                <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-current mr-2" />
-                Exporting...
-              </>
-            ) : (
-              <>
-                <Download size={18} className="mr-2" />
-                Export Character
-              </>
-            )}
+            <Copy size={16} className="mr-1.5" />
+            Duplicate
           </Button>
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            onClick={handleConvertToPersona}
+            title="Create a new persona using this character's data"
+          >
+            <UserCircle size={16} className="mr-1.5" />
+            To Persona
+          </Button>
+          <div className="relative">
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              className="w-full"
+              onClick={() => setShowExportMenu(!showExportMenu)}
+              disabled={isExporting}
+            >
+              {isExporting ? (
+                <>
+                  <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-current mr-1.5" />
+                  Exporting
+                </>
+              ) : (
+                <>
+                  <Download size={16} className="mr-1.5" />
+                  Export
+                </>
+              )}
+            </Button>
 
-          {showExportMenu && (
-            <div className="absolute top-full left-0 right-0 mt-1 bg-[var(--color-bg-secondary)] border border-[var(--color-border)] rounded-lg shadow-lg z-10 overflow-hidden">
-              <button
-                type="button"
-                className="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-[var(--color-bg-tertiary)] transition-colors"
-                onClick={handleExportPNG}
-              >
-                <FileImage size={18} className="text-[var(--color-primary)]" />
-                <div>
-                  <p className="text-sm font-medium text-[var(--color-text-primary)]">PNG Card</p>
-                  <p className="text-xs text-[var(--color-text-secondary)]">Character card with embedded data</p>
-                </div>
-              </button>
-              <button
-                type="button"
-                className="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-[var(--color-bg-tertiary)] transition-colors border-t border-[var(--color-border)]"
-                onClick={handleExportJSON}
-              >
-                <FileJson size={18} className="text-[var(--color-primary)]" />
-                <div>
-                  <p className="text-sm font-medium text-[var(--color-text-primary)]">JSON</p>
-                  <p className="text-xs text-[var(--color-text-secondary)]">Character data as JSON file</p>
-                </div>
-              </button>
-            </div>
-          )}
+            {showExportMenu && (
+              <div className="absolute top-full right-0 mt-1 min-w-[220px] bg-[var(--color-bg-secondary)] border border-[var(--color-border)] rounded-lg shadow-lg z-10 overflow-hidden">
+                <button
+                  type="button"
+                  className="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-[var(--color-bg-tertiary)] transition-colors"
+                  onClick={handleExportPNG}
+                >
+                  <FileImage size={18} className="text-[var(--color-primary)]" />
+                  <div>
+                    <p className="text-sm font-medium text-[var(--color-text-primary)]">PNG Card</p>
+                    <p className="text-xs text-[var(--color-text-secondary)]">Card with embedded data</p>
+                  </div>
+                </button>
+                <button
+                  type="button"
+                  className="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-[var(--color-bg-tertiary)] transition-colors border-t border-[var(--color-border)]"
+                  onClick={handleExportJSON}
+                >
+                  <FileJson size={18} className="text-[var(--color-primary)]" />
+                  <div>
+                    <p className="text-sm font-medium text-[var(--color-text-primary)]">JSON</p>
+                    <p className="text-xs text-[var(--color-text-secondary)]">V2 card as JSON</p>
+                  </div>
+                </button>
+              </div>
+            )}
+          </div>
         </div>
 
         {/* Name - Required */}
@@ -224,6 +324,12 @@ export function CharacterEdit({ isOpen, onClose, character, onSaved }: Character
           rows={4}
         />
 
+        {/* Alternate Greetings */}
+        <AlternateGreetingsEditor
+          greetings={alternateGreetings}
+          onChange={setAlternateGreetings}
+        />
+
         {/* Scenario */}
         <TextArea
           label="Scenario"
@@ -253,6 +359,95 @@ export function CharacterEdit({ isOpen, onClose, character, onSaved }: Character
               value={formData.exampleMessages}
               onChange={handleChange('exampleMessages')}
               rows={4}
+            />
+
+            {/* Character's Note (Depth Prompt) */}
+            <div className="space-y-2">
+              <TextArea
+                label="Character's Note"
+                placeholder="Injected at a configurable depth in the chat to reinforce behavior..."
+                value={depthPromptPrompt}
+                onChange={(e) => setDepthPromptPrompt(e.target.value)}
+                rows={2}
+              />
+              {depthPromptPrompt && (
+                <div className="grid grid-cols-2 gap-2">
+                  <div>
+                    <label className="block text-xs font-medium text-[var(--color-text-secondary)] mb-1">
+                      Injection Depth
+                    </label>
+                    <input
+                      type="number"
+                      min={0}
+                      max={20}
+                      value={depthPromptDepth}
+                      onChange={(e) => setDepthPromptDepth(Number(e.target.value))}
+                      className="w-full px-3 py-2 bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] rounded-lg text-[var(--color-text-primary)] text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-xs font-medium text-[var(--color-text-secondary)] mb-1">
+                      Role
+                    </label>
+                    <select
+                      value={depthPromptRole}
+                      onChange={(e) =>
+                        setDepthPromptRole(e.target.value as 'system' | 'user' | 'assistant')
+                      }
+                      className="w-full px-3 py-2 bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] rounded-lg text-[var(--color-text-primary)] text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]"
+                    >
+                      <option value="system">System</option>
+                      <option value="user">User</option>
+                      <option value="assistant">Assistant</option>
+                    </select>
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {/* System Prompt Override */}
+            <TextArea
+              label="System Prompt Override"
+              placeholder="Overrides the main system prompt for this character..."
+              value={systemPromptOverride}
+              onChange={(e) => setSystemPromptOverride(e.target.value)}
+              rows={3}
+            />
+
+            {/* Post-History Instructions */}
+            <TextArea
+              label="Post-History Instructions"
+              placeholder="Instructions appended after the chat history..."
+              value={postHistoryInstructions}
+              onChange={(e) => setPostHistoryInstructions(e.target.value)}
+              rows={2}
+            />
+
+            {/* Talkativeness */}
+            <div>
+              <label className="block text-sm font-medium text-[var(--color-text-secondary)] mb-1.5">
+                Talkativeness ({talkativeness})
+              </label>
+              <input
+                type="range"
+                min={0}
+                max={1}
+                step={0.05}
+                value={talkativeness}
+                onChange={(e) => setTalkativeness(e.target.value)}
+                className="w-full"
+              />
+              <p className="text-xs text-[var(--color-text-secondary)] mt-1">
+                Used in group chats to control how often this character speaks.
+              </p>
+            </div>
+
+            {/* Character Version */}
+            <Input
+              label="Character Version"
+              placeholder="e.g., 1.0"
+              value={characterVersion}
+              onChange={(e) => setCharacterVersion(e.target.value)}
             />
 
             {/* Creator Notes */}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -6,6 +6,8 @@ import { useCharacterStore } from '../../stores/characterStore';
 import { Avatar, Button } from '../ui';
 import { CharacterEdit } from '../character/CharacterEdit';
 import { ChatHistoryPanel } from '../chat/ChatHistoryPanel';
+import { PersonaSelector, PersonaManager } from '../persona';
+import type { CharacterInfo } from '../../api/client';
 
 interface HeaderProps {
   onMenuClick: () => void;
@@ -14,9 +16,25 @@ interface HeaderProps {
 export function Header({ onMenuClick }: HeaderProps) {
   const navigate = useNavigate();
   const { currentUser, logout } = useAuthStore();
-  const { selectedCharacter, isGroupChatMode } = useCharacterStore();
+  const { selectedCharacter, isGroupChatMode, fetchCharacters } = useCharacterStore();
   const [showEditModal, setShowEditModal] = useState(false);
   const [showHistoryPanel, setShowHistoryPanel] = useState(false);
+  const [convertToPersonaData, setConvertToPersonaData] = useState<
+    { name: string; description: string } | null
+  >(null);
+
+  const handleConvertToPersona = (character: CharacterInfo) => {
+    const desc =
+      character.description ||
+      character.data?.description ||
+      '';
+    setConvertToPersonaData({ name: character.name, description: desc });
+  };
+
+  const handleDuplicated = async () => {
+    // Refresh character list to show the new duplicate
+    await fetchCharacters();
+  };
 
   const getAvatarUrl = (avatar: string) => `/thumbnail?type=avatar&file=${encodeURIComponent(avatar)}`;
 
@@ -61,7 +79,7 @@ export function Header({ onMenuClick }: HeaderProps) {
       </div>
 
       {/* User Menu */}
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-1">
         {selectedCharacter && !isGroupChatMode && (
           <Button
             variant="ghost"
@@ -73,6 +91,7 @@ export function Header({ onMenuClick }: HeaderProps) {
             <History size={20} />
           </Button>
         )}
+        <PersonaSelector />
         <Button
           variant="ghost"
           size="sm"
@@ -92,7 +111,7 @@ export function Header({ onMenuClick }: HeaderProps) {
           <LogOut size={20} />
         </Button>
         {currentUser && (
-          <Avatar size="sm" alt={currentUser.name} />
+          <Avatar size="sm" alt={currentUser.name} className="hidden lg:flex" />
         )}
       </div>
 
@@ -102,6 +121,8 @@ export function Header({ onMenuClick }: HeaderProps) {
           isOpen={showEditModal}
           onClose={() => setShowEditModal(false)}
           character={selectedCharacter}
+          onDuplicated={handleDuplicated}
+          onConvertToPersona={handleConvertToPersona}
         />
       )}
 
@@ -110,6 +131,15 @@ export function Header({ onMenuClick }: HeaderProps) {
         isOpen={showHistoryPanel}
         onClose={() => setShowHistoryPanel(false)}
       />
+
+      {/* Persona Manager (opened from convert-to-persona) */}
+      {convertToPersonaData && (
+        <PersonaManager
+          isOpen={!!convertToPersonaData}
+          onClose={() => setConvertToPersonaData(null)}
+          initialPersona={convertToPersonaData}
+        />
+      )}
     </header>
   );
 }

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,5 +1,19 @@
 import { useEffect, useState, useMemo, useCallback } from 'react';
-import { X, Search, Plus, MessageSquare, Users, ChevronLeft, UserPlus, Check, Trash2, Upload } from 'lucide-react';
+import {
+  X,
+  Search,
+  Plus,
+  MessageSquare,
+  Users,
+  ChevronLeft,
+  UserPlus,
+  Check,
+  Trash2,
+  Upload,
+  Star,
+  Filter,
+  ArrowUpDown,
+} from 'lucide-react';
 import { useCharacterStore } from '../../stores/characterStore';
 import { useChatStore, type GroupChatInfo } from '../../stores/chatStore';
 import { Avatar, Button, Input } from '../ui';
@@ -19,8 +33,8 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
   const [showCharacterList, setShowCharacterList] = useState(false);
   const [failedExpressions, setFailedExpressions] = useState<Set<string>>(new Set());
   const [isGroupSelectMode, setIsGroupSelectMode] = useState(false);
+  const [showFilters, setShowFilters] = useState(false);
   const {
-    characters,
     selectedCharacter,
     isLoading,
     fetchCharacters,
@@ -31,9 +45,27 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
     exitGroupChat,
     isCharacterInGroup,
     setGroupChatCharacters,
+    favorites,
+    toggleFavorite,
+    searchQuery,
+    setSearchQuery,
+    selectedTags,
+    toggleTagFilter,
+    clearTagFilters,
+    showFavoritesOnly,
+    setShowFavoritesOnly,
+    sortMode,
+    setSortMode,
+    getAllTags,
+    getFilteredCharacters,
   } = useCharacterStore();
   const { messages, startNewGroupChat, groupChats, loadGroupChat, deleteGroupChat } = useChatStore();
   const [showGroupChats, setShowGroupChats] = useState(false);
+
+  const filteredCharacters = getFilteredCharacters();
+  const allTags = getAllTags();
+  const activeFilterCount =
+    selectedTags.size + (showFavoritesOnly ? 1 : 0) + (searchQuery.trim() ? 1 : 0);
 
   // Fetch actual sprite paths from API (hook extracts character name from avatar filename)
   const { getSpritePath } = useCharacterSprites(selectedCharacter?.avatar);
@@ -287,8 +319,8 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
               </div>
             </div>
 
-            {/* Search */}
-            <div className="p-3 border-b border-[var(--color-border)]">
+            {/* Search & Filters */}
+            <div className="p-3 border-b border-[var(--color-border)] space-y-2">
               <div className="relative">
                 <Search
                   size={18}
@@ -298,8 +330,89 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
                   type="search"
                   placeholder="Search characters..."
                   className="pl-10"
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
                 />
               </div>
+
+              {/* Filter controls */}
+              <div className="flex items-center gap-1">
+                <button
+                  onClick={() => setShowFavoritesOnly(!showFavoritesOnly)}
+                  className={`flex items-center gap-1 px-2 py-1 text-xs rounded-md transition-colors ${
+                    showFavoritesOnly
+                      ? 'bg-yellow-500/20 text-yellow-400'
+                      : 'text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-tertiary)]'
+                  }`}
+                  title="Show favorites only"
+                >
+                  <Star size={12} fill={showFavoritesOnly ? 'currentColor' : 'none'} />
+                  <span className="hidden sm:inline">Favorites</span>
+                </button>
+                <button
+                  onClick={() => setShowFilters(!showFilters)}
+                  className={`flex items-center gap-1 px-2 py-1 text-xs rounded-md transition-colors ${
+                    showFilters || selectedTags.size > 0
+                      ? 'bg-[var(--color-primary)]/20 text-[var(--color-primary)]'
+                      : 'text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-tertiary)]'
+                  }`}
+                  title="Tag filters"
+                >
+                  <Filter size={12} />
+                  <span className="hidden sm:inline">Tags</span>
+                  {selectedTags.size > 0 && (
+                    <span className="bg-[var(--color-primary)] text-white px-1 rounded text-[10px]">
+                      {selectedTags.size}
+                    </span>
+                  )}
+                </button>
+                <select
+                  value={sortMode}
+                  onChange={(e) => setSortMode(e.target.value as never)}
+                  className="flex items-center gap-1 px-2 py-1 text-xs rounded-md text-[var(--color-text-secondary)] bg-transparent hover:bg-[var(--color-bg-tertiary)] cursor-pointer appearance-none focus:outline-none"
+                  title="Sort mode"
+                >
+                  <option value="name">Name</option>
+                  <option value="date_added">Recently added</option>
+                  <option value="date_last_chat">Recent chat</option>
+                </select>
+                <ArrowUpDown size={12} className="text-[var(--color-text-secondary)] -ml-1" />
+                {activeFilterCount > 0 && (
+                  <button
+                    onClick={() => {
+                      clearTagFilters();
+                      setShowFavoritesOnly(false);
+                      setSearchQuery('');
+                    }}
+                    className="ml-auto text-xs text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] underline"
+                    title="Clear all filters"
+                  >
+                    Clear
+                  </button>
+                )}
+              </div>
+
+              {/* Tag filter chips */}
+              {showFilters && allTags.length > 0 && (
+                <div className="flex flex-wrap gap-1 pt-1">
+                  {allTags.map((tag) => {
+                    const isSelected = selectedTags.has(tag);
+                    return (
+                      <button
+                        key={tag}
+                        onClick={() => toggleTagFilter(tag)}
+                        className={`text-xs px-2 py-1 rounded-full transition-colors ${
+                          isSelected
+                            ? 'bg-[var(--color-primary)] text-white'
+                            : 'bg-[var(--color-bg-tertiary)] text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-primary)]'
+                        }`}
+                      >
+                        {tag}
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
             </div>
 
             {/* Character List */}
@@ -308,30 +421,25 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
                 <div className="flex items-center justify-center py-8">
                   <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-[var(--color-primary)]" />
                 </div>
-              ) : characters.length === 0 ? (
+              ) : filteredCharacters.length === 0 ? (
                 <div className="text-center py-8 px-4">
                   <MessageSquare size={32} className="mx-auto text-[var(--color-text-secondary)] mb-2" />
                   <p className="text-sm text-[var(--color-text-secondary)]">
-                    No characters found
+                    {activeFilterCount > 0
+                      ? 'No characters match your filters'
+                      : 'No characters found'}
                   </p>
                 </div>
               ) : (
                 <ul className="py-2">
-                  {characters.map((character) => {
+                  {filteredCharacters.map((character) => {
                     const isInGroup = isCharacterInGroup(character.avatar);
+                    const isFav = favorites.has(character.avatar);
                     return (
-                      <li key={character.avatar}>
-                        <button
-                          onClick={() => {
-                            if (isGroupSelectMode) {
-                              toggleGroupChatCharacter(character.avatar);
-                            } else {
-                              handleCharacterSelect(character.avatar);
-                            }
-                          }}
+                      <li key={character.avatar} className="group">
+                        <div
                           className={`
-                            w-full flex items-center gap-3 px-4 py-3
-                            transition-colors
+                            relative flex items-center
                             ${
                               isGroupSelectMode && isInGroup
                                 ? 'bg-[var(--color-primary)]/20 border-l-2 border-[var(--color-primary)]'
@@ -341,33 +449,64 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
                             }
                           `}
                         >
-                          {/* Checkbox for group select mode */}
-                          {isGroupSelectMode && (
-                            <div
-                              className={`
-                                w-5 h-5 rounded border-2 flex items-center justify-center flex-shrink-0
-                                ${
-                                  isInGroup
-                                    ? 'bg-[var(--color-primary)] border-[var(--color-primary)]'
-                                    : 'border-[var(--color-text-secondary)]'
-                                }
-                              `}
-                            >
-                              {isInGroup && <Check size={14} className="text-white" />}
-                            </div>
-                          )}
-                          <Avatar src={getThumbnailUrl(character.avatar)} alt={character.name} size="md" />
-                          <div className="flex-1 min-w-0 text-left">
-                            <p className="text-sm font-medium text-[var(--color-text-primary)] truncate">
-                              {character.name}
-                            </p>
-                            {character.description && (
-                              <p className="text-xs text-[var(--color-text-secondary)] truncate">
-                                {character.description}
-                              </p>
+                          <button
+                            onClick={() => {
+                              if (isGroupSelectMode) {
+                                toggleGroupChatCharacter(character.avatar);
+                              } else {
+                                handleCharacterSelect(character.avatar);
+                              }
+                            }}
+                            className="flex-1 flex items-center gap-3 px-4 py-3 text-left transition-colors min-w-0"
+                          >
+                            {/* Checkbox for group select mode */}
+                            {isGroupSelectMode && (
+                              <div
+                                className={`
+                                  w-5 h-5 rounded border-2 flex items-center justify-center flex-shrink-0
+                                  ${
+                                    isInGroup
+                                      ? 'bg-[var(--color-primary)] border-[var(--color-primary)]'
+                                      : 'border-[var(--color-text-secondary)]'
+                                  }
+                                `}
+                              >
+                                {isInGroup && <Check size={14} className="text-white" />}
+                              </div>
                             )}
-                          </div>
-                        </button>
+                            <Avatar
+                              src={getThumbnailUrl(character.avatar)}
+                              alt={character.name}
+                              size="md"
+                            />
+                            <div className="flex-1 min-w-0">
+                              <p className="text-sm font-medium text-[var(--color-text-primary)] truncate">
+                                {character.name}
+                              </p>
+                              {character.description && (
+                                <p className="text-xs text-[var(--color-text-secondary)] truncate">
+                                  {character.description}
+                                </p>
+                              )}
+                            </div>
+                          </button>
+                          {!isGroupSelectMode && (
+                            <button
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                toggleFavorite(character.avatar);
+                              }}
+                              className={`p-2 mr-2 rounded-lg transition-opacity ${
+                                isFav
+                                  ? 'text-yellow-400 opacity-100'
+                                  : 'text-[var(--color-text-secondary)] opacity-0 group-hover:opacity-100 hover:text-yellow-400'
+                              }`}
+                              title={isFav ? 'Unfavorite' : 'Favorite'}
+                            >
+                              <Star size={16} fill={isFav ? 'currentColor' : 'none'} />
+                            </button>
+                          )}
+                        </div>
                       </li>
                     );
                   })}

--- a/src/components/persona/PersonaForm.tsx
+++ b/src/components/persona/PersonaForm.tsx
@@ -1,0 +1,198 @@
+import { useEffect, useState } from 'react';
+import { User } from 'lucide-react';
+import { usePersonaStore, type PersonaDescriptionPosition, type PersonaDescriptionRole, type Persona } from '../../stores/personaStore';
+import { Button, Input, TextArea, ImageUpload } from '../ui';
+
+interface PersonaFormProps {
+  persona?: Persona | null;
+  onClose: () => void;
+  onSaved?: () => void;
+  initialValues?: {
+    name?: string;
+    description?: string;
+  };
+}
+
+export function PersonaForm({ persona, onClose, onSaved, initialValues }: PersonaFormProps) {
+  const { createPersona, updatePersona } = usePersonaStore();
+
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [avatarDataUrl, setAvatarDataUrl] = useState<string | undefined>(undefined);
+  const [descriptionPosition, setDescriptionPosition] =
+    useState<PersonaDescriptionPosition>('before_char');
+  const [descriptionDepth, setDescriptionDepth] = useState(4);
+  const [descriptionRole, setDescriptionRole] = useState<PersonaDescriptionRole>('system');
+  const [isDefault, setIsDefault] = useState(false);
+
+  useEffect(() => {
+    if (persona) {
+      setName(persona.name);
+      setDescription(persona.description);
+      setAvatarDataUrl(persona.avatarDataUrl);
+      setDescriptionPosition(persona.descriptionPosition);
+      setDescriptionDepth(persona.descriptionDepth);
+      setDescriptionRole(persona.descriptionRole);
+      setIsDefault(!!persona.isDefault);
+    } else {
+      setName(initialValues?.name || '');
+      setDescription(initialValues?.description || '');
+      setAvatarDataUrl(undefined);
+      setDescriptionPosition('before_char');
+      setDescriptionDepth(4);
+      setDescriptionRole('system');
+      setIsDefault(false);
+    }
+  }, [persona, initialValues]);
+
+  const handleAvatarSelect = async (file: File | null) => {
+    if (!file) {
+      setAvatarDataUrl(undefined);
+      return;
+    }
+    // Resize to small size and convert to data URL
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      const result = e.target?.result as string;
+      setAvatarDataUrl(result);
+    };
+    reader.readAsDataURL(file);
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim()) return;
+
+    const data = {
+      name: name.trim(),
+      description: description.trim(),
+      avatarDataUrl,
+      descriptionPosition,
+      descriptionDepth,
+      descriptionRole,
+      isDefault,
+    };
+
+    if (persona) {
+      updatePersona(persona.id, data);
+    } else {
+      createPersona(data);
+    }
+    onSaved?.();
+    onClose();
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="flex items-start gap-4">
+        <div className="w-20 h-20 rounded-full overflow-hidden bg-[var(--color-bg-tertiary)] flex items-center justify-center border-2 border-[var(--color-border)] flex-shrink-0">
+          {avatarDataUrl ? (
+            <img src={avatarDataUrl} alt="Persona avatar" className="w-full h-full object-cover" />
+          ) : (
+            <User size={36} className="text-[var(--color-text-secondary)]" />
+          )}
+        </div>
+        <div className="flex-1">
+          <ImageUpload
+            currentImage={avatarDataUrl}
+            onImageSelect={handleAvatarSelect}
+            label="Avatar (optional)"
+          />
+        </div>
+      </div>
+
+      <Input
+        label="Name *"
+        placeholder="e.g., Alex, Dungeon Master, Narrator"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        required
+        autoFocus
+      />
+
+      <TextArea
+        label="Description"
+        placeholder="Describe who you are when using this persona..."
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+        rows={4}
+      />
+
+      <div>
+        <label className="block text-sm font-medium text-[var(--color-text-secondary)] mb-1.5">
+          Description Position
+        </label>
+        <select
+          value={descriptionPosition}
+          onChange={(e) =>
+            setDescriptionPosition(e.target.value as PersonaDescriptionPosition)
+          }
+          className="w-full px-3 py-2 bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] rounded-lg text-[var(--color-text-primary)] text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]"
+        >
+          <option value="in_prompt">In system prompt</option>
+          <option value="before_char">Before character info</option>
+          <option value="after_char">After character info</option>
+          <option value="at_depth">At specific depth in chat</option>
+        </select>
+      </div>
+
+      {descriptionPosition === 'at_depth' && (
+        <div className="grid grid-cols-2 gap-2">
+          <div>
+            <label className="block text-xs font-medium text-[var(--color-text-secondary)] mb-1">
+              Injection Depth
+            </label>
+            <input
+              type="number"
+              min={0}
+              max={20}
+              value={descriptionDepth}
+              onChange={(e) => setDescriptionDepth(Number(e.target.value))}
+              className="w-full px-3 py-2 bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] rounded-lg text-[var(--color-text-primary)] text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]"
+            />
+          </div>
+          <div>
+            <label className="block text-xs font-medium text-[var(--color-text-secondary)] mb-1">
+              Role
+            </label>
+            <select
+              value={descriptionRole}
+              onChange={(e) =>
+                setDescriptionRole(e.target.value as PersonaDescriptionRole)
+              }
+              className="w-full px-3 py-2 bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] rounded-lg text-[var(--color-text-primary)] text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]"
+            >
+              <option value="system">System</option>
+              <option value="user">User</option>
+              <option value="assistant">Assistant</option>
+            </select>
+          </div>
+        </div>
+      )}
+
+      <label className="flex items-center gap-2 cursor-pointer text-sm text-[var(--color-text-primary)]">
+        <input
+          type="checkbox"
+          checked={isDefault}
+          onChange={(e) => setIsDefault(e.target.checked)}
+          className="w-4 h-4 accent-[var(--color-primary)]"
+        />
+        Set as default persona
+      </label>
+
+      <div className="flex gap-3 pt-4 border-t border-[var(--color-border)]">
+        <Button type="button" variant="secondary" onClick={onClose} className="flex-1">
+          Cancel
+        </Button>
+        <Button
+          type="submit"
+          variant="primary"
+          disabled={!name.trim()}
+          className="flex-1"
+        >
+          {persona ? 'Save Changes' : 'Create Persona'}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/persona/PersonaManager.tsx
+++ b/src/components/persona/PersonaManager.tsx
@@ -1,0 +1,213 @@
+import { useState } from 'react';
+import { Plus, Edit2, Trash2, Star, User, Check } from 'lucide-react';
+import { usePersonaStore, type Persona } from '../../stores/personaStore';
+import { Modal, Button, ConfirmDialog } from '../ui';
+import { PersonaForm } from './PersonaForm';
+
+interface PersonaManagerProps {
+  isOpen: boolean;
+  onClose: () => void;
+  initialPersona?: { name?: string; description?: string } | null;
+}
+
+export function PersonaManager({ isOpen, onClose, initialPersona }: PersonaManagerProps) {
+  const {
+    personas,
+    activePersonaId,
+    deletePersona,
+    setActivePersona,
+    setDefaultPersona,
+  } = usePersonaStore();
+
+  const [editingPersona, setEditingPersona] = useState<Persona | null>(null);
+  const [isCreating, setIsCreating] = useState(!!initialPersona);
+  const [confirmDelete, setConfirmDelete] = useState<Persona | null>(null);
+
+  const handleCreate = () => {
+    setEditingPersona(null);
+    setIsCreating(true);
+  };
+
+  const handleEdit = (persona: Persona) => {
+    setEditingPersona(persona);
+    setIsCreating(true);
+  };
+
+  const handleFormClose = () => {
+    setEditingPersona(null);
+    setIsCreating(false);
+  };
+
+  const handleDelete = (persona: Persona) => {
+    setConfirmDelete(persona);
+  };
+
+  const confirmDeleteAction = () => {
+    if (confirmDelete) {
+      deletePersona(confirmDelete.id);
+      setConfirmDelete(null);
+    }
+  };
+
+  const title = isCreating
+    ? editingPersona
+      ? `Edit ${editingPersona.name}`
+      : 'Create Persona'
+    : 'Personas';
+
+  return (
+    <>
+      <Modal isOpen={isOpen} onClose={onClose} title={title} size="lg">
+        {isCreating ? (
+          <PersonaForm
+            persona={editingPersona}
+            onClose={handleFormClose}
+            initialValues={!editingPersona ? initialPersona || undefined : undefined}
+          />
+        ) : (
+          <div className="space-y-3">
+            {personas.length === 0 ? (
+              <div className="text-center py-10">
+                <User
+                  size={48}
+                  className="mx-auto text-[var(--color-text-secondary)] mb-3"
+                />
+                <h3 className="text-sm font-medium text-[var(--color-text-primary)] mb-1">
+                  No personas yet
+                </h3>
+                <p className="text-xs text-[var(--color-text-secondary)] mb-4">
+                  Create a persona to define who you are in conversations.
+                </p>
+              </div>
+            ) : (
+              <ul className="space-y-2">
+                {personas.map((persona) => {
+                  const isActive = persona.id === activePersonaId;
+                  return (
+                    <li
+                      key={persona.id}
+                      className={`
+                        flex items-center gap-3 p-3 rounded-lg border transition-colors
+                        ${
+                          isActive
+                            ? 'bg-[var(--color-primary)]/10 border-[var(--color-primary)]'
+                            : 'bg-[var(--color-bg-tertiary)] border-[var(--color-border)]'
+                        }
+                      `}
+                    >
+                      {/* Avatar */}
+                      <div className="w-12 h-12 rounded-full overflow-hidden bg-[var(--color-bg-primary)] flex items-center justify-center flex-shrink-0">
+                        {persona.avatarDataUrl ? (
+                          <img
+                            src={persona.avatarDataUrl}
+                            alt={persona.name}
+                            className="w-full h-full object-cover"
+                          />
+                        ) : (
+                          <User
+                            size={24}
+                            className="text-[var(--color-text-secondary)]"
+                          />
+                        )}
+                      </div>
+
+                      {/* Info */}
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2">
+                          <p className="text-sm font-medium text-[var(--color-text-primary)] truncate">
+                            {persona.name}
+                          </p>
+                          {persona.isDefault && (
+                            <span className="text-[10px] px-1.5 py-0.5 rounded bg-[var(--color-primary)]/20 text-[var(--color-primary)] font-medium">
+                              DEFAULT
+                            </span>
+                          )}
+                          {isActive && (
+                            <span className="text-[10px] px-1.5 py-0.5 rounded bg-green-500/20 text-green-400 font-medium">
+                              ACTIVE
+                            </span>
+                          )}
+                        </div>
+                        {persona.description && (
+                          <p className="text-xs text-[var(--color-text-secondary)] truncate mt-0.5">
+                            {persona.description}
+                          </p>
+                        )}
+                      </div>
+
+                      {/* Actions */}
+                      <div className="flex items-center gap-1 flex-shrink-0">
+                        {!isActive && (
+                          <button
+                            onClick={() => setActivePersona(persona.id)}
+                            className="p-2 rounded-lg text-[var(--color-text-secondary)] hover:text-[var(--color-primary)] hover:bg-[var(--color-primary)]/10"
+                            title="Set as active persona"
+                          >
+                            <Check size={16} />
+                          </button>
+                        )}
+                        <button
+                          onClick={() =>
+                            setDefaultPersona(persona.isDefault ? null : persona.id)
+                          }
+                          className={`p-2 rounded-lg hover:bg-[var(--color-bg-secondary)] ${
+                            persona.isDefault
+                              ? 'text-yellow-400'
+                              : 'text-[var(--color-text-secondary)] hover:text-yellow-400'
+                          }`}
+                          title={
+                            persona.isDefault ? 'Unset as default' : 'Set as default'
+                          }
+                        >
+                          <Star
+                            size={16}
+                            fill={persona.isDefault ? 'currentColor' : 'none'}
+                          />
+                        </button>
+                        <button
+                          onClick={() => handleEdit(persona)}
+                          className="p-2 rounded-lg text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-secondary)]"
+                          title="Edit persona"
+                        >
+                          <Edit2 size={16} />
+                        </button>
+                        <button
+                          onClick={() => handleDelete(persona)}
+                          className="p-2 rounded-lg text-[var(--color-text-secondary)] hover:text-red-400 hover:bg-red-500/10"
+                          title="Delete persona"
+                        >
+                          <Trash2 size={16} />
+                        </button>
+                      </div>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+
+            <Button
+              variant="primary"
+              onClick={handleCreate}
+              className="w-full"
+            >
+              <Plus size={18} className="mr-2" />
+              New Persona
+            </Button>
+          </div>
+        )}
+      </Modal>
+
+      {confirmDelete && (
+        <ConfirmDialog
+          isOpen={!!confirmDelete}
+          onClose={() => setConfirmDelete(null)}
+          onConfirm={confirmDeleteAction}
+          title="Delete Persona"
+          message={`Delete persona "${confirmDelete.name}"? This cannot be undone.`}
+          confirmLabel="Delete"
+          danger
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/persona/PersonaSelector.tsx
+++ b/src/components/persona/PersonaSelector.tsx
@@ -1,0 +1,143 @@
+import { useState, useRef, useEffect } from 'react';
+import { User, ChevronDown, Check, Plus, Settings } from 'lucide-react';
+import { usePersonaStore } from '../../stores/personaStore';
+import { PersonaManager } from './PersonaManager';
+
+interface PersonaSelectorProps {
+  className?: string;
+}
+
+export function PersonaSelector({ className = '' }: PersonaSelectorProps) {
+  const { personas, activePersonaId, setActivePersona, getActivePersona } =
+    usePersonaStore();
+  const [isOpen, setIsOpen] = useState(false);
+  const [showManager, setShowManager] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const activePersona = getActivePersona();
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    if (isOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+    }
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [isOpen]);
+
+  const handleManage = () => {
+    setIsOpen(false);
+    setShowManager(true);
+  };
+
+  const handleSelect = (id: string) => {
+    setActivePersona(id);
+    setIsOpen(false);
+  };
+
+  return (
+    <>
+      <div ref={dropdownRef} className={`relative ${className}`}>
+        <button
+          onClick={() => setIsOpen(!isOpen)}
+          className="flex items-center gap-2 px-2 py-1.5 rounded-lg hover:bg-[var(--color-bg-tertiary)] transition-colors"
+          aria-label="Persona selector"
+          title={activePersona ? `Persona: ${activePersona.name}` : 'Select persona'}
+        >
+          <div className="w-7 h-7 rounded-full overflow-hidden bg-[var(--color-bg-tertiary)] flex items-center justify-center flex-shrink-0">
+            {activePersona?.avatarDataUrl ? (
+              <img
+                src={activePersona.avatarDataUrl}
+                alt={activePersona.name}
+                className="w-full h-full object-cover"
+              />
+            ) : (
+              <User size={16} className="text-[var(--color-text-secondary)]" />
+            )}
+          </div>
+          <ChevronDown size={14} className="text-[var(--color-text-secondary)]" />
+        </button>
+
+        {isOpen && (
+          <div className="absolute right-0 top-full mt-1 min-w-[240px] bg-[var(--color-bg-secondary)] border border-[var(--color-border)] rounded-lg shadow-xl overflow-hidden z-50">
+            <div className="px-3 py-2 text-xs font-medium text-[var(--color-text-secondary)] border-b border-[var(--color-border)]">
+              Persona
+            </div>
+            {personas.length === 0 ? (
+              <div className="px-3 py-4 text-center">
+                <p className="text-xs text-[var(--color-text-secondary)] mb-2">
+                  No personas yet
+                </p>
+                <button
+                  onClick={handleManage}
+                  className="text-xs text-[var(--color-primary)] hover:underline"
+                >
+                  Create your first persona
+                </button>
+              </div>
+            ) : (
+              <ul className="max-h-[300px] overflow-y-auto">
+                {personas.map((persona) => {
+                  const isActive = persona.id === activePersonaId;
+                  return (
+                    <li key={persona.id}>
+                      <button
+                        onClick={() => handleSelect(persona.id)}
+                        className={`w-full flex items-center gap-3 px-3 py-2 text-left hover:bg-[var(--color-bg-tertiary)] ${
+                          isActive ? 'bg-[var(--color-primary)]/10' : ''
+                        }`}
+                      >
+                        <div className="w-8 h-8 rounded-full overflow-hidden bg-[var(--color-bg-tertiary)] flex items-center justify-center flex-shrink-0">
+                          {persona.avatarDataUrl ? (
+                            <img
+                              src={persona.avatarDataUrl}
+                              alt={persona.name}
+                              className="w-full h-full object-cover"
+                            />
+                          ) : (
+                            <User
+                              size={16}
+                              className="text-[var(--color-text-secondary)]"
+                            />
+                          )}
+                        </div>
+                        <span className="flex-1 text-sm text-[var(--color-text-primary)] truncate">
+                          {persona.name}
+                        </span>
+                        {isActive && (
+                          <Check size={16} className="text-[var(--color-primary)]" />
+                        )}
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+
+            <div className="border-t border-[var(--color-border)]">
+              <button
+                onClick={handleManage}
+                className="w-full flex items-center gap-2 px-3 py-2 text-xs text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-tertiary)]"
+              >
+                <Plus size={14} />
+                New Persona
+              </button>
+              <button
+                onClick={handleManage}
+                className="w-full flex items-center gap-2 px-3 py-2 text-xs text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-tertiary)] border-t border-[var(--color-border)]"
+              >
+                <Settings size={14} />
+                Manage Personas
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      <PersonaManager isOpen={showManager} onClose={() => setShowManager(false)} />
+    </>
+  );
+}

--- a/src/components/persona/index.ts
+++ b/src/components/persona/index.ts
@@ -1,0 +1,3 @@
+export { PersonaManager } from './PersonaManager';
+export { PersonaSelector } from './PersonaSelector';
+export { PersonaForm } from './PersonaForm';

--- a/src/stores/characterStore.ts
+++ b/src/stores/characterStore.ts
@@ -12,6 +12,25 @@ import {
   type CharacterExportData,
 } from '../utils/characterCard';
 
+const FAVORITES_KEY = 'sillytavern_character_favorites';
+
+function loadFavorites(): Set<string> {
+  try {
+    const raw = localStorage.getItem(FAVORITES_KEY);
+    if (!raw) return new Set();
+    const arr: string[] = JSON.parse(raw);
+    return new Set(arr);
+  } catch {
+    return new Set();
+  }
+}
+
+function saveFavorites(favorites: Set<string>) {
+  localStorage.setItem(FAVORITES_KEY, JSON.stringify(Array.from(favorites)));
+}
+
+export type CharacterSortMode = 'name' | 'date_added' | 'date_last_chat' | 'recent_chat';
+
 interface CharacterState {
   characters: CharacterInfo[];
   selectedCharacter: CharacterInfo | null;
@@ -23,7 +42,14 @@ interface CharacterState {
   isEditing: boolean;
   isImporting: boolean;
   isExporting: boolean;
+  isDuplicating: boolean;
   error: string | null;
+  // Organization state
+  favorites: Set<string>;
+  searchQuery: string;
+  selectedTags: Set<string>;
+  showFavoritesOnly: boolean;
+  sortMode: CharacterSortMode;
 
   // Actions
   fetchCharacters: () => Promise<void>;
@@ -31,6 +57,7 @@ interface CharacterState {
   createCharacter: (data: CharacterCreateData, avatarFile?: File) => Promise<string | null>;
   updateCharacter: (data: CharacterEditData, avatarFile?: File) => Promise<boolean>;
   deleteCharacter: (avatar: string) => Promise<boolean>;
+  duplicateCharacter: (avatar: string) => Promise<string | null>;
   clearSelection: () => void;
   clearError: () => void;
   // Group chat actions
@@ -43,6 +70,16 @@ interface CharacterState {
   importCharacter: (file: File) => Promise<{ data: Partial<CharacterInfo>; avatarFile?: File } | null>;
   exportCharacterAsPNG: (character: CharacterInfo) => Promise<void>;
   exportCharacterAsJSON: (character: CharacterInfo) => void;
+  // Organization actions
+  toggleFavorite: (avatar: string) => void;
+  isFavorite: (avatar: string) => boolean;
+  setSearchQuery: (q: string) => void;
+  toggleTagFilter: (tag: string) => void;
+  clearTagFilters: () => void;
+  setShowFavoritesOnly: (show: boolean) => void;
+  setSortMode: (mode: CharacterSortMode) => void;
+  getAllTags: () => string[];
+  getFilteredCharacters: () => CharacterInfo[];
 }
 
 export const useCharacterStore = create<CharacterState>((set, get) => ({
@@ -55,7 +92,13 @@ export const useCharacterStore = create<CharacterState>((set, get) => ({
   isEditing: false,
   isImporting: false,
   isExporting: false,
+  isDuplicating: false,
   error: null,
+  favorites: loadFavorites(),
+  searchQuery: '',
+  selectedTags: new Set<string>(),
+  showFavoritesOnly: false,
+  sortMode: 'name' as CharacterSortMode,
 
   fetchCharacters: async () => {
     set({ isLoading: true, error: null });
@@ -150,9 +193,16 @@ export const useCharacterStore = create<CharacterState>((set, get) => ({
     try {
       await api.deleteCharacter(avatar);
       // Clear selection if deleting the selected character
-      const { selectedCharacter } = get();
+      const { selectedCharacter, favorites } = get();
       if (selectedCharacter?.avatar === avatar) {
         set({ selectedCharacter: null });
+      }
+      // Also remove from favorites
+      if (favorites.has(avatar)) {
+        const newFavorites = new Set(favorites);
+        newFavorites.delete(avatar);
+        saveFavorites(newFavorites);
+        set({ favorites: newFavorites });
       }
       // Refresh the character list
       await get().fetchCharacters();
@@ -166,7 +216,143 @@ export const useCharacterStore = create<CharacterState>((set, get) => ({
     }
   },
 
+  duplicateCharacter: async (avatar: string) => {
+    set({ isDuplicating: true, error: null });
+    try {
+      const newAvatar = await api.duplicateCharacter(avatar);
+      // Refresh list to show the new character
+      await get().fetchCharacters();
+      set({ isDuplicating: false });
+      return newAvatar;
+    } catch (error) {
+      set({
+        isDuplicating: false,
+        error: error instanceof Error ? error.message : 'Failed to duplicate character',
+      });
+      return null;
+    }
+  },
+
   clearError: () => set({ error: null }),
+
+  // ---- Organization actions ----
+  toggleFavorite: (avatar: string) => {
+    const { favorites } = get();
+    const newFavorites = new Set(favorites);
+    if (newFavorites.has(avatar)) {
+      newFavorites.delete(avatar);
+    } else {
+      newFavorites.add(avatar);
+    }
+    saveFavorites(newFavorites);
+    set({ favorites: newFavorites });
+  },
+
+  isFavorite: (avatar: string) => get().favorites.has(avatar),
+
+  setSearchQuery: (q: string) => set({ searchQuery: q }),
+
+  toggleTagFilter: (tag: string) => {
+    const { selectedTags } = get();
+    const newTags = new Set(selectedTags);
+    if (newTags.has(tag)) {
+      newTags.delete(tag);
+    } else {
+      newTags.add(tag);
+    }
+    set({ selectedTags: newTags });
+  },
+
+  clearTagFilters: () => set({ selectedTags: new Set<string>() }),
+
+  setShowFavoritesOnly: (show: boolean) => set({ showFavoritesOnly: show }),
+
+  setSortMode: (mode: CharacterSortMode) => set({ sortMode: mode }),
+
+  getAllTags: () => {
+    const { characters } = get();
+    const tagSet = new Set<string>();
+    for (const char of characters) {
+      const tags = char.tags || char.data?.tags || [];
+      for (const tag of tags) {
+        if (tag && typeof tag === 'string') {
+          tagSet.add(tag);
+        }
+      }
+    }
+    return Array.from(tagSet).sort((a, b) => a.localeCompare(b));
+  },
+
+  getFilteredCharacters: () => {
+    const {
+      characters,
+      searchQuery,
+      selectedTags,
+      showFavoritesOnly,
+      favorites,
+      sortMode,
+    } = get();
+
+    const query = searchQuery.trim().toLowerCase();
+
+    const filtered = characters.filter((char) => {
+      // Favorites filter
+      if (showFavoritesOnly && !favorites.has(char.avatar)) {
+        return false;
+      }
+
+      // Tag filter (AND logic: must match all selected tags)
+      if (selectedTags.size > 0) {
+        const charTags = (char.tags || char.data?.tags || []).map((t) => t.toLowerCase());
+        for (const tag of selectedTags) {
+          if (!charTags.includes(tag.toLowerCase())) {
+            return false;
+          }
+        }
+      }
+
+      // Search filter
+      if (query) {
+        const name = (char.name || '').toLowerCase();
+        const desc = (char.description || char.data?.description || '').toLowerCase();
+        const personality = (char.personality || char.data?.personality || '').toLowerCase();
+        const creator = (char.creator || char.data?.creator || '').toLowerCase();
+        if (
+          !name.includes(query) &&
+          !desc.includes(query) &&
+          !personality.includes(query) &&
+          !creator.includes(query)
+        ) {
+          return false;
+        }
+      }
+
+      return true;
+    });
+
+    // Sort
+    const sorted = [...filtered].sort((a, b) => {
+      // Favorites always bubble to the top
+      const aFav = favorites.has(a.avatar);
+      const bFav = favorites.has(b.avatar);
+      if (aFav && !bFav) return -1;
+      if (!aFav && bFav) return 1;
+
+      switch (sortMode) {
+        case 'name':
+          return (a.name || '').localeCompare(b.name || '');
+        case 'date_added':
+          return (b.date_added || 0) - (a.date_added || 0);
+        case 'date_last_chat':
+        case 'recent_chat':
+          return (b.date_last_chat || 0) - (a.date_last_chat || 0);
+        default:
+          return 0;
+      }
+    });
+
+    return sorted;
+  },
 
   // Group chat actions
   toggleGroupChatCharacter: async (avatar: string) => {

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { api, type CharacterInfo } from '../api/client';
 import { useSettingsStore } from './settingsStore';
+import { usePersonaStore } from './personaStore';
 import { parseEmotion, stripEmotionTag, type Emotion } from '../utils/emotions';
 
 export interface ChatMessage {
@@ -155,6 +156,50 @@ async function* parseSSEStream(
   }
 }
 
+// Resolve advanced character fields (checks both top-level and data.*)
+function getCharacterField(character: CharacterInfo, field: string): string {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const top = (character as any)[field];
+  if (typeof top === 'string' && top.trim()) return top;
+  const data = character.data as Record<string, unknown> | undefined;
+  const nested = data?.[field];
+  if (typeof nested === 'string' && nested.trim()) return nested;
+  return '';
+}
+
+function getAlternateGreetings(character: CharacterInfo): string[] {
+  return (
+    character.alternate_greetings || character.data?.alternate_greetings || []
+  ).filter((g) => g && g.trim());
+}
+
+function getDepthPrompt(character: CharacterInfo): {
+  prompt: string;
+  depth: number;
+  role: 'system' | 'user' | 'assistant';
+} | null {
+  const dp = character.data?.extensions?.depth_prompt;
+  if (!dp || !dp.prompt?.trim()) return null;
+  return {
+    prompt: dp.prompt,
+    depth: dp.depth ?? 4,
+    role: (dp.role as 'system' | 'user' | 'assistant') || 'system',
+  };
+}
+
+// Simple macro substitution: {{char}}, {{user}}, {{persona}}
+function substituteMacros(
+  text: string,
+  character: CharacterInfo,
+  personaName: string,
+  personaDescription: string
+): string {
+  return text
+    .replace(/\{\{char\}\}/gi, character.name || '')
+    .replace(/\{\{user\}\}/gi, personaName || 'User')
+    .replace(/\{\{persona\}\}/gi, personaDescription || '');
+}
+
 // Build conversation context for AI
 function buildConversationContext(
   messages: ChatMessage[],
@@ -163,13 +208,24 @@ function buildConversationContext(
 ): { role: 'user' | 'assistant' | 'system'; content: string }[] {
   const context: { role: 'user' | 'assistant' | 'system'; content: string }[] = [];
 
-  const systemPrompt = [
-    character.description && `Description: ${character.description}`,
-    character.personality && `Personality: ${character.personality}`,
-    character.scenario && `Scenario: ${character.scenario}`,
-  ]
-    .filter(Boolean)
-    .join('\n\n');
+  // Get active persona for this character/chat
+  const persona = usePersonaStore
+    .getState()
+    .getPersonaForContext(character.avatar);
+  const personaName = persona?.name || 'You';
+  const personaDescription = persona?.description || '';
+
+  const sub = (text: string) =>
+    substituteMacros(text, character, personaName, personaDescription);
+
+  const description = sub(getCharacterField(character, 'description'));
+  const personality = sub(getCharacterField(character, 'personality'));
+  const scenario = sub(getCharacterField(character, 'scenario'));
+  const mesExample = sub(getCharacterField(character, 'mes_example'));
+  const systemPromptOverride = sub(getCharacterField(character, 'system_prompt'));
+  const postHistoryInstructions = sub(
+    getCharacterField(character, 'post_history_instructions')
+  );
 
   const emotionList = availableEmotions && availableEmotions.length > 0
     ? availableEmotions.join(', ')
@@ -184,25 +240,123 @@ Example: [emotion:joy] I'm so glad you asked about that!
 
 Choose the emotion that best matches how ${character.name} would feel based on the conversation context.`.trim();
 
-  if (systemPrompt) {
-    context.push({
-      role: 'system',
-      content: `You are ${character.name}. Stay in character.\n\n${systemPrompt}\n\n${emotionInstruction}`,
-    });
-  } else {
-    context.push({
-      role: 'system',
-      content: `You are ${character.name}. Stay in character.\n\n${emotionInstruction}`,
+  // Build character info block
+  const charInfoParts = [
+    description && `Description: ${description}`,
+    personality && `Personality: ${personality}`,
+    scenario && `Scenario: ${scenario}`,
+    mesExample && `Example dialogue:\n${mesExample}`,
+  ].filter(Boolean);
+
+  const charInfoBlock = charInfoParts.join('\n\n');
+
+  // Main system prompt: either override or default
+  const mainPrompt =
+    systemPromptOverride ||
+    `You are ${character.name}. Stay in character.`;
+
+  // Persona description injection
+  let personaBlock = '';
+  if (persona && personaDescription.trim()) {
+    const position = persona.descriptionPosition;
+    if (position === 'in_prompt' || position === 'before_char') {
+      personaBlock = `[The user you're talking to is ${personaName}. ${personaDescription}]`;
+    } else if (position === 'after_char') {
+      // handled later
+    }
+  }
+
+  // Assemble system prompt parts in order
+  const systemParts: string[] = [mainPrompt];
+  if (persona && persona.descriptionPosition === 'before_char' && personaBlock) {
+    systemParts.push(personaBlock);
+  }
+  if (charInfoBlock) {
+    systemParts.push(charInfoBlock);
+  }
+  if (persona && persona.descriptionPosition === 'after_char' && personaDescription) {
+    systemParts.push(`[The user you're talking to is ${personaName}. ${personaDescription}]`);
+  }
+  if (persona && persona.descriptionPosition === 'in_prompt' && personaDescription) {
+    // Only add it once; if not added as before_char
+    // Already added as before_char, so only add if not already
+  }
+  systemParts.push(emotionInstruction);
+
+  context.push({
+    role: 'system',
+    content: systemParts.filter(Boolean).join('\n\n'),
+  });
+
+  const recentMessages = messages.slice(-20).filter((m) => !m.isSystem);
+
+  // Character's Note (depth prompt): inject at configurable depth from the END of the history
+  const depthPrompt = getDepthPrompt(character);
+  const depthPromptContent = depthPrompt ? sub(depthPrompt.prompt) : '';
+
+  // Persona @ depth
+  const personaAtDepth =
+    persona && persona.descriptionPosition === 'at_depth' && personaDescription
+      ? {
+          depth: persona.descriptionDepth,
+          role: persona.descriptionRole,
+          content: `[The user you're talking to is ${personaName}. ${personaDescription}]`,
+        }
+      : null;
+
+  // Build a list of history messages with depth-based insertions
+  const historyWithInsertions: {
+    role: 'user' | 'assistant' | 'system';
+    content: string;
+  }[] = [];
+
+  for (let i = 0; i < recentMessages.length; i++) {
+    const msg = recentMessages[i];
+    const depthFromEnd = recentMessages.length - i;
+
+    // Insert depth-prompt items BEFORE this message if depth matches
+    if (depthPrompt && depthFromEnd === depthPrompt.depth && depthPromptContent) {
+      historyWithInsertions.push({
+        role: depthPrompt.role,
+        content: depthPromptContent,
+      });
+    }
+    if (personaAtDepth && depthFromEnd === personaAtDepth.depth) {
+      historyWithInsertions.push({
+        role: personaAtDepth.role,
+        content: personaAtDepth.content,
+      });
+    }
+
+    historyWithInsertions.push({
+      role: msg.isUser ? 'user' : 'assistant',
+      content: sub(msg.content),
     });
   }
 
-  const recentMessages = messages.slice(-20);
-  for (const msg of recentMessages) {
-    if (msg.isSystem) continue;
-    context.push({
-      role: msg.isUser ? 'user' : 'assistant',
-      content: msg.content,
+  // If depth exceeds history length, prepend to entire history
+  if (
+    depthPrompt &&
+    depthPromptContent &&
+    depthPrompt.depth > recentMessages.length
+  ) {
+    historyWithInsertions.unshift({
+      role: depthPrompt.role,
+      content: depthPromptContent,
     });
+  }
+  if (personaAtDepth && personaAtDepth.depth > recentMessages.length) {
+    historyWithInsertions.unshift({
+      role: personaAtDepth.role,
+      content: personaAtDepth.content,
+    });
+  }
+
+  context.push(...historyWithInsertions);
+
+  // Post-history instructions as a final system message
+  if (postHistoryInstructions) {
+    context.push({ role: 'system', content: postHistoryInstructions });
   }
 
   return context;
@@ -407,18 +561,43 @@ export const useChatStore = create<ChatState>((set, get) => ({
     }
   },
 
+  loadGroupChat: async (groupChat: GroupChatInfo) => {
+    set({ isLoading: true, error: null, currentChatFile: groupChat.fileName });
+    try {
+      // Use the first character's avatar to fetch the chat file
+      const avatarUrl = groupChat.characterAvatars[0];
+      const rawMessages = await api.getChatMessages(avatarUrl, groupChat.fileName);
+      const messages = rawMessages.map(normalizeMessage);
+      set({ messages, isLoading: false });
+    } catch (error) {
+      set({
+        isLoading: false,
+        error: error instanceof Error ? error.message : 'Failed to load group chat',
+      });
+    }
+  },
+
   startNewChat: async (character: CharacterInfo) => {
     const messages: ChatMessage[] = [];
 
-    if (character.first_mes) {
-      messages.push(createMessage({
+    const firstMes = character.first_mes || character.data?.first_mes || '';
+    const altGreetings = getAlternateGreetings(character);
+
+    if (firstMes || altGreetings.length > 0) {
+      // Build swipes array: primary greeting + alternate greetings
+      const swipes = [firstMes, ...altGreetings].filter(Boolean);
+      const firstMessage = createMessage({
         name: character.name,
         isUser: false,
         isSystem: false,
-        content: character.first_mes,
+        content: swipes[0] || '',
         timestamp: Date.now(),
         characterAvatar: character.avatar,
-      }));
+      });
+      // Override the swipes to include all greetings
+      firstMessage.swipes = swipes;
+      firstMessage.swipeId = 0;
+      messages.push(firstMessage);
     }
 
     const fileName = await api.createChat(character.name);
@@ -437,15 +616,21 @@ export const useChatStore = create<ChatState>((set, get) => ({
     }));
 
     for (const character of characters) {
-      if (character.first_mes) {
-        messages.push(createMessage({
+      const firstMes = character.first_mes || character.data?.first_mes || '';
+      const altGreetings = getAlternateGreetings(character);
+      if (firstMes || altGreetings.length > 0) {
+        const swipes = [firstMes, ...altGreetings].filter(Boolean);
+        const message = createMessage({
           name: character.name,
           isUser: false,
           isSystem: false,
-          content: character.first_mes,
+          content: swipes[0] || '',
           timestamp: Date.now() + characters.indexOf(character),
           characterAvatar: character.avatar,
-        }));
+        });
+        message.swipes = swipes;
+        message.swipeId = 0;
+        messages.push(message);
       }
     }
 

--- a/src/stores/personaStore.ts
+++ b/src/stores/personaStore.ts
@@ -1,0 +1,308 @@
+import { create } from 'zustand';
+
+// Where the persona description is injected in the prompt
+export type PersonaDescriptionPosition =
+  | 'in_prompt' // Included inline in the system prompt
+  | 'before_char' // Inserted before character info
+  | 'after_char' // Inserted after character info
+  | 'at_depth'; // Inserted at a specific depth in the message history
+
+export type PersonaDescriptionRole = 'system' | 'user' | 'assistant';
+
+export interface Persona {
+  id: string;
+  name: string;
+  description: string;
+  avatarDataUrl?: string; // base64-encoded data URL stored locally
+  descriptionPosition: PersonaDescriptionPosition;
+  descriptionDepth: number; // only used when position = 'at_depth'
+  descriptionRole: PersonaDescriptionRole;
+  isDefault?: boolean;
+  createdAt: number;
+  updatedAt: number;
+}
+
+// Locks persona to a specific character (by avatar) or chat (by chat file name)
+export interface PersonaLocks {
+  byCharacter: Record<string, string>; // characterAvatar -> personaId
+  byChat: Record<string, string>; // chatFileName -> personaId
+}
+
+const PERSONAS_KEY = 'sillytavern_personas_v2';
+const ACTIVE_PERSONA_KEY = 'sillytavern_active_persona';
+const PERSONA_LOCKS_KEY = 'sillytavern_persona_locks';
+
+function loadPersonas(): Persona[] {
+  try {
+    const raw = localStorage.getItem(PERSONAS_KEY);
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+}
+
+function savePersonas(personas: Persona[]) {
+  localStorage.setItem(PERSONAS_KEY, JSON.stringify(personas));
+}
+
+function loadActivePersonaId(): string | null {
+  try {
+    return localStorage.getItem(ACTIVE_PERSONA_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function saveActivePersonaId(id: string | null) {
+  if (id) localStorage.setItem(ACTIVE_PERSONA_KEY, id);
+  else localStorage.removeItem(ACTIVE_PERSONA_KEY);
+}
+
+function loadLocks(): PersonaLocks {
+  try {
+    const raw = localStorage.getItem(PERSONA_LOCKS_KEY);
+    if (!raw) return { byCharacter: {}, byChat: {} };
+    const parsed = JSON.parse(raw);
+    return {
+      byCharacter: parsed.byCharacter || {},
+      byChat: parsed.byChat || {},
+    };
+  } catch {
+    return { byCharacter: {}, byChat: {} };
+  }
+}
+
+function saveLocks(locks: PersonaLocks) {
+  localStorage.setItem(PERSONA_LOCKS_KEY, JSON.stringify(locks));
+}
+
+function generatePersonaId(): string {
+  return `persona_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+interface PersonaState {
+  personas: Persona[];
+  activePersonaId: string | null;
+  locks: PersonaLocks;
+  error: string | null;
+
+  // Queries
+  getActivePersona: () => Persona | null;
+  getPersonaForContext: (characterAvatar?: string, chatFileName?: string) => Persona | null;
+
+  // CRUD
+  createPersona: (
+    data: Omit<Persona, 'id' | 'createdAt' | 'updatedAt'>
+  ) => Persona;
+  updatePersona: (
+    id: string,
+    data: Partial<Omit<Persona, 'id' | 'createdAt'>>
+  ) => void;
+  deletePersona: (id: string) => void;
+  setActivePersona: (id: string | null) => void;
+  setDefaultPersona: (id: string | null) => void;
+
+  // Locking
+  lockPersonaToCharacter: (personaId: string, characterAvatar: string) => void;
+  unlockCharacter: (characterAvatar: string) => void;
+  lockPersonaToChat: (personaId: string, chatFileName: string) => void;
+  unlockChat: (chatFileName: string) => void;
+  getCharacterLock: (characterAvatar: string) => string | null;
+  getChatLock: (chatFileName: string) => string | null;
+
+  clearError: () => void;
+}
+
+export const usePersonaStore = create<PersonaState>((set, get) => {
+  const initialPersonas = loadPersonas();
+  const initialActiveId = loadActivePersonaId();
+  const initialLocks = loadLocks();
+
+  // If there's a default persona and no active, set it as active
+  let resolvedActiveId = initialActiveId;
+  if (!resolvedActiveId) {
+    const defaultPersona = initialPersonas.find((p) => p.isDefault);
+    if (defaultPersona) {
+      resolvedActiveId = defaultPersona.id;
+    }
+  }
+
+  return {
+    personas: initialPersonas,
+    activePersonaId: resolvedActiveId,
+    locks: initialLocks,
+    error: null,
+
+    getActivePersona: () => {
+      const { personas, activePersonaId } = get();
+      return personas.find((p) => p.id === activePersonaId) || null;
+    },
+
+    getPersonaForContext: (characterAvatar, chatFileName) => {
+      const { personas, locks, activePersonaId } = get();
+
+      // Chat lock wins over character lock
+      if (chatFileName && locks.byChat[chatFileName]) {
+        const locked = personas.find((p) => p.id === locks.byChat[chatFileName]);
+        if (locked) return locked;
+      }
+      if (characterAvatar && locks.byCharacter[characterAvatar]) {
+        const locked = personas.find((p) => p.id === locks.byCharacter[characterAvatar]);
+        if (locked) return locked;
+      }
+
+      // Fall back to active persona
+      return personas.find((p) => p.id === activePersonaId) || null;
+    },
+
+    createPersona: (data) => {
+      const now = Date.now();
+      const persona: Persona = {
+        ...data,
+        id: generatePersonaId(),
+        createdAt: now,
+        updatedAt: now,
+      };
+
+      const { personas } = get();
+
+      // If isDefault, clear other defaults
+      const updatedPersonas: Persona[] = persona.isDefault
+        ? [...personas.map((p) => ({ ...p, isDefault: false })), persona]
+        : [...personas, persona];
+
+      savePersonas(updatedPersonas);
+      set({ personas: updatedPersonas });
+
+      // If this is the first persona, make it active
+      if (personas.length === 0 || persona.isDefault) {
+        saveActivePersonaId(persona.id);
+        set({ activePersonaId: persona.id });
+      }
+
+      return persona;
+    },
+
+    updatePersona: (id, data) => {
+      const { personas, activePersonaId } = get();
+      const exists = personas.some((p) => p.id === id);
+      if (!exists) {
+        set({ error: 'Persona not found' });
+        return;
+      }
+
+      let updatedPersonas = personas.map((p) =>
+        p.id === id ? { ...p, ...data, updatedAt: Date.now() } : p
+      );
+
+      // If setting isDefault = true, clear other defaults
+      if (data.isDefault === true) {
+        updatedPersonas = updatedPersonas.map((p) =>
+          p.id === id ? p : { ...p, isDefault: false }
+        );
+      }
+
+      savePersonas(updatedPersonas);
+      set({ personas: updatedPersonas });
+
+      // If active persona was deleted or is no longer valid, choose a new active
+      if (activePersonaId === id && data.isDefault === false) {
+        // If we unset the default, keep active the same
+      }
+    },
+
+    deletePersona: (id) => {
+      const { personas, activePersonaId, locks } = get();
+      const updatedPersonas = personas.filter((p) => p.id !== id);
+      savePersonas(updatedPersonas);
+
+      // Remove any locks that point to this persona
+      const cleanedLocks: PersonaLocks = {
+        byCharacter: Object.fromEntries(
+          Object.entries(locks.byCharacter).filter(([, v]) => v !== id)
+        ),
+        byChat: Object.fromEntries(
+          Object.entries(locks.byChat).filter(([, v]) => v !== id)
+        ),
+      };
+      saveLocks(cleanedLocks);
+
+      let newActiveId = activePersonaId;
+      if (activePersonaId === id) {
+        // Fall back to default or first remaining persona
+        const defaultPersona = updatedPersonas.find((p) => p.isDefault);
+        newActiveId = defaultPersona?.id || updatedPersonas[0]?.id || null;
+        saveActivePersonaId(newActiveId);
+      }
+
+      set({
+        personas: updatedPersonas,
+        locks: cleanedLocks,
+        activePersonaId: newActiveId,
+      });
+    },
+
+    setActivePersona: (id) => {
+      saveActivePersonaId(id);
+      set({ activePersonaId: id });
+    },
+
+    setDefaultPersona: (id) => {
+      const { personas } = get();
+      const updatedPersonas = personas.map((p) => ({
+        ...p,
+        isDefault: p.id === id,
+      }));
+      savePersonas(updatedPersonas);
+      set({ personas: updatedPersonas });
+    },
+
+    lockPersonaToCharacter: (personaId, characterAvatar) => {
+      const { locks } = get();
+      const updated: PersonaLocks = {
+        ...locks,
+        byCharacter: { ...locks.byCharacter, [characterAvatar]: personaId },
+      };
+      saveLocks(updated);
+      set({ locks: updated });
+    },
+
+    unlockCharacter: (characterAvatar) => {
+      const { locks } = get();
+      const newByCharacter = { ...locks.byCharacter };
+      delete newByCharacter[characterAvatar];
+      const updated: PersonaLocks = { ...locks, byCharacter: newByCharacter };
+      saveLocks(updated);
+      set({ locks: updated });
+    },
+
+    lockPersonaToChat: (personaId, chatFileName) => {
+      const { locks } = get();
+      const updated: PersonaLocks = {
+        ...locks,
+        byChat: { ...locks.byChat, [chatFileName]: personaId },
+      };
+      saveLocks(updated);
+      set({ locks: updated });
+    },
+
+    unlockChat: (chatFileName) => {
+      const { locks } = get();
+      const newByChat = { ...locks.byChat };
+      delete newByChat[chatFileName];
+      const updated: PersonaLocks = { ...locks, byChat: newByChat };
+      saveLocks(updated);
+      set({ locks: updated });
+    },
+
+    getCharacterLock: (characterAvatar) => {
+      return get().locks.byCharacter[characterAvatar] || null;
+    },
+
+    getChatLock: (chatFileName) => {
+      return get().locks.byChat[chatFileName] || null;
+    },
+
+    clearError: () => set({ error: null }),
+  };
+});

--- a/src/utils/characterCard.ts
+++ b/src/utils/characterCard.ts
@@ -17,11 +17,21 @@ export interface CharacterCardV2 {
     creator_notes: string;
     creator: string;
     tags: string[];
+    character_version?: string;
     system_prompt?: string;
     post_history_instructions?: string;
     alternate_greetings?: string[];
     character_book?: unknown;
-    extensions?: Record<string, unknown>;
+    extensions?: {
+      depth_prompt?: {
+        prompt?: string;
+        depth?: number;
+        role?: string;
+      };
+      talkativeness?: string;
+      fav?: boolean;
+      [key: string]: unknown;
+    };
   };
 }
 
@@ -36,6 +46,16 @@ export interface CharacterExportData {
   creator_notes: string;
   creator: string;
   tags: string[];
+  character_version?: string;
+  system_prompt?: string;
+  post_history_instructions?: string;
+  alternate_greetings?: string[];
+  depth_prompt?: {
+    prompt?: string;
+    depth?: number;
+    role?: string;
+  };
+  talkativeness?: string;
   avatar_base64?: string;
 }
 
@@ -43,6 +63,22 @@ export interface CharacterExportData {
  * Convert CharacterInfo to Character Card V2 format
  */
 export function characterToCardV2(character: CharacterInfo): CharacterCardV2 {
+  const extensions: CharacterCardV2['data']['extensions'] = {
+    ...(character.data?.extensions || {}),
+  };
+
+  // Preserve depth prompt (character's note)
+  const depthPrompt = character.data?.extensions?.depth_prompt;
+  if (depthPrompt && (depthPrompt.prompt || depthPrompt.depth !== undefined || depthPrompt.role)) {
+    extensions.depth_prompt = depthPrompt;
+  }
+
+  // Preserve talkativeness
+  const talkativeness = character.data?.extensions?.talkativeness;
+  if (talkativeness !== undefined) {
+    extensions.talkativeness = talkativeness;
+  }
+
   return {
     spec: 'chara_card_v2',
     spec_version: '2.0',
@@ -52,10 +88,16 @@ export function characterToCardV2(character: CharacterInfo): CharacterCardV2 {
       personality: character.personality || character.data?.personality || '',
       first_mes: character.first_mes || character.data?.first_mes || '',
       scenario: character.scenario || character.data?.scenario || '',
-      mes_example: character.mes_example || '',
-      creator_notes: character.data?.creator_notes || '',
-      creator: character.data?.creator || '',
-      tags: character.tags || [],
+      mes_example: character.mes_example || character.data?.mes_example || '',
+      creator_notes: character.creator_notes || character.data?.creator_notes || '',
+      creator: character.creator || character.data?.creator || '',
+      tags: character.tags || character.data?.tags || [],
+      character_version: character.character_version || character.data?.character_version || '',
+      system_prompt: character.system_prompt || character.data?.system_prompt || '',
+      post_history_instructions:
+        character.post_history_instructions || character.data?.post_history_instructions || '',
+      alternate_greetings: character.alternate_greetings || character.data?.alternate_greetings || [],
+      extensions,
     },
   };
 }
@@ -75,6 +117,7 @@ export function cardToCharacterInfo(
 ): Partial<CharacterInfo> {
   if (isCharacterCardV2(card)) {
     // V2 card format
+    const depthPrompt = card.data.extensions?.depth_prompt;
     return {
       name: card.data.name,
       description: card.data.description,
@@ -83,14 +126,30 @@ export function cardToCharacterInfo(
       scenario: card.data.scenario,
       mes_example: card.data.mes_example,
       tags: card.data.tags,
+      creator: card.data.creator,
+      creator_notes: card.data.creator_notes,
+      character_version: card.data.character_version,
+      system_prompt: card.data.system_prompt,
+      post_history_instructions: card.data.post_history_instructions,
+      alternate_greetings: card.data.alternate_greetings,
       data: {
         name: card.data.name,
         description: card.data.description,
         personality: card.data.personality,
         first_mes: card.data.first_mes,
         scenario: card.data.scenario,
+        mes_example: card.data.mes_example,
         creator_notes: card.data.creator_notes,
         creator: card.data.creator,
+        tags: card.data.tags,
+        character_version: card.data.character_version,
+        system_prompt: card.data.system_prompt,
+        post_history_instructions: card.data.post_history_instructions,
+        alternate_greetings: card.data.alternate_greetings,
+        extensions: {
+          ...(card.data.extensions || {}),
+          ...(depthPrompt ? { depth_prompt: depthPrompt } : {}),
+        },
       },
     };
   }
@@ -104,14 +163,27 @@ export function cardToCharacterInfo(
     scenario: card.scenario,
     mes_example: card.mes_example,
     tags: card.tags,
+    creator: card.creator,
+    creator_notes: card.creator_notes,
+    character_version: card.character_version,
+    system_prompt: card.system_prompt,
+    post_history_instructions: card.post_history_instructions,
+    alternate_greetings: card.alternate_greetings,
     data: {
       name: card.name,
       description: card.description,
       personality: card.personality,
       first_mes: card.first_mes,
       scenario: card.scenario,
+      mes_example: card.mes_example,
       creator_notes: card.creator_notes,
       creator: card.creator,
+      tags: card.tags,
+      character_version: card.character_version,
+      system_prompt: card.system_prompt,
+      post_history_instructions: card.post_history_instructions,
+      alternate_greetings: card.alternate_greetings,
+      extensions: card.depth_prompt ? { depth_prompt: card.depth_prompt } : {},
     },
   };
 }
@@ -327,22 +399,11 @@ export async function embedCharacterInPNG(
 }
 
 /**
- * Export character as JSON file
+ * Export character as JSON file (as Character Card V2 so advanced fields survive)
  */
 export function exportCharacterAsJSON(character: CharacterInfo): Blob {
-  const exportData: CharacterExportData = {
-    name: character.name || '',
-    description: character.description || character.data?.description || '',
-    personality: character.personality || character.data?.personality || '',
-    first_mes: character.first_mes || character.data?.first_mes || '',
-    scenario: character.scenario || character.data?.scenario || '',
-    mes_example: character.mes_example || '',
-    creator_notes: character.data?.creator_notes || '',
-    creator: character.data?.creator || '',
-    tags: character.tags || [],
-  };
-
-  const jsonString = JSON.stringify(exportData, null, 2);
+  const cardV2 = characterToCardV2(character);
+  const jsonString = JSON.stringify(cardV2, null, 2);
   return new Blob([jsonString], { type: 'application/json' });
 }
 
@@ -373,6 +434,14 @@ export async function parseCharacterFromJSON(
       creator_notes: data.creator_notes || '',
       creator: data.creator || '',
       tags: Array.isArray(data.tags) ? data.tags : [],
+      character_version: data.character_version,
+      system_prompt: data.system_prompt,
+      post_history_instructions: data.post_history_instructions,
+      alternate_greetings: Array.isArray(data.alternate_greetings)
+        ? data.alternate_greetings
+        : undefined,
+      depth_prompt: data.depth_prompt,
+      talkativeness: data.talkativeness,
     } as CharacterExportData;
   } catch {
     throw new Error('Invalid JSON file');


### PR DESCRIPTION
Extends the mobile app with advanced Character Card V2 fields and a full user persona system to reach parity with SillyTavern desktop.

Advanced character fields:
- Alternate greetings with swipeable first message
- Character's Note (depth prompt) with configurable depth & role
- System prompt override and post-history instructions
- Talkativeness slider and character version
- {{char}}/{{user}}/{{persona}} macro substitution

User personas:
- personaStore with CRUD, default flag, and active selection
- Description position: in_prompt/before_char/after_char/at_depth
- Per-character and per-chat persona locking
- PersonaSelector dropdown in header + PersonaManager modal
- Persona description injected into chat context at configured point

Character organization:
- Tag filter chips with AND logic across selected tags
- Favorites toggle (localStorage) with favorites-only filter
- Text search across name/description/personality/creator
- Sort by name, date added, or recent chat
- Favorites bubble to the top of the list

Duplicate & convert:
- Server-side character duplication via /api/characters/duplicate
- Convert-to-persona pre-fills new persona from character data