### PR TITLE
Add Phase 4.1: basic World Info / lorebooks

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -110,10 +110,12 @@ Features are grouped into **phases** ordered by user impact and dependency. Each
 ## Phase 4: World Info / Lorebook
 *Goal: Enable persistent world-building context injection.*
 
-### 4.1 Basic World Info
-- **Gap:** No World Info support at all.
-- **ST Feature:** Keyword-triggered lore entries injected into context.
-- **Work:** World Info store and CRUD UI. Entry fields: keys, content, position, insertion order. Keyword scanning against recent messages. Inject matching entries into prompt. Import/export World Info JSON.
+### 4.1 Basic World Info ✅
+- `src/stores/worldInfoStore.ts`: lorebook store with full CRUD for books and entries. Per-entry fields: keys, content, comment, enabled, constant, caseSensitive, position, depth, order. Configurable scan depth. Multiple books can be active at once.
+- Keyword scanner (`scanMessagesForEntries`): joins the last N non-system messages into a haystack and matches entry keys (case-(in)sensitive). Constant entries bypass matching.
+- `buildConversationContext` in `chatStore.ts` groups matched entries by position and injects into the prompt: `before_char`, `after_char`, `before_an`, `after_an`, and `at_depth` (interleaved with history). Macros (`{{char}}` etc.) run on entry content.
+- UI at `/settings/worldinfo`: lorebook list with active toggle, rename, duplicate, delete, create, import, export; dedicated book editor with per-entry create/edit/enable/disable/delete.
+- JSON import/export uses SillyTavern's lorebook format (`{ entries: { uid: { key, content, position, order, ... } } }`) with position codes 0-4 mapped round-trip.
 
 ### 4.2 Advanced World Info
 - **Gap:** N/A (depends on 4.1).

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { RegisterPage } from './components/auth/RegisterPage';
 import { MainLayout } from './components/layout/MainLayout';
 import { ChatView } from './components/chat/ChatView';
 import { SettingsPage, GenerationSettingsPage } from './components/settings';
+import { WorldInfoPage } from './components/worldinfo';
 
 function App() {
   return (
@@ -13,6 +14,7 @@ function App() {
         <Route path="/register" element={<RegisterPage />} />
         <Route path="/settings" element={<SettingsPage />} />
         <Route path="/settings/generation" element={<GenerationSettingsPage />} />
+        <Route path="/settings/worldinfo" element={<WorldInfoPage />} />
         <Route path="/" element={<MainLayout />}>
           <Route index element={<ChatView />} />
           <Route path="chat/:characterId" element={<ChatView />} />

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { ArrowLeft, Check, ChevronRight, Eye, EyeOff, Key, Loader2, Sliders, Trash2 } from 'lucide-react';
+import { ArrowLeft, BookOpen, Check, ChevronRight, Eye, EyeOff, Key, Loader2, Sliders, Trash2 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useSettingsStore } from '../../stores/settingsStore';
 import { PROVIDERS, type SecretState } from '../../api/client';
@@ -270,6 +270,27 @@ export function SettingsPage() {
                   </h3>
                   <p className="text-xs text-[var(--color-text-secondary)]">
                     Samplers, prompts, context, and instruct mode
+                  </p>
+                </div>
+                <ChevronRight size={20} className="text-[var(--color-text-secondary)]" />
+              </button>
+            </section>
+
+            {/* World Info Link */}
+            <section className="bg-[var(--color-bg-secondary)] rounded-lg overflow-hidden">
+              <button
+                onClick={() => navigate('/settings/worldinfo')}
+                className="w-full flex items-center gap-3 p-4 hover:bg-[var(--color-bg-tertiary)] transition-colors text-left"
+              >
+                <div className="w-10 h-10 rounded-lg bg-[var(--color-primary)]/20 flex items-center justify-center">
+                  <BookOpen size={20} className="text-[var(--color-primary)]" />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <h3 className="text-sm font-semibold text-[var(--color-text-primary)]">
+                    World Info
+                  </h3>
+                  <p className="text-xs text-[var(--color-text-secondary)]">
+                    Lorebooks with keyword-triggered context injection
                   </p>
                 </div>
                 <ChevronRight size={20} className="text-[var(--color-text-secondary)]" />

--- a/src/components/worldinfo/WorldInfoBookEditor.tsx
+++ b/src/components/worldinfo/WorldInfoBookEditor.tsx
@@ -1,0 +1,206 @@
+import { useState } from 'react';
+import { Plus, Edit2, Trash2, Check, X, ChevronRight } from 'lucide-react';
+import {
+  useWorldInfoStore,
+  type WorldInfoBook,
+  type WorldInfoEntry,
+} from '../../stores/worldInfoStore';
+import { Modal, Button, ConfirmDialog } from '../ui';
+import { WorldInfoEntryForm } from './WorldInfoEntryForm';
+
+interface WorldInfoBookEditorProps {
+  isOpen: boolean;
+  onClose: () => void;
+  book: WorldInfoBook;
+}
+
+const POSITION_LABELS: Record<string, string> = {
+  before_char: 'Before Char',
+  after_char: 'After Char',
+  before_an: 'Before AN',
+  after_an: 'After AN',
+  at_depth: '@ Depth',
+};
+
+export function WorldInfoBookEditor({ isOpen, onClose, book }: WorldInfoBookEditorProps) {
+  const { deleteEntry, updateEntry } = useWorldInfoStore();
+
+  const [editingEntry, setEditingEntry] = useState<WorldInfoEntry | null>(null);
+  const [isCreating, setIsCreating] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState<WorldInfoEntry | null>(null);
+
+  const handleFormClose = () => {
+    setEditingEntry(null);
+    setIsCreating(false);
+  };
+
+  const formMode = isCreating || editingEntry;
+  const title = isCreating
+    ? `${book.name} — New Entry`
+    : editingEntry
+      ? `${book.name} — Edit Entry`
+      : book.name;
+
+  return (
+    <>
+      <Modal isOpen={isOpen} onClose={onClose} title={title} size="lg">
+        {formMode ? (
+          <WorldInfoEntryForm
+            bookId={book.id}
+            entry={editingEntry}
+            onClose={handleFormClose}
+          />
+        ) : (
+          <div className="space-y-3">
+            {book.entries.length === 0 ? (
+              <div className="text-center py-10">
+                <p className="text-sm text-[var(--color-text-secondary)] mb-4">
+                  No entries yet. Add one to start building lore.
+                </p>
+              </div>
+            ) : (
+              <ul className="space-y-2">
+                {book.entries.map((entry) => (
+                  <li
+                    key={entry.id}
+                    className={`
+                      p-3 rounded-lg border transition-colors
+                      ${
+                        entry.enabled
+                          ? 'bg-[var(--color-bg-tertiary)] border-[var(--color-border)]'
+                          : 'bg-[var(--color-bg-tertiary)]/40 border-[var(--color-border)] opacity-60'
+                      }
+                    `}
+                  >
+                    <div className="flex items-start gap-2">
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2 mb-1 flex-wrap">
+                          <span className="text-xs px-1.5 py-0.5 rounded bg-[var(--color-primary)]/20 text-[var(--color-primary)] font-medium">
+                            {POSITION_LABELS[entry.position] || entry.position}
+                          </span>
+                          {entry.constant && (
+                            <span className="text-xs px-1.5 py-0.5 rounded bg-amber-500/20 text-amber-400 font-medium">
+                              CONSTANT
+                            </span>
+                          )}
+                          {entry.caseSensitive && (
+                            <span className="text-[10px] px-1.5 py-0.5 rounded bg-[var(--color-bg-primary)] text-[var(--color-text-secondary)]">
+                              Aa
+                            </span>
+                          )}
+                          <span className="text-[10px] text-[var(--color-text-secondary)]">
+                            order {entry.order}
+                          </span>
+                          {entry.position === 'at_depth' && (
+                            <span className="text-[10px] text-[var(--color-text-secondary)]">
+                              depth {entry.depth}
+                            </span>
+                          )}
+                        </div>
+                        {entry.comment && (
+                          <p className="text-xs text-[var(--color-text-primary)] font-medium mb-1 truncate">
+                            {entry.comment}
+                          </p>
+                        )}
+                        <p className="text-xs text-[var(--color-text-secondary)] mb-1">
+                          {entry.constant ? (
+                            <em>No keywords (always active)</em>
+                          ) : entry.keys.length > 0 ? (
+                            entry.keys.map((k, i) => (
+                              <span
+                                key={i}
+                                className="inline-block mr-1 mb-0.5 px-1.5 py-0.5 rounded bg-[var(--color-bg-primary)]"
+                              >
+                                {k}
+                              </span>
+                            ))
+                          ) : (
+                            <em className="text-red-400">Missing keywords</em>
+                          )}
+                        </p>
+                        <p className="text-xs text-[var(--color-text-secondary)] line-clamp-2">
+                          {entry.content}
+                        </p>
+                      </div>
+                      <div className="flex items-center gap-1 flex-shrink-0">
+                        <button
+                          onClick={() =>
+                            updateEntry(book.id, entry.id, { enabled: !entry.enabled })
+                          }
+                          className={`p-1.5 rounded-lg hover:bg-[var(--color-bg-secondary)] ${
+                            entry.enabled
+                              ? 'text-green-400'
+                              : 'text-[var(--color-text-secondary)]'
+                          }`}
+                          title={entry.enabled ? 'Disable' : 'Enable'}
+                          aria-label={entry.enabled ? 'Disable entry' : 'Enable entry'}
+                        >
+                          {entry.enabled ? <Check size={14} /> : <X size={14} />}
+                        </button>
+                        <button
+                          onClick={() => {
+                            setEditingEntry(entry);
+                            setIsCreating(false);
+                          }}
+                          className="p-1.5 rounded-lg text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-secondary)]"
+                          title="Edit entry"
+                          aria-label="Edit entry"
+                        >
+                          <Edit2 size={14} />
+                        </button>
+                        <button
+                          onClick={() => setConfirmDelete(entry)}
+                          className="p-1.5 rounded-lg text-[var(--color-text-secondary)] hover:text-red-400 hover:bg-red-500/10"
+                          title="Delete entry"
+                          aria-label="Delete entry"
+                        >
+                          <Trash2 size={14} />
+                        </button>
+                      </div>
+                    </div>
+                    <button
+                      onClick={() => {
+                        setEditingEntry(entry);
+                        setIsCreating(false);
+                      }}
+                      className="mt-1 text-xs text-[var(--color-primary)] hover:underline flex items-center gap-1"
+                    >
+                      View details <ChevronRight size={12} />
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+
+            <Button
+              variant="primary"
+              onClick={() => {
+                setEditingEntry(null);
+                setIsCreating(true);
+              }}
+              className="w-full"
+            >
+              <Plus size={18} className="mr-2" />
+              New Entry
+            </Button>
+          </div>
+        )}
+      </Modal>
+
+      {confirmDelete && (
+        <ConfirmDialog
+          isOpen={!!confirmDelete}
+          onClose={() => setConfirmDelete(null)}
+          onConfirm={() => {
+            deleteEntry(book.id, confirmDelete.id);
+            setConfirmDelete(null);
+          }}
+          title="Delete Entry"
+          message={`Delete this world info entry? This cannot be undone.`}
+          confirmLabel="Delete"
+          danger
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/worldinfo/WorldInfoEntryForm.tsx
+++ b/src/components/worldinfo/WorldInfoEntryForm.tsx
@@ -1,0 +1,224 @@
+import { useEffect, useState } from 'react';
+import {
+  useWorldInfoStore,
+  type WorldInfoEntry,
+  type WorldInfoPosition,
+} from '../../stores/worldInfoStore';
+import { Button, Input, TextArea } from '../ui';
+
+interface WorldInfoEntryFormProps {
+  bookId: string;
+  entry: WorldInfoEntry | null; // null = creating new
+  onClose: () => void;
+}
+
+const POSITION_OPTIONS: { value: WorldInfoPosition; label: string; hint: string }[] = [
+  { value: 'before_char', label: 'Before Character', hint: 'Injected before character description' },
+  { value: 'after_char', label: 'After Character', hint: "Injected after character description" },
+  { value: 'before_an', label: "Before Author's Note", hint: 'Injected before auxiliary prompt' },
+  { value: 'after_an', label: "After Author's Note", hint: 'Injected after post-history instructions' },
+  { value: 'at_depth', label: '@ Depth', hint: 'Injected at a specific depth in the chat' },
+];
+
+export function WorldInfoEntryForm({ bookId, entry, onClose }: WorldInfoEntryFormProps) {
+  const { createEntry, updateEntry } = useWorldInfoStore();
+
+  const [keys, setKeys] = useState('');
+  const [content, setContent] = useState('');
+  const [comment, setComment] = useState('');
+  const [enabled, setEnabled] = useState(true);
+  const [constant, setConstant] = useState(false);
+  const [caseSensitive, setCaseSensitive] = useState(false);
+  const [position, setPosition] = useState<WorldInfoPosition>('before_char');
+  const [depth, setDepth] = useState(4);
+  const [order, setOrder] = useState(100);
+
+  useEffect(() => {
+    if (entry) {
+      setKeys(entry.keys.join(', '));
+      setContent(entry.content);
+      setComment(entry.comment);
+      setEnabled(entry.enabled);
+      setConstant(entry.constant);
+      setCaseSensitive(entry.caseSensitive);
+      setPosition(entry.position);
+      setDepth(entry.depth);
+      setOrder(entry.order);
+    } else {
+      setKeys('');
+      setContent('');
+      setComment('');
+      setEnabled(true);
+      setConstant(false);
+      setCaseSensitive(false);
+      setPosition('before_char');
+      setDepth(4);
+      setOrder(100);
+    }
+  }, [entry]);
+
+  const parsedKeys = keys
+    .split(',')
+    .map((k) => k.trim())
+    .filter(Boolean);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!content.trim()) return;
+    if (!constant && parsedKeys.length === 0) return;
+
+    const data = {
+      keys: parsedKeys,
+      content: content.trim(),
+      comment: comment.trim(),
+      enabled,
+      constant,
+      caseSensitive,
+      position,
+      depth,
+      order,
+    };
+
+    if (entry) {
+      updateEntry(bookId, entry.id, data);
+    } else {
+      createEntry(bookId, data);
+    }
+    onClose();
+  };
+
+  const canSubmit = content.trim().length > 0 && (constant || parsedKeys.length > 0);
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <Input
+        label="Keywords (comma-separated)"
+        placeholder="e.g. dragon, wyrm, drake"
+        value={keys}
+        onChange={(e) => setKeys(e.target.value)}
+        disabled={constant}
+        autoFocus={!entry}
+      />
+      <p className="-mt-3 text-xs text-[var(--color-text-secondary)]">
+        {constant
+          ? 'Constant entries activate on every generation; keywords are ignored.'
+          : 'Entry activates when ANY keyword appears in scanned chat history.'}
+      </p>
+
+      <TextArea
+        label="Content *"
+        placeholder="Lore content to inject into the prompt when triggered. Supports {{char}}, {{user}}, etc."
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+        rows={6}
+        required
+      />
+
+      <Input
+        label="Comment (optional)"
+        placeholder="Displayed in the UI only"
+        value={comment}
+        onChange={(e) => setComment(e.target.value)}
+      />
+
+      <div>
+        <label className="block text-sm font-medium text-[var(--color-text-secondary)] mb-1.5">
+          Position
+        </label>
+        <select
+          value={position}
+          onChange={(e) => setPosition(e.target.value as WorldInfoPosition)}
+          className="w-full px-3 py-2 bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] rounded-lg text-[var(--color-text-primary)] text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]"
+        >
+          {POSITION_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+        <p className="mt-1 text-xs text-[var(--color-text-secondary)]">
+          {POSITION_OPTIONS.find((o) => o.value === position)?.hint}
+        </p>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        {position === 'at_depth' && (
+          <div>
+            <label className="block text-xs font-medium text-[var(--color-text-secondary)] mb-1">
+              Depth
+            </label>
+            <input
+              type="number"
+              min={0}
+              max={100}
+              value={depth}
+              onChange={(e) => setDepth(Number(e.target.value) || 0)}
+              className="w-full px-3 py-2 bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] rounded-lg text-[var(--color-text-primary)] text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]"
+            />
+          </div>
+        )}
+        <div className={position === 'at_depth' ? '' : 'col-span-2'}>
+          <label className="block text-xs font-medium text-[var(--color-text-secondary)] mb-1">
+            Order
+          </label>
+          <input
+            type="number"
+            min={0}
+            max={10000}
+            value={order}
+            onChange={(e) => setOrder(Number(e.target.value) || 0)}
+            className="w-full px-3 py-2 bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] rounded-lg text-[var(--color-text-primary)] text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]"
+          />
+          <p className="mt-1 text-xs text-[var(--color-text-secondary)]">
+            Lower order is injected first.
+          </p>
+        </div>
+      </div>
+
+      <div className="space-y-2 pt-2 border-t border-[var(--color-border)]">
+        <label className="flex items-center gap-2 text-sm text-[var(--color-text-primary)] cursor-pointer">
+          <input
+            type="checkbox"
+            checked={enabled}
+            onChange={(e) => setEnabled(e.target.checked)}
+            className="w-4 h-4 accent-[var(--color-primary)]"
+          />
+          Enabled
+        </label>
+        <label className="flex items-center gap-2 text-sm text-[var(--color-text-primary)] cursor-pointer">
+          <input
+            type="checkbox"
+            checked={constant}
+            onChange={(e) => setConstant(e.target.checked)}
+            className="w-4 h-4 accent-[var(--color-primary)]"
+          />
+          Constant (always inject, ignore keywords)
+        </label>
+        <label className="flex items-center gap-2 text-sm text-[var(--color-text-primary)] cursor-pointer">
+          <input
+            type="checkbox"
+            checked={caseSensitive}
+            onChange={(e) => setCaseSensitive(e.target.checked)}
+            disabled={constant}
+            className="w-4 h-4 accent-[var(--color-primary)]"
+          />
+          Case-sensitive matching
+        </label>
+      </div>
+
+      <div className="flex gap-3 pt-4 border-t border-[var(--color-border)]">
+        <Button type="button" variant="secondary" onClick={onClose} className="flex-1">
+          Cancel
+        </Button>
+        <Button
+          type="submit"
+          variant="primary"
+          disabled={!canSubmit}
+          className="flex-1"
+        >
+          {entry ? 'Save Changes' : 'Create Entry'}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/worldinfo/WorldInfoPage.tsx
+++ b/src/components/worldinfo/WorldInfoPage.tsx
@@ -1,0 +1,363 @@
+import { useRef, useState } from 'react';
+import {
+  ArrowLeft,
+  Plus,
+  Trash2,
+  Edit2,
+  Download,
+  Upload,
+  Copy,
+  BookOpen,
+} from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import {
+  useWorldInfoStore,
+  type WorldInfoBook,
+} from '../../stores/worldInfoStore';
+import { Button, Input, ConfirmDialog } from '../ui';
+import { WorldInfoBookEditor } from './WorldInfoBookEditor';
+
+export function WorldInfoPage() {
+  const navigate = useNavigate();
+  const {
+    books,
+    activeBookIds,
+    scanDepth,
+    error,
+    createBook,
+    renameBook,
+    deleteBook,
+    duplicateBook,
+    toggleBookActive,
+    setScanDepth,
+    exportBookJson,
+    importBookJson,
+    clearError,
+  } = useWorldInfoStore();
+
+  const [newBookName, setNewBookName] = useState('');
+  const [editingBook, setEditingBook] = useState<WorldInfoBook | null>(null);
+  const [renamingId, setRenamingId] = useState<string | null>(null);
+  const [renameValue, setRenameValue] = useState('');
+  const [confirmDelete, setConfirmDelete] = useState<WorldInfoBook | null>(null);
+  const [importNotice, setImportNotice] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const handleCreate = () => {
+    const trimmed = newBookName.trim();
+    if (!trimmed) return;
+    createBook(trimmed);
+    setNewBookName('');
+  };
+
+  const handleStartRename = (book: WorldInfoBook) => {
+    setRenamingId(book.id);
+    setRenameValue(book.name);
+  };
+
+  const handleFinishRename = () => {
+    if (renamingId && renameValue.trim()) {
+      renameBook(renamingId, renameValue.trim());
+    }
+    setRenamingId(null);
+    setRenameValue('');
+  };
+
+  const handleExport = (book: WorldInfoBook) => {
+    const json = exportBookJson(book.id);
+    if (!json) return;
+    const safeName = book.name.replace(/[^a-z0-9_\-\s]/gi, '_').trim() || 'lorebook';
+    const blob = new Blob([json], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${safeName}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleImportClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleFileSelected = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    e.target.value = ''; // reset
+    try {
+      const text = await file.text();
+      const nameFromFile = file.name.replace(/\.json$/i, '');
+      const imported = importBookJson(text, nameFromFile);
+      if (imported) {
+        setImportNotice(
+          `Imported "${imported.name}" with ${imported.entries.length} entr${imported.entries.length === 1 ? 'y' : 'ies'}`
+        );
+        setTimeout(() => setImportNotice(null), 4000);
+      }
+    } catch (err) {
+      console.error('[WI] Import failed:', err);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-[var(--color-bg-primary)]">
+      <header className="h-14 bg-[var(--color-bg-secondary)] border-b border-[var(--color-border)] flex items-center px-4 gap-3 safe-top">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => navigate('/settings')}
+          className="p-2"
+          aria-label="Back"
+        >
+          <ArrowLeft size={24} />
+        </Button>
+        <h1 className="text-lg font-semibold text-[var(--color-text-primary)] flex-1">
+          World Info
+        </h1>
+        <span className="text-xs px-2 py-1 rounded-full bg-[var(--color-bg-tertiary)] text-[var(--color-text-secondary)]">
+          {activeBookIds.length} active
+        </span>
+      </header>
+
+      <div className="max-w-2xl mx-auto p-4 space-y-4">
+        {error && (
+          <div className="p-3 bg-red-500/10 border border-red-500/30 rounded-lg flex items-center justify-between">
+            <p className="text-sm text-red-400">{error}</p>
+            <button
+              onClick={clearError}
+              className="text-red-400 hover:text-red-300"
+              aria-label="Dismiss"
+            >
+              ×
+            </button>
+          </div>
+        )}
+        {importNotice && (
+          <div className="p-3 bg-green-500/10 border border-green-500/30 rounded-lg">
+            <p className="text-sm text-green-400">{importNotice}</p>
+          </div>
+        )}
+
+        {/* Global settings */}
+        <section className="bg-[var(--color-bg-secondary)] rounded-lg p-4">
+          <h2 className="text-sm font-semibold text-[var(--color-text-primary)] mb-3">
+            Scan Settings
+          </h2>
+          <div>
+            <div className="flex items-center justify-between mb-1.5">
+              <label className="text-sm font-medium text-[var(--color-text-secondary)]">
+                Scan Depth
+              </label>
+              <input
+                type="number"
+                value={scanDepth}
+                min={1}
+                max={50}
+                onChange={(e) => setScanDepth(Number(e.target.value) || 4)}
+                className="w-20 px-2 py-1 text-sm text-right bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] rounded text-[var(--color-text-primary)] focus:outline-none focus:ring-1 focus:ring-[var(--color-primary)]"
+              />
+            </div>
+            <input
+              type="range"
+              min={1}
+              max={50}
+              step={1}
+              value={scanDepth}
+              onChange={(e) => setScanDepth(Number(e.target.value))}
+              className="w-full accent-[var(--color-primary)]"
+            />
+            <p className="mt-1 text-xs text-[var(--color-text-secondary)]">
+              Number of recent messages scanned for keyword matches.
+            </p>
+          </div>
+        </section>
+
+        {/* Lorebooks */}
+        <section className="bg-[var(--color-bg-secondary)] rounded-lg p-4">
+          <div className="flex items-center justify-between mb-3">
+            <h2 className="text-sm font-semibold text-[var(--color-text-primary)]">
+              Lorebooks
+            </h2>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="application/json,.json"
+              onChange={handleFileSelected}
+              className="hidden"
+            />
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleImportClick}
+              className="text-xs"
+            >
+              <Upload size={14} className="mr-1" />
+              Import
+            </Button>
+          </div>
+
+          <div className="flex gap-2 mb-3">
+            <Input
+              value={newBookName}
+              onChange={(e) => setNewBookName(e.target.value)}
+              placeholder="New lorebook name..."
+              onKeyDown={(e) => e.key === 'Enter' && handleCreate()}
+              className="flex-1"
+            />
+            <Button
+              onClick={handleCreate}
+              disabled={!newBookName.trim()}
+              className="shrink-0"
+              size="sm"
+            >
+              <Plus size={14} className="mr-1" />
+              Create
+            </Button>
+          </div>
+
+          {books.length === 0 ? (
+            <div className="text-center py-10">
+              <BookOpen
+                size={48}
+                className="mx-auto text-[var(--color-text-secondary)] mb-3"
+              />
+              <h3 className="text-sm font-medium text-[var(--color-text-primary)] mb-1">
+                No lorebooks yet
+              </h3>
+              <p className="text-xs text-[var(--color-text-secondary)]">
+                Create one above, or import an existing World Info JSON.
+              </p>
+            </div>
+          ) : (
+            <ul className="space-y-2">
+              {books.map((book) => {
+                const isActive = activeBookIds.includes(book.id);
+                const isRenaming = renamingId === book.id;
+                return (
+                  <li
+                    key={book.id}
+                    className={`
+                      p-3 rounded-lg border transition-colors
+                      ${
+                        isActive
+                          ? 'bg-[var(--color-primary)]/10 border-[var(--color-primary)]'
+                          : 'bg-[var(--color-bg-tertiary)] border-[var(--color-border)]'
+                      }
+                    `}
+                  >
+                    <div className="flex items-center gap-2">
+                      <label className="flex items-center cursor-pointer flex-shrink-0">
+                        <input
+                          type="checkbox"
+                          checked={isActive}
+                          onChange={() => toggleBookActive(book.id)}
+                          className="w-4 h-4 accent-[var(--color-primary)]"
+                          aria-label={`${isActive ? 'Deactivate' : 'Activate'} ${book.name}`}
+                        />
+                      </label>
+                      {isRenaming ? (
+                        <input
+                          type="text"
+                          value={renameValue}
+                          onChange={(e) => setRenameValue(e.target.value)}
+                          onBlur={handleFinishRename}
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter') handleFinishRename();
+                            if (e.key === 'Escape') {
+                              setRenamingId(null);
+                              setRenameValue('');
+                            }
+                          }}
+                          autoFocus
+                          className="flex-1 px-2 py-1 text-sm bg-[var(--color-bg-primary)] border border-[var(--color-border)] rounded text-[var(--color-text-primary)] focus:outline-none focus:ring-1 focus:ring-[var(--color-primary)]"
+                        />
+                      ) : (
+                        <button
+                          onClick={() => setEditingBook(book)}
+                          className="flex-1 min-w-0 text-left"
+                        >
+                          <p className="text-sm font-medium text-[var(--color-text-primary)] truncate">
+                            {book.name}
+                          </p>
+                          <p className="text-xs text-[var(--color-text-secondary)]">
+                            {book.entries.length} entr
+                            {book.entries.length === 1 ? 'y' : 'ies'}
+                            {isActive ? ' · active' : ''}
+                          </p>
+                        </button>
+                      )}
+                      <div className="flex items-center gap-0.5 flex-shrink-0">
+                        <button
+                          onClick={() => handleStartRename(book)}
+                          className="p-1.5 rounded-lg text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-secondary)]"
+                          title="Rename"
+                          aria-label="Rename lorebook"
+                        >
+                          <Edit2 size={14} />
+                        </button>
+                        <button
+                          onClick={() => duplicateBook(book.id)}
+                          className="p-1.5 rounded-lg text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-secondary)]"
+                          title="Duplicate"
+                          aria-label="Duplicate lorebook"
+                        >
+                          <Copy size={14} />
+                        </button>
+                        <button
+                          onClick={() => handleExport(book)}
+                          className="p-1.5 rounded-lg text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-secondary)]"
+                          title="Export JSON"
+                          aria-label="Export lorebook"
+                        >
+                          <Download size={14} />
+                        </button>
+                        <button
+                          onClick={() => setConfirmDelete(book)}
+                          className="p-1.5 rounded-lg text-[var(--color-text-secondary)] hover:text-red-400 hover:bg-red-500/10"
+                          title="Delete"
+                          aria-label="Delete lorebook"
+                        >
+                          <Trash2 size={14} />
+                        </button>
+                      </div>
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </section>
+
+        <section className="text-center py-4">
+          <p className="text-xs text-[var(--color-text-secondary)]">
+            Lorebooks are stored locally. Active books are scanned against recent
+            messages; matching entries are injected at their configured position.
+          </p>
+        </section>
+      </div>
+
+      {editingBook && (
+        <WorldInfoBookEditor
+          isOpen={!!editingBook}
+          onClose={() => setEditingBook(null)}
+          book={books.find((b) => b.id === editingBook.id) || editingBook}
+        />
+      )}
+
+      {confirmDelete && (
+        <ConfirmDialog
+          isOpen={!!confirmDelete}
+          onClose={() => setConfirmDelete(null)}
+          onConfirm={() => {
+            deleteBook(confirmDelete.id);
+            setConfirmDelete(null);
+          }}
+          title="Delete Lorebook"
+          message={`Delete "${confirmDelete.name}" and all its entries? This cannot be undone.`}
+          confirmLabel="Delete"
+          danger
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/worldinfo/index.ts
+++ b/src/components/worldinfo/index.ts
@@ -1,0 +1,3 @@
+export { WorldInfoPage } from './WorldInfoPage';
+export { WorldInfoBookEditor } from './WorldInfoBookEditor';
+export { WorldInfoEntryForm } from './WorldInfoEntryForm';

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -3,6 +3,12 @@ import { api, type CharacterInfo, type GenerationOptions } from '../api/client';
 import { useSettingsStore } from './settingsStore';
 import { usePersonaStore } from './personaStore';
 import { useGenerationStore } from './generationStore';
+import {
+  useWorldInfoStore,
+  scanMessagesForEntries,
+  type WorldInfoPosition,
+  type MatchedEntry,
+} from './worldInfoStore';
 import { parseEmotion, stripEmotionTag, type Emotion } from '../utils/emotions';
 import { processMacros, type MacroContext } from '../utils/macros';
 import {
@@ -254,6 +260,30 @@ function buildConversationContext(
   );
   const sub = (text: string) => (text ? processMacros(text, macroCtx) : '');
 
+  // Scan active world info books for keyword matches against recent history
+  const wiState = useWorldInfoStore.getState();
+  const matchedEntries = scanMessagesForEntries(
+    wiState.books,
+    wiState.activeBookIds,
+    messages,
+    wiState.scanDepth
+  );
+  const wiByPosition: Record<WorldInfoPosition, MatchedEntry[]> = {
+    before_char: [],
+    after_char: [],
+    before_an: [],
+    after_an: [],
+    at_depth: [],
+  };
+  for (const m of matchedEntries) {
+    wiByPosition[m.entry.position].push(m);
+  }
+  const joinWi = (list: MatchedEntry[]): string =>
+    list
+      .map((m) => sub(m.entry.content))
+      .filter((c) => c.trim().length > 0)
+      .join('\n\n');
+
   const description = sub(getCharacterField(character, 'description'));
   const personality = sub(getCharacterField(character, 'personality'));
   const scenario = sub(getCharacterField(character, 'scenario'));
@@ -315,8 +345,16 @@ Choose the emotion that best matches how ${character.name} would feel based on t
   if (persona && persona.descriptionPosition === 'before_char' && personaBlock) {
     systemParts.push(personaBlock);
   }
+  const wiBeforeChar = joinWi(wiByPosition.before_char);
+  if (wiBeforeChar) {
+    systemParts.push(wiBeforeChar);
+  }
   if (charInfoBlock) {
     systemParts.push(charInfoBlock);
+  }
+  const wiAfterChar = joinWi(wiByPosition.after_char);
+  if (wiAfterChar) {
+    systemParts.push(wiAfterChar);
   }
   if (persona && persona.descriptionPosition === 'after_char' && personaDescription) {
     systemParts.push(`[The user you're talking to is ${personaName}. ${personaDescription}]`);
@@ -324,6 +362,10 @@ Choose the emotion that best matches how ${character.name} would feel based on t
   if (persona && persona.descriptionPosition === 'in_prompt' && personaDescription) {
     // Only add it once; if not added as before_char
     // Already added as before_char, so only add if not already
+  }
+  const wiBeforeAn = joinWi(wiByPosition.before_an);
+  if (wiBeforeAn) {
+    systemParts.push(wiBeforeAn);
   }
   if (userJailbreak) {
     systemParts.push(userJailbreak);
@@ -362,6 +404,14 @@ Choose the emotion that best matches how ${character.name} would feel based on t
     content: string;
   }[] = [];
 
+  // Group WI at-depth entries by their depth value for interleaved injection.
+  const wiAtDepthByDepth: Record<number, MatchedEntry[]> = {};
+  for (const m of wiByPosition.at_depth) {
+    const d = Math.max(0, Math.floor(m.entry.depth));
+    if (!wiAtDepthByDepth[d]) wiAtDepthByDepth[d] = [];
+    wiAtDepthByDepth[d].push(m);
+  }
+
   for (let i = 0; i < recentMessages.length; i++) {
     const msg = recentMessages[i];
     const depthFromEnd = recentMessages.length - i;
@@ -378,6 +428,14 @@ Choose the emotion that best matches how ${character.name} would feel based on t
         role: personaAtDepth.role,
         content: personaAtDepth.content,
       });
+    }
+    // WI at-depth entries: inject as system messages at the matching depth
+    const wiHere = wiAtDepthByDepth[depthFromEnd];
+    if (wiHere && wiHere.length > 0) {
+      const content = joinWi(wiHere);
+      if (content) {
+        historyWithInsertions.push({ role: 'system', content });
+      }
     }
 
     historyWithInsertions.push({
@@ -403,6 +461,16 @@ Choose the emotion that best matches how ${character.name} would feel based on t
       content: personaAtDepth.content,
     });
   }
+  // WI at-depth: any entries whose depth exceeds history length prepend.
+  for (const depthKey of Object.keys(wiAtDepthByDepth)) {
+    const d = parseInt(depthKey, 10);
+    if (d > recentMessages.length) {
+      const content = joinWi(wiAtDepthByDepth[d]);
+      if (content) {
+        historyWithInsertions.unshift({ role: 'system', content });
+      }
+    }
+  }
 
   // Token-aware trimming: keep system prompts, drop oldest history that exceeds budget
   if (ctxConfig.tokenAware) {
@@ -427,6 +495,12 @@ Choose the emotion that best matches how ${character.name} would feel based on t
   }
   if (userPHI) {
     context.push({ role: 'system', content: userPHI });
+  }
+
+  // World info 'after_an' entries go after post-history instructions
+  const wiAfterAn = joinWi(wiByPosition.after_an);
+  if (wiAfterAn) {
+    context.push({ role: 'system', content: wiAfterAn });
   }
 
   // If not token-aware, still estimate tokens for the UI badge

--- a/src/stores/worldInfoStore.ts
+++ b/src/stores/worldInfoStore.ts
@@ -1,0 +1,523 @@
+import { create } from 'zustand';
+
+// Where a world info entry is injected relative to the character definitions
+// and the rest of the prompt. These map 1:1 onto SillyTavern's position codes
+// (0-4) for import/export compatibility.
+export type WorldInfoPosition =
+  | 'before_char' // Before character description (ST position 0)
+  | 'after_char' // After character description (ST position 1)
+  | 'before_an' // Before author's note / jailbreak (ST position 2)
+  | 'after_an' // After author's note / post-history (ST position 3)
+  | 'at_depth'; // Injected at a specific depth in the chat (ST position 4)
+
+export interface WorldInfoEntry {
+  id: string;
+  /** Primary keywords – entry activates when ANY appears in scanned text. */
+  keys: string[];
+  /** Lore content injected into the prompt. Supports macros. */
+  content: string;
+  /** User comment, shown in the UI only. */
+  comment: string;
+  /** When false, the entry is ignored entirely. */
+  enabled: boolean;
+  /** When true, entry is always injected regardless of keyword scanning. */
+  constant: boolean;
+  /** When true, keyword matching respects case. */
+  caseSensitive: boolean;
+  /** Where this entry is injected. */
+  position: WorldInfoPosition;
+  /** Depth from the END of the chat (for position === 'at_depth'). */
+  depth: number;
+  /** Insertion order within the same position group. Higher = later. */
+  order: number;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface WorldInfoBook {
+  id: string;
+  name: string;
+  entries: WorldInfoEntry[];
+  createdAt: number;
+  updatedAt: number;
+}
+
+const BOOKS_KEY = 'sillytavern_worldinfo_books_v1';
+const ACTIVE_BOOKS_KEY = 'sillytavern_worldinfo_active_books_v1';
+const SCAN_DEPTH_KEY = 'sillytavern_worldinfo_scan_depth_v1';
+
+const DEFAULT_SCAN_DEPTH = 4;
+
+export const DEFAULT_ENTRY: Omit<
+  WorldInfoEntry,
+  'id' | 'createdAt' | 'updatedAt'
+> = {
+  keys: [],
+  content: '',
+  comment: '',
+  enabled: true,
+  constant: false,
+  caseSensitive: false,
+  position: 'before_char',
+  depth: 4,
+  order: 100,
+};
+
+function loadBooks(): WorldInfoBook[] {
+  try {
+    const raw = localStorage.getItem(BOOKS_KEY);
+    return raw ? (JSON.parse(raw) as WorldInfoBook[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveBooks(books: WorldInfoBook[]) {
+  try {
+    localStorage.setItem(BOOKS_KEY, JSON.stringify(books));
+  } catch {
+    // ignore quota/security errors
+  }
+}
+
+function loadActiveBooks(): string[] {
+  try {
+    const raw = localStorage.getItem(ACTIVE_BOOKS_KEY);
+    return raw ? (JSON.parse(raw) as string[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveActiveBooks(ids: string[]) {
+  try {
+    localStorage.setItem(ACTIVE_BOOKS_KEY, JSON.stringify(ids));
+  } catch {
+    // ignore
+  }
+}
+
+function loadScanDepth(): number {
+  try {
+    const raw = localStorage.getItem(SCAN_DEPTH_KEY);
+    const n = raw ? parseInt(raw, 10) : DEFAULT_SCAN_DEPTH;
+    return Number.isFinite(n) && n >= 1 ? n : DEFAULT_SCAN_DEPTH;
+  } catch {
+    return DEFAULT_SCAN_DEPTH;
+  }
+}
+
+function saveScanDepth(depth: number) {
+  try {
+    localStorage.setItem(SCAN_DEPTH_KEY, String(depth));
+  } catch {
+    // ignore
+  }
+}
+
+function generateId(prefix: string): string {
+  return `${prefix}_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+// ---- SillyTavern lorebook format interop --------------------------------
+//
+// ST stores WI as { entries: { "<uid>": { uid, key[], keysecondary[], comment,
+// content, constant, selective, order, position, disable, depth, ... } } }.
+// position is an integer:  0 = Before Char, 1 = After Char, 2 = Before AN,
+// 3 = After AN, 4 = @Depth, 5 = Before Examples, 6 = After Examples.
+// We only support 0-4 in Phase 4.1; anything else maps to 'before_char'.
+
+const ST_POS_TO_LOCAL: Record<number, WorldInfoPosition> = {
+  0: 'before_char',
+  1: 'after_char',
+  2: 'before_an',
+  3: 'after_an',
+  4: 'at_depth',
+  5: 'before_char',
+  6: 'after_char',
+};
+
+const LOCAL_POS_TO_ST: Record<WorldInfoPosition, number> = {
+  before_char: 0,
+  after_char: 1,
+  before_an: 2,
+  after_an: 3,
+  at_depth: 4,
+};
+
+interface StEntry {
+  uid?: number;
+  key?: string[];
+  keysecondary?: string[];
+  comment?: string;
+  content?: string;
+  constant?: boolean;
+  vectorized?: boolean;
+  selective?: boolean;
+  order?: number;
+  position?: number;
+  disable?: boolean;
+  depth?: number;
+  displayIndex?: number;
+  caseSensitive?: boolean | null;
+  addMemo?: boolean;
+  name?: string;
+}
+
+interface StBook {
+  entries?: Record<string, StEntry> | StEntry[];
+  name?: string;
+}
+
+export function entryFromStFormat(raw: StEntry): WorldInfoEntry {
+  const now = Date.now();
+  return {
+    id: generateId('wi'),
+    keys: Array.isArray(raw.key)
+      ? raw.key.filter((k): k is string => typeof k === 'string' && !!k.trim())
+      : [],
+    content: typeof raw.content === 'string' ? raw.content : '',
+    comment: typeof raw.comment === 'string' ? raw.comment : '',
+    enabled: raw.disable === true ? false : true,
+    constant: raw.constant === true,
+    caseSensitive: raw.caseSensitive === true,
+    position:
+      typeof raw.position === 'number'
+        ? ST_POS_TO_LOCAL[raw.position] || 'before_char'
+        : 'before_char',
+    depth: typeof raw.depth === 'number' ? raw.depth : DEFAULT_ENTRY.depth,
+    order: typeof raw.order === 'number' ? raw.order : DEFAULT_ENTRY.order,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+export function entryToStFormat(
+  entry: WorldInfoEntry,
+  uid: number
+): StEntry {
+  return {
+    uid,
+    key: entry.keys,
+    keysecondary: [],
+    comment: entry.comment,
+    content: entry.content,
+    constant: entry.constant,
+    vectorized: false,
+    selective: true,
+    order: entry.order,
+    position: LOCAL_POS_TO_ST[entry.position],
+    disable: !entry.enabled,
+    depth: entry.depth,
+    displayIndex: uid,
+    caseSensitive: entry.caseSensitive,
+    addMemo: !!entry.comment,
+  };
+}
+
+export function bookFromStFormat(name: string, raw: StBook): WorldInfoBook {
+  const rawEntries = raw.entries;
+  const list: StEntry[] = [];
+  if (Array.isArray(rawEntries)) {
+    list.push(...rawEntries);
+  } else if (rawEntries && typeof rawEntries === 'object') {
+    for (const k of Object.keys(rawEntries)) {
+      list.push(rawEntries[k] as StEntry);
+    }
+  }
+  const now = Date.now();
+  return {
+    id: generateId('wibook'),
+    name: raw.name || name || 'Imported Lorebook',
+    entries: list.map(entryFromStFormat),
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+export function bookToStFormat(book: WorldInfoBook): StBook {
+  const entries: Record<string, StEntry> = {};
+  book.entries.forEach((e, idx) => {
+    entries[String(idx)] = entryToStFormat(e, idx);
+  });
+  return { name: book.name, entries };
+}
+
+// ---- Keyword scanning ----------------------------------------------------
+
+export interface MatchedEntry {
+  entry: WorldInfoEntry;
+  bookId: string;
+  bookName: string;
+}
+
+function containsKey(haystack: string, key: string, caseSensitive: boolean): boolean {
+  if (!key) return false;
+  if (caseSensitive) return haystack.includes(key);
+  return haystack.toLowerCase().includes(key.toLowerCase());
+}
+
+/**
+ * Scan the last `scanDepth` messages for keyword matches across the given
+ * active books. Returns an ordered list (by position > order > insertion).
+ */
+export function scanMessagesForEntries(
+  books: WorldInfoBook[],
+  activeBookIds: string[],
+  messages: { content: string; isSystem?: boolean }[],
+  scanDepth: number
+): MatchedEntry[] {
+  const activeBooks = books.filter((b) => activeBookIds.includes(b.id));
+  if (activeBooks.length === 0) return [];
+
+  // Build haystack from the last `scanDepth` non-system messages.
+  const nonSystem = messages.filter((m) => !m.isSystem);
+  const recent = nonSystem.slice(-Math.max(1, scanDepth));
+  const haystack = recent.map((m) => m.content || '').join('\n');
+
+  const matches: MatchedEntry[] = [];
+  for (const book of activeBooks) {
+    for (const entry of book.entries) {
+      if (!entry.enabled) continue;
+      if (entry.content.trim().length === 0) continue;
+
+      if (entry.constant) {
+        matches.push({ entry, bookId: book.id, bookName: book.name });
+        continue;
+      }
+
+      if (entry.keys.length === 0) continue;
+
+      const matched = entry.keys.some((k) =>
+        containsKey(haystack, k, entry.caseSensitive)
+      );
+      if (matched) {
+        matches.push({ entry, bookId: book.id, bookName: book.name });
+      }
+    }
+  }
+
+  // Sort by order (ascending). Position grouping happens at injection time.
+  matches.sort((a, b) => a.entry.order - b.entry.order);
+  return matches;
+}
+
+// ---- Store ---------------------------------------------------------------
+
+interface WorldInfoState {
+  books: WorldInfoBook[];
+  activeBookIds: string[];
+  scanDepth: number;
+  error: string | null;
+
+  // Book CRUD
+  createBook: (name: string) => WorldInfoBook;
+  renameBook: (bookId: string, name: string) => void;
+  deleteBook: (bookId: string) => void;
+  duplicateBook: (bookId: string) => WorldInfoBook | null;
+
+  // Entry CRUD
+  createEntry: (
+    bookId: string,
+    data?: Partial<Omit<WorldInfoEntry, 'id' | 'createdAt' | 'updatedAt'>>
+  ) => WorldInfoEntry | null;
+  updateEntry: (
+    bookId: string,
+    entryId: string,
+    data: Partial<Omit<WorldInfoEntry, 'id' | 'createdAt'>>
+  ) => void;
+  deleteEntry: (bookId: string, entryId: string) => void;
+
+  // Activation
+  setBookActive: (bookId: string, active: boolean) => void;
+  toggleBookActive: (bookId: string) => void;
+  setScanDepth: (depth: number) => void;
+
+  // Import / export
+  exportBookJson: (bookId: string) => string | null;
+  importBookJson: (json: string, fallbackName?: string) => WorldInfoBook | null;
+
+  clearError: () => void;
+}
+
+export const useWorldInfoStore = create<WorldInfoState>((set, get) => ({
+  books: loadBooks(),
+  activeBookIds: loadActiveBooks(),
+  scanDepth: loadScanDepth(),
+  error: null,
+
+  createBook: (name) => {
+    const trimmed = name.trim() || 'Untitled Lorebook';
+    const now = Date.now();
+    const book: WorldInfoBook = {
+      id: generateId('wibook'),
+      name: trimmed,
+      entries: [],
+      createdAt: now,
+      updatedAt: now,
+    };
+    const next = [...get().books, book];
+    saveBooks(next);
+    set({ books: next });
+    return book;
+  },
+
+  renameBook: (bookId, name) => {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    const next = get().books.map((b) =>
+      b.id === bookId ? { ...b, name: trimmed, updatedAt: Date.now() } : b
+    );
+    saveBooks(next);
+    set({ books: next });
+  },
+
+  deleteBook: (bookId) => {
+    const next = get().books.filter((b) => b.id !== bookId);
+    const activeNext = get().activeBookIds.filter((id) => id !== bookId);
+    saveBooks(next);
+    saveActiveBooks(activeNext);
+    set({ books: next, activeBookIds: activeNext });
+  },
+
+  duplicateBook: (bookId) => {
+    const original = get().books.find((b) => b.id === bookId);
+    if (!original) return null;
+    const now = Date.now();
+    const copy: WorldInfoBook = {
+      id: generateId('wibook'),
+      name: `${original.name} (Copy)`,
+      entries: original.entries.map((e) => ({
+        ...e,
+        id: generateId('wi'),
+        createdAt: now,
+        updatedAt: now,
+      })),
+      createdAt: now,
+      updatedAt: now,
+    };
+    const next = [...get().books, copy];
+    saveBooks(next);
+    set({ books: next });
+    return copy;
+  },
+
+  createEntry: (bookId, data) => {
+    const book = get().books.find((b) => b.id === bookId);
+    if (!book) {
+      set({ error: 'Lorebook not found' });
+      return null;
+    }
+    const now = Date.now();
+    const entry: WorldInfoEntry = {
+      ...DEFAULT_ENTRY,
+      ...(data || {}),
+      id: generateId('wi'),
+      createdAt: now,
+      updatedAt: now,
+    };
+    const next = get().books.map((b) =>
+      b.id === bookId
+        ? { ...b, entries: [...b.entries, entry], updatedAt: now }
+        : b
+    );
+    saveBooks(next);
+    set({ books: next });
+    return entry;
+  },
+
+  updateEntry: (bookId, entryId, data) => {
+    const now = Date.now();
+    const next = get().books.map((b) => {
+      if (b.id !== bookId) return b;
+      return {
+        ...b,
+        entries: b.entries.map((e) =>
+          e.id === entryId ? { ...e, ...data, updatedAt: now } : e
+        ),
+        updatedAt: now,
+      };
+    });
+    saveBooks(next);
+    set({ books: next });
+  },
+
+  deleteEntry: (bookId, entryId) => {
+    const now = Date.now();
+    const next = get().books.map((b) =>
+      b.id === bookId
+        ? {
+            ...b,
+            entries: b.entries.filter((e) => e.id !== entryId),
+            updatedAt: now,
+          }
+        : b
+    );
+    saveBooks(next);
+    set({ books: next });
+  },
+
+  setBookActive: (bookId, active) => {
+    const cur = get().activeBookIds;
+    const has = cur.includes(bookId);
+    let next = cur;
+    if (active && !has) next = [...cur, bookId];
+    else if (!active && has) next = cur.filter((id) => id !== bookId);
+    else return;
+    saveActiveBooks(next);
+    set({ activeBookIds: next });
+  },
+
+  toggleBookActive: (bookId) => {
+    const cur = get().activeBookIds;
+    const next = cur.includes(bookId)
+      ? cur.filter((id) => id !== bookId)
+      : [...cur, bookId];
+    saveActiveBooks(next);
+    set({ activeBookIds: next });
+  },
+
+  setScanDepth: (depth) => {
+    const d = Math.max(1, Math.min(50, Math.floor(depth)));
+    saveScanDepth(d);
+    set({ scanDepth: d });
+  },
+
+  exportBookJson: (bookId) => {
+    const book = get().books.find((b) => b.id === bookId);
+    if (!book) return null;
+    return JSON.stringify(bookToStFormat(book), null, 2);
+  },
+
+  importBookJson: (json, fallbackName) => {
+    try {
+      const parsed = JSON.parse(json) as StBook;
+      if (!parsed || typeof parsed !== 'object') {
+        set({ error: 'Invalid lorebook JSON' });
+        return null;
+      }
+      // Accept either { entries: ... } (ST format) OR a bare object where
+      // the top level is the entries map.
+      let book: WorldInfoBook;
+      if ('entries' in parsed && parsed.entries) {
+        book = bookFromStFormat(fallbackName || 'Imported Lorebook', parsed);
+      } else {
+        // Treat the whole object as an entries map.
+        book = bookFromStFormat(fallbackName || 'Imported Lorebook', {
+          entries: parsed as unknown as Record<string, StEntry>,
+        });
+      }
+      const next = [...get().books, book];
+      saveBooks(next);
+      set({ books: next, error: null });
+      return book;
+    } catch (err) {
+      set({
+        error: err instanceof Error ? err.message : 'Failed to parse JSON',
+      });
+      return null;
+    }
+  },
+
+  clearError: () => set({ error: null }),
+}));


### PR DESCRIPTION
Adds keyword-triggered lore injection: a worldInfoStore with per-book CRUD, entry CRUD (keys, content, position, order, constant, case sensitivity, @depth), a scanner that matches recent messages against active books, and injection into buildConversationContext at five position slots. UI at /settings/worldinfo and a nav card from /settings. JSON import/export uses SillyTavern's lorebook format for interop.