### PR TITLE
Add Phase 4.3: character-embedded lorebooks

### DIFF
--- a/src/components/character/CharacterEdit.tsx
+++ b/src/components/character/CharacterEdit.tsx
@@ -4,6 +4,7 @@ import { useCharacterStore } from '../../stores/characterStore';
 import { spritesApi, type CharacterInfo } from '../../api/client';
 import { Modal, Button, Input, TextArea, ImageUpload, ExpressionUpload } from '../ui';
 import { AlternateGreetingsEditor } from './AlternateGreetingsEditor';
+import { CharacterLorebookSection } from './CharacterLorebookSection';
 
 interface CharacterEditProps {
   isOpen: boolean;
@@ -32,6 +33,8 @@ export function CharacterEdit({
     clearError,
     exportCharacterAsPNG,
     exportCharacterAsJSON,
+    getLinkedBookIds,
+    setLinkedBookIds,
   } = useCharacterStore();
   const [showExportMenu, setShowExportMenu] = useState(false);
 
@@ -59,6 +62,8 @@ export function CharacterEdit({
   const [systemPromptOverride, setSystemPromptOverride] = useState('');
   const [postHistoryInstructions, setPostHistoryInstructions] = useState('');
   const [talkativeness, setTalkativeness] = useState('0.5');
+  // Phase 4.3: extra linked lorebooks (staged, committed on Save)
+  const [linkedBookIds, setLinkedBookIdsLocal] = useState<string[]>([]);
 
   const getAvatarUrl = (avatar: string) => `/thumbnail?type=avatar&file=${encodeURIComponent(avatar)}`;
 
@@ -102,8 +107,11 @@ export function CharacterEdit({
 
       const charTalkativeness = character.data?.extensions?.talkativeness;
       setTalkativeness(typeof charTalkativeness === 'string' ? charTalkativeness : '0.5');
+
+      // Phase 4.3: hydrate linked lorebook ids for this character
+      setLinkedBookIdsLocal(getLinkedBookIds(character.avatar));
     }
-  }, [isOpen, character]);
+  }, [isOpen, character, getLinkedBookIds]);
 
   const handleExportPNG = async () => {
     setShowExportMenu(false);
@@ -157,6 +165,9 @@ export function CharacterEdit({
     );
 
     if (success) {
+      // Persist linked lorebook selections (client-side only)
+      setLinkedBookIds(character.avatar, linkedBookIds);
+
       // Upload expression images if any
       if (expressionFiles.size > 0) {
         setIsUploadingExpressions(true);
@@ -343,6 +354,13 @@ export function CharacterEdit({
         <ExpressionUpload
           characterName={character.name}
           onExpressionsChange={setExpressionFiles}
+        />
+
+        {/* Phase 4.3: Character lorebooks */}
+        <CharacterLorebookSection
+          avatar={character.avatar}
+          linkedBookIds={linkedBookIds}
+          onLinkedBookIdsChange={setLinkedBookIdsLocal}
         />
 
         {/* Collapsible Advanced Section */}

--- a/src/components/character/CharacterImport.tsx
+++ b/src/components/character/CharacterImport.tsx
@@ -1,8 +1,9 @@
 import { useState, useRef } from 'react';
-import { Upload, FileImage, FileJson, X } from 'lucide-react';
+import { Upload, FileImage, FileJson, X, BookOpen } from 'lucide-react';
 import { useCharacterStore } from '../../stores/characterStore';
 import { Modal, Button, Input, TextArea, ImageUpload } from '../ui';
 import type { CharacterInfo } from '../../api/client';
+import type { CharacterBookV2 } from '../../utils/characterCard';
 
 interface CharacterImportProps {
   isOpen: boolean;
@@ -14,6 +15,7 @@ export function CharacterImport({ isOpen, onClose, onImported }: CharacterImport
   const {
     importCharacter,
     createCharacter,
+    registerEmbeddedBookFromCard,
     isImporting,
     isCreating,
     error,
@@ -24,6 +26,7 @@ export function CharacterImport({ isOpen, onClose, onImported }: CharacterImport
   const [importedData, setImportedData] = useState<Partial<CharacterInfo> | null>(null);
   const [avatarFile, setAvatarFile] = useState<File | null>(null);
   const [avatarPreview, setAvatarPreview] = useState<string | null>(null);
+  const [importedBook, setImportedBook] = useState<CharacterBookV2 | null>(null);
   const [formData, setFormData] = useState({
     name: '',
     description: '',
@@ -45,6 +48,7 @@ export function CharacterImport({ isOpen, onClose, onImported }: CharacterImport
 
     if (result) {
       setImportedData(result.data);
+      setImportedBook(result.characterBook || null);
       if (result.avatarFile) {
         setAvatarFile(result.avatarFile);
         // Create preview URL
@@ -112,6 +116,15 @@ export function CharacterImport({ isOpen, onClose, onImported }: CharacterImport
     );
 
     if (avatarUrl) {
+      // Persist the character's embedded lorebook after the server assigns
+      // the final avatar filename.
+      if (importedBook) {
+        registerEmbeddedBookFromCard(
+          avatarUrl,
+          importedBook,
+          `${formData.name.trim() || 'Character'} Lorebook`
+        );
+      }
       handleClose();
       onImported?.(avatarUrl);
     }
@@ -123,6 +136,7 @@ export function CharacterImport({ isOpen, onClose, onImported }: CharacterImport
       URL.revokeObjectURL(avatarPreview);
     }
     setImportedData(null);
+    setImportedBook(null);
     setAvatarFile(null);
     setAvatarPreview(null);
     setFormData({
@@ -165,6 +179,7 @@ export function CharacterImport({ isOpen, onClose, onImported }: CharacterImport
 
     if (result) {
       setImportedData(result.data);
+      setImportedBook(result.characterBook || null);
       if (result.avatarFile) {
         setAvatarFile(result.avatarFile);
         const previewUrl = URL.createObjectURL(result.avatarFile);
@@ -258,6 +273,7 @@ export function CharacterImport({ isOpen, onClose, onImported }: CharacterImport
               type="button"
               onClick={() => {
                 setImportedData(null);
+                setImportedBook(null);
                 setAvatarFile(null);
                 if (avatarPreview) {
                   URL.revokeObjectURL(avatarPreview);
@@ -269,6 +285,22 @@ export function CharacterImport({ isOpen, onClose, onImported }: CharacterImport
               <X size={16} />
             </button>
           </div>
+
+          {/* Embedded Lorebook Notice */}
+          {importedBook && (
+            <div className="p-3 bg-[var(--color-primary)]/10 border border-[var(--color-primary)]/40 rounded-lg flex items-center gap-2.5 text-sm text-[var(--color-text-primary)]">
+              <BookOpen size={16} className="text-[var(--color-primary)] shrink-0" />
+              <div className="flex-1 min-w-0">
+                <p className="font-medium">Embedded lorebook detected</p>
+                <p className="text-xs text-[var(--color-text-secondary)] truncate">
+                  {importedBook.name || 'Character Lorebook'} ·{' '}
+                  {importedBook.entries?.length ?? 0} entr
+                  {(importedBook.entries?.length ?? 0) === 1 ? 'y' : 'ies'} — will
+                  auto-activate when this character is selected.
+                </p>
+              </div>
+            </div>
+          )}
 
           {/* Avatar */}
           <ImageUpload

--- a/src/components/character/CharacterLorebookSection.tsx
+++ b/src/components/character/CharacterLorebookSection.tsx
@@ -1,0 +1,135 @@
+import { useState } from 'react';
+import { BookOpen, Edit2 } from 'lucide-react';
+import { useWorldInfoStore } from '../../stores/worldInfoStore';
+import { WorldInfoBookEditor } from '../worldinfo/WorldInfoBookEditor';
+
+interface CharacterLorebookSectionProps {
+  /** The character's avatar filename (unique id). */
+  avatar: string;
+  /** Currently-linked extra book ids (staged). */
+  linkedBookIds: string[];
+  /** Called with the new full list whenever the user toggles a checkbox. */
+  onLinkedBookIdsChange: (ids: string[]) => void;
+}
+
+/**
+ * CharacterEdit sub-section that surfaces the character's embedded
+ * lorebook (if any) and lets the user attach extra non-owner global
+ * lorebooks to auto-activate whenever the character is selected.
+ */
+export function CharacterLorebookSection({
+  avatar,
+  linkedBookIds,
+  onLinkedBookIdsChange,
+}: CharacterLorebookSectionProps) {
+  const books = useWorldInfoStore((s) => s.books);
+  const [editingEmbedded, setEditingEmbedded] = useState(false);
+
+  const embeddedBook = books.find((b) => b.ownerCharacterAvatar === avatar);
+  // Only non-character-owned books are eligible to be linked as extras
+  // (picking another character's embedded book would be surprising).
+  const candidateBooks = books.filter((b) => b.ownerCharacterAvatar == null);
+
+  const toggleLink = (bookId: string) => {
+    if (linkedBookIds.includes(bookId)) {
+      onLinkedBookIdsChange(linkedBookIds.filter((id) => id !== bookId));
+    } else {
+      onLinkedBookIdsChange([...linkedBookIds, bookId]);
+    }
+  };
+
+  return (
+    <section className="space-y-3">
+      <div className="flex items-center gap-2">
+        <BookOpen size={16} className="text-[var(--color-text-secondary)]" />
+        <h3 className="text-sm font-medium text-[var(--color-text-primary)]">
+          Lorebooks
+        </h3>
+      </div>
+
+      {/* Embedded book */}
+      <div className="rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-tertiary)] p-3">
+        <p className="text-xs font-medium text-[var(--color-text-secondary)] uppercase tracking-wide mb-2">
+          Embedded Lorebook
+        </p>
+        {embeddedBook ? (
+          <div className="flex items-center gap-2">
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-medium text-[var(--color-text-primary)] truncate">
+                {embeddedBook.name}
+              </p>
+              <p className="text-xs text-[var(--color-text-secondary)]">
+                {embeddedBook.entries.length} entr
+                {embeddedBook.entries.length === 1 ? 'y' : 'ies'} · auto-active
+                for this character
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => setEditingEmbedded(true)}
+              className="shrink-0 flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-xs text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-secondary)] border border-[var(--color-border)]"
+              aria-label="Edit embedded lorebook"
+            >
+              <Edit2 size={13} />
+              Edit
+            </button>
+          </div>
+        ) : (
+          <p className="text-sm text-[var(--color-text-secondary)]">
+            No embedded lorebook. One will be created automatically if you
+            import a character card that contains one.
+          </p>
+        )}
+      </div>
+
+      {/* Linked books */}
+      <div className="rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-tertiary)] p-3">
+        <p className="text-xs font-medium text-[var(--color-text-secondary)] uppercase tracking-wide mb-2">
+          Additional Lorebooks
+        </p>
+        {candidateBooks.length === 0 ? (
+          <p className="text-sm text-[var(--color-text-secondary)]">
+            No global lorebooks exist yet. Create some in Settings → World
+            Info.
+          </p>
+        ) : (
+          <ul className="space-y-1.5">
+            {candidateBooks.map((book) => {
+              const checked = linkedBookIds.includes(book.id);
+              return (
+                <li key={book.id}>
+                  <label className="flex items-center gap-2.5 cursor-pointer rounded-md px-1.5 py-1 hover:bg-[var(--color-bg-secondary)]">
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      onChange={() => toggleLink(book.id)}
+                      className="w-4 h-4 accent-[var(--color-primary)]"
+                    />
+                    <span className="flex-1 min-w-0 text-sm text-[var(--color-text-primary)] truncate">
+                      {book.name}
+                    </span>
+                    <span className="text-xs text-[var(--color-text-secondary)]">
+                      {book.entries.length}
+                    </span>
+                  </label>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+        <p className="mt-2 text-xs text-[var(--color-text-secondary)]">
+          Linked books are auto-activated (in addition to globally-active
+          books) whenever this character is the scan target.
+        </p>
+      </div>
+
+      {embeddedBook && editingEmbedded && (
+        <WorldInfoBookEditor
+          isOpen={editingEmbedded}
+          onClose={() => setEditingEmbedded(false)}
+          book={embeddedBook}
+        />
+      )}
+    </section>
+  );
+}

--- a/src/components/worldinfo/WorldInfoPage.tsx
+++ b/src/components/worldinfo/WorldInfoPage.tsx
@@ -47,6 +47,11 @@ export function WorldInfoPage() {
   const [importNotice, setImportNotice] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
+  // Character-embedded books are managed from the character editor; hide
+  // them from the global lorebook list to avoid confusion.
+  const globalBooks = books.filter((b) => b.ownerCharacterAvatar == null);
+  const charOwnedCount = books.length - globalBooks.length;
+
   const handleCreate = () => {
     const trimmed = newBookName.trim();
     if (!trimmed) return;
@@ -272,7 +277,7 @@ export function WorldInfoPage() {
             </Button>
           </div>
 
-          {books.length === 0 ? (
+          {globalBooks.length === 0 ? (
             <div className="text-center py-10">
               <BookOpen
                 size={48}
@@ -284,10 +289,17 @@ export function WorldInfoPage() {
               <p className="text-xs text-[var(--color-text-secondary)]">
                 Create one above, or import an existing World Info JSON.
               </p>
+              {charOwnedCount > 0 && (
+                <p className="mt-2 text-xs text-[var(--color-text-secondary)]">
+                  {charOwnedCount} character-embedded lorebook
+                  {charOwnedCount === 1 ? ' is' : 's are'} managed from the
+                  character editor.
+                </p>
+              )}
             </div>
           ) : (
             <ul className="space-y-2">
-              {books.map((book) => {
+              {globalBooks.map((book) => {
                 const isActive = activeBookIds.includes(book.id);
                 const isRenaming = renamingId === book.id;
                 return (
@@ -390,6 +402,13 @@ export function WorldInfoPage() {
             Lorebooks are stored locally. Active books are scanned against recent
             messages; matching entries are injected at their configured position.
           </p>
+          {globalBooks.length > 0 && charOwnedCount > 0 && (
+            <p className="mt-2 text-xs text-[var(--color-text-secondary)]">
+              {charOwnedCount} character-embedded lorebook
+              {charOwnedCount === 1 ? '' : 's'} hidden (managed from the
+              character editor).
+            </p>
+          )}
         </section>
       </div>
 

--- a/src/stores/characterStore.ts
+++ b/src/stores/characterStore.ts
@@ -2,17 +2,24 @@ import { create } from 'zustand';
 import { api, type CharacterInfo, type CharacterCreateData, type CharacterEditData } from '../api/client';
 import {
   extractCharacterFromPNG,
+  extractCharacterBook,
   parseCharacterFromJSON,
   cardToCharacterInfo,
   embedCharacterInPNG,
   exportCharacterAsJSON,
   downloadFile,
   fetchImageAsBlob,
+  type CharacterBookV2,
   type CharacterCardV2,
   type CharacterExportData,
 } from '../utils/characterCard';
+import {
+  useWorldInfoStore,
+  bookToCharacterBookV2,
+} from './worldInfoStore';
 
 const FAVORITES_KEY = 'sillytavern_character_favorites';
+const LINKED_BOOKS_KEY = 'sillytavern_character_linked_books_v1';
 
 function loadFavorites(): Set<string> {
   try {
@@ -27,6 +34,28 @@ function loadFavorites(): Set<string> {
 
 function saveFavorites(favorites: Set<string>) {
   localStorage.setItem(FAVORITES_KEY, JSON.stringify(Array.from(favorites)));
+}
+
+function loadLinkedBooks(): Record<string, string[]> {
+  try {
+    const raw = localStorage.getItem(LINKED_BOOKS_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object') {
+      return parsed as Record<string, string[]>;
+    }
+    return {};
+  } catch {
+    return {};
+  }
+}
+
+function saveLinkedBooks(map: Record<string, string[]>) {
+  try {
+    localStorage.setItem(LINKED_BOOKS_KEY, JSON.stringify(map));
+  } catch {
+    // ignore quota/security errors
+  }
 }
 
 export type CharacterSortMode = 'name' | 'date_added' | 'date_last_chat' | 'recent_chat';
@@ -50,6 +79,10 @@ interface CharacterState {
   selectedTags: Set<string>;
   showFavoritesOnly: boolean;
   sortMode: CharacterSortMode;
+  // Per-character extra lorebooks to auto-activate (avatar → book ids).
+  // The embedded book (if any) is tracked on the WI book itself via
+  // `ownerCharacterAvatar` and is NOT duplicated here.
+  linkedBookIdsByAvatar: Record<string, string[]>;
 
   // Actions
   fetchCharacters: () => Promise<void>;
@@ -67,9 +100,25 @@ interface CharacterState {
   isCharacterInGroup: (avatar: string) => boolean;
   setGroupChatCharacters: (avatars: string[]) => Promise<void>;
   // Import/Export actions
-  importCharacter: (file: File) => Promise<{ data: Partial<CharacterInfo>; avatarFile?: File } | null>;
+  importCharacter: (
+    file: File
+  ) => Promise<{
+    data: Partial<CharacterInfo>;
+    avatarFile?: File;
+    characterBook?: CharacterBookV2;
+  } | null>;
   exportCharacterAsPNG: (character: CharacterInfo) => Promise<void>;
   exportCharacterAsJSON: (character: CharacterInfo) => void;
+  // Character-embedded lorebook actions
+  registerEmbeddedBookFromCard: (
+    avatar: string,
+    characterBook: CharacterBookV2,
+    fallbackName: string
+  ) => void;
+  getLinkedBookIds: (avatar: string) => string[];
+  setLinkedBookIds: (avatar: string, ids: string[]) => void;
+  /** Ids to merge with the globally-active ids during scan. */
+  getActiveBookIdsForCharacter: (avatar: string) => string[];
   // Organization actions
   toggleFavorite: (avatar: string) => void;
   isFavorite: (avatar: string) => boolean;
@@ -99,6 +148,7 @@ export const useCharacterStore = create<CharacterState>((set, get) => ({
   selectedTags: new Set<string>(),
   showFavoritesOnly: false,
   sortMode: 'name' as CharacterSortMode,
+  linkedBookIdsByAvatar: loadLinkedBooks(),
 
   fetchCharacters: async () => {
     set({ isLoading: true, error: null });
@@ -193,7 +243,7 @@ export const useCharacterStore = create<CharacterState>((set, get) => ({
     try {
       await api.deleteCharacter(avatar);
       // Clear selection if deleting the selected character
-      const { selectedCharacter, favorites } = get();
+      const { selectedCharacter, favorites, linkedBookIdsByAvatar } = get();
       if (selectedCharacter?.avatar === avatar) {
         set({ selectedCharacter: null });
       }
@@ -203,6 +253,14 @@ export const useCharacterStore = create<CharacterState>((set, get) => ({
         newFavorites.delete(avatar);
         saveFavorites(newFavorites);
         set({ favorites: newFavorites });
+      }
+      // Clean up character-embedded lorebook and linked-book references
+      useWorldInfoStore.getState().deleteCharacterBook(avatar);
+      if (linkedBookIdsByAvatar[avatar]) {
+        const nextLinks = { ...linkedBookIdsByAvatar };
+        delete nextLinks[avatar];
+        saveLinkedBooks(nextLinks);
+        set({ linkedBookIdsByAvatar: nextLinks });
       }
       // Refresh the character list
       await get().fetchCharacters();
@@ -461,8 +519,9 @@ export const useCharacterStore = create<CharacterState>((set, get) => ({
       }
 
       const info = cardToCharacterInfo(characterData);
+      const characterBook = extractCharacterBook(characterData) || undefined;
       set({ isImporting: false });
-      return { data: info, avatarFile };
+      return { data: info, avatarFile, characterBook };
     } catch (error) {
       set({
         isImporting: false,
@@ -479,8 +538,12 @@ export const useCharacterStore = create<CharacterState>((set, get) => ({
       const avatarUrl = `/characters/${encodeURIComponent(character.avatar)}`;
       const imageBlob = await fetchImageAsBlob(avatarUrl);
 
+      // Include the character's embedded lorebook when exporting
+      const embedded = useWorldInfoStore.getState().getCharacterBook(character.avatar);
+      const characterBook = embedded ? bookToCharacterBookV2(embedded) : undefined;
+
       // Embed character data in the PNG
-      const pngBlob = await embedCharacterInPNG(imageBlob, character);
+      const pngBlob = await embedCharacterInPNG(imageBlob, character, characterBook);
 
       // Download the file
       const filename = `${character.name.replace(/[^a-zA-Z0-9]/g, '_')}.png`;
@@ -497,7 +560,9 @@ export const useCharacterStore = create<CharacterState>((set, get) => ({
 
   exportCharacterAsJSON: (character: CharacterInfo) => {
     try {
-      const jsonBlob = exportCharacterAsJSON(character);
+      const embedded = useWorldInfoStore.getState().getCharacterBook(character.avatar);
+      const characterBook = embedded ? bookToCharacterBookV2(embedded) : undefined;
+      const jsonBlob = exportCharacterAsJSON(character, characterBook);
       const filename = `${character.name.replace(/[^a-zA-Z0-9]/g, '_')}.json`;
       downloadFile(jsonBlob, filename);
     } catch (error) {
@@ -505,5 +570,57 @@ export const useCharacterStore = create<CharacterState>((set, get) => ({
         error: error instanceof Error ? error.message : 'Failed to export character',
       });
     }
+  },
+
+  // ---- Character-embedded lorebook actions ----
+  registerEmbeddedBookFromCard: (avatar, characterBook, fallbackName) => {
+    useWorldInfoStore
+      .getState()
+      .upsertCharacterBook(avatar, characterBook, fallbackName);
+  },
+
+  getLinkedBookIds: (avatar) => {
+    return get().linkedBookIdsByAvatar[avatar] || [];
+  },
+
+  setLinkedBookIds: (avatar, ids) => {
+    // Drop missing books + character-owned books belonging to a different
+    // character. A user linking a book for character A should not be able
+    // to scope-activate character B's embedded book.
+    const allBooks = useWorldInfoStore.getState().books;
+    const valid = ids.filter((id) => {
+      const book = allBooks.find((b) => b.id === id);
+      if (!book) return false;
+      if (book.ownerCharacterAvatar && book.ownerCharacterAvatar !== avatar) {
+        return false;
+      }
+      return true;
+    });
+    const deduped = Array.from(new Set(valid));
+    const next = { ...get().linkedBookIdsByAvatar, [avatar]: deduped };
+    if (deduped.length === 0) {
+      delete next[avatar];
+    }
+    saveLinkedBooks(next);
+    set({ linkedBookIdsByAvatar: next });
+  },
+
+  getActiveBookIdsForCharacter: (avatar) => {
+    if (!avatar) return [];
+    const ids: string[] = [];
+    const embedded = useWorldInfoStore.getState().getCharacterBook(avatar);
+    if (embedded) ids.push(embedded.id);
+    const linked = get().linkedBookIdsByAvatar[avatar] || [];
+    const allBooks = useWorldInfoStore.getState().books;
+    for (const linkedId of linked) {
+      if (ids.includes(linkedId)) continue; // avoid double-adding the embedded id
+      const book = allBooks.find((b) => b.id === linkedId);
+      if (!book) continue;
+      if (book.ownerCharacterAvatar && book.ownerCharacterAvatar !== avatar) {
+        continue;
+      }
+      ids.push(linkedId);
+    }
+    return ids;
   },
 }));

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -3,6 +3,7 @@ import { api, type CharacterInfo, type GenerationOptions } from '../api/client';
 import { useSettingsStore } from './settingsStore';
 import { usePersonaStore } from './personaStore';
 import { useGenerationStore } from './generationStore';
+import { useCharacterStore } from './characterStore';
 import {
   useWorldInfoStore,
   scanMessagesForEntries,
@@ -260,12 +261,21 @@ function buildConversationContext(
   );
   const sub = (text: string) => (text ? processMacros(text, macroCtx) : '');
 
-  // Scan active world info books for keyword matches against recent history
+  // Scan active world info books for keyword matches against recent history.
+  // The character's embedded book + per-character linked books are
+  // auto-activated at scan time (scoped to this call), leaving the global
+  // `activeBookIds` list untouched as the user navigates between characters.
   const wiState = useWorldInfoStore.getState();
+  const charBookIds = useCharacterStore
+    .getState()
+    .getActiveBookIdsForCharacter(character.avatar || '');
+  const scanBookIds = Array.from(
+    new Set([...wiState.activeBookIds, ...charBookIds])
+  );
   const tokenProfile = profileForProvider(activeProvider);
   const matchedEntries = scanMessagesForEntries(
     wiState.books,
-    wiState.activeBookIds,
+    scanBookIds,
     messages,
     {
       scanDepth: wiState.scanDepth,

--- a/src/stores/worldInfoStore.ts
+++ b/src/stores/worldInfoStore.ts
@@ -1,5 +1,9 @@
 import { create } from 'zustand';
 import { estimateTokens, type TokenizerProfile } from '../utils/tokenizer';
+import type {
+  CharacterBookV2,
+  CharacterBookEntryV2,
+} from '../utils/characterCard';
 
 // Where a world info entry is injected relative to the character definitions
 // and the rest of the prompt. These map 1:1 onto SillyTavern's position codes
@@ -65,6 +69,13 @@ export interface WorldInfoBook {
   id: string;
   name: string;
   entries: WorldInfoEntry[];
+  /**
+   * Non-null when this book is embedded in / owned by a character card
+   * (its avatar filename). Character-owned books are hidden from the
+   * global lorebook list and are auto-activated when that character is
+   * selected. Null = a normal global book.
+   */
+  ownerCharacterAvatar: string | null;
   createdAt: number;
   updatedAt: number;
 }
@@ -108,7 +119,15 @@ export const DEFAULT_ENTRY: Omit<
 function loadBooks(): WorldInfoBook[] {
   try {
     const raw = localStorage.getItem(BOOKS_KEY);
-    return raw ? (JSON.parse(raw) as WorldInfoBook[]) : [];
+    const list = raw ? (JSON.parse(raw) as WorldInfoBook[]) : [];
+    // Backfill `ownerCharacterAvatar` for books saved before it existed.
+    return list.map((b) => ({
+      ...b,
+      ownerCharacterAvatar:
+        typeof b.ownerCharacterAvatar === 'string'
+          ? b.ownerCharacterAvatar
+          : null,
+    }));
   } catch {
     return [];
   }
@@ -373,6 +392,7 @@ export function bookFromStFormat(name: string, raw: StBook): WorldInfoBook {
     id: generateId('wibook'),
     name: raw.name || name || 'Imported Lorebook',
     entries: list.map(entryFromStFormat),
+    ownerCharacterAvatar: null,
     createdAt: now,
     updatedAt: now,
   };
@@ -384,6 +404,161 @@ export function bookToStFormat(book: WorldInfoBook): StBook {
     entries[String(idx)] = entryToStFormat(e, idx);
   });
   return { name: book.name, entries };
+}
+
+// ---- Character Card V2 character_book interop --------------------------
+//
+// The V2 card spec embeds a lorebook as `data.character_book` with a
+// different shape than ST's standalone export: entries are an *array*,
+// `position` is the string "before_char"|"after_char", `insertion_order`
+// replaces `order`, and our ST-specific fields (depth, scanDepth,
+// probability, groups, recursion flags, numeric-position override, etc.)
+// go under `entry.extensions` so that SillyTavern can round-trip them.
+
+interface CharacterBookExtensions {
+  position?: number; // ST 0-6 numeric position; overrides the spec's string position
+  depth?: number;
+  scan_depth?: number | null;
+  probability?: number;
+  useProbability?: boolean;
+  selectiveLogic?: number;
+  group?: string;
+  group_override?: boolean;
+  group_weight?: number;
+  prevent_recursion?: boolean;
+  exclude_recursion?: boolean;
+}
+
+function positionFromString(
+  pos: string | undefined
+): WorldInfoPosition {
+  return pos === 'after_char' ? 'after_char' : 'before_char';
+}
+
+function positionToString(
+  pos: WorldInfoPosition
+): 'before_char' | 'after_char' {
+  // The V2 spec only has two positions; everything that isn't `after_char`
+  // falls back to `before_char`. Full ST position code is preserved in
+  // extensions.position so ST can recover the original on import.
+  return pos === 'after_char' ? 'after_char' : 'before_char';
+}
+
+export function entryFromCharacterBookV2(
+  raw: CharacterBookEntryV2
+): WorldInfoEntry {
+  const now = Date.now();
+  const ext = (raw.extensions || {}) as CharacterBookExtensions;
+
+  // Prefer the ST numeric position in extensions when present (it can
+  // express at_depth / before_an / after_an which the spec's two-state
+  // string cannot).
+  const position: WorldInfoPosition =
+    typeof ext.position === 'number'
+      ? ST_POS_TO_LOCAL[ext.position] || positionFromString(raw.position)
+      : positionFromString(raw.position);
+
+  const logic: SelectiveLogic =
+    typeof ext.selectiveLogic === 'number'
+      ? ST_LOGIC_TO_LOCAL[ext.selectiveLogic] || 'AND_ANY'
+      : 'AND_ANY';
+
+  return {
+    id: generateId('wi'),
+    keys: pickStringArray(raw.keys),
+    content: typeof raw.content === 'string' ? raw.content : '',
+    comment: typeof raw.comment === 'string' ? raw.comment : '',
+    enabled: raw.enabled !== false,
+    constant: raw.constant === true,
+    caseSensitive: raw.case_sensitive === true,
+    position,
+    depth: typeof ext.depth === 'number' ? ext.depth : DEFAULT_ENTRY.depth,
+    order:
+      typeof raw.insertion_order === 'number'
+        ? raw.insertion_order
+        : DEFAULT_ENTRY.order,
+    keysSecondary: pickStringArray(raw.secondary_keys),
+    selective: raw.selective === true,
+    selectiveLogic: logic,
+    scanDepth:
+      typeof ext.scan_depth === 'number' && ext.scan_depth >= 0
+        ? Math.floor(ext.scan_depth)
+        : null,
+    probability:
+      typeof ext.probability === 'number'
+        ? clamp(ext.probability, 0, 100)
+        : 100,
+    useProbability: ext.useProbability === true,
+    group: typeof ext.group === 'string' ? ext.group : '',
+    groupOverride: ext.group_override === true,
+    groupWeight:
+      typeof ext.group_weight === 'number' && ext.group_weight > 0
+        ? ext.group_weight
+        : 100,
+    preventRecursion: ext.prevent_recursion === true,
+    excludeRecursion: ext.exclude_recursion === true,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+export function entryToCharacterBookV2(
+  entry: WorldInfoEntry,
+  id: number
+): CharacterBookEntryV2 {
+  const extensions: CharacterBookExtensions = {
+    position: LOCAL_POS_TO_ST[entry.position],
+    depth: entry.depth,
+    scan_depth: entry.scanDepth,
+    probability: entry.probability,
+    useProbability: entry.useProbability,
+    selectiveLogic: LOCAL_LOGIC_TO_ST[entry.selectiveLogic],
+    group: entry.group,
+    group_override: entry.groupOverride,
+    group_weight: entry.groupWeight,
+    prevent_recursion: entry.preventRecursion,
+    exclude_recursion: entry.excludeRecursion,
+  };
+  return {
+    id,
+    keys: entry.keys,
+    secondary_keys: entry.keysSecondary,
+    content: entry.content,
+    comment: entry.comment,
+    enabled: entry.enabled,
+    constant: entry.constant,
+    selective: entry.selective,
+    case_sensitive: entry.caseSensitive,
+    insertion_order: entry.order,
+    position: positionToString(entry.position),
+    name: entry.comment,
+    priority: entry.order,
+    extensions: extensions as unknown as Record<string, unknown>,
+  };
+}
+
+export function bookFromCharacterBookV2(
+  raw: CharacterBookV2,
+  fallbackName: string,
+  ownerCharacterAvatar: string | null
+): WorldInfoBook {
+  const entries = Array.isArray(raw.entries) ? raw.entries : [];
+  const now = Date.now();
+  return {
+    id: generateId('wibook'),
+    name: raw.name || fallbackName || 'Character Lorebook',
+    entries: entries.map(entryFromCharacterBookV2),
+    ownerCharacterAvatar,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+export function bookToCharacterBookV2(book: WorldInfoBook): CharacterBookV2 {
+  return {
+    name: book.name,
+    entries: book.entries.map((e, idx) => entryToCharacterBookV2(e, idx)),
+  };
 }
 
 // ---- Keyword scanning ----------------------------------------------------
@@ -675,6 +850,16 @@ interface WorldInfoState {
   exportBookJson: (bookId: string) => string | null;
   importBookJson: (json: string, fallbackName?: string) => WorldInfoBook | null;
 
+  // Character-embedded lorebooks: at most one book per character avatar,
+  // auto-scoped to that character's chats.
+  upsertCharacterBook: (
+    ownerAvatar: string,
+    raw: CharacterBookV2,
+    fallbackName: string
+  ) => WorldInfoBook;
+  getCharacterBook: (ownerAvatar: string) => WorldInfoBook | null;
+  deleteCharacterBook: (ownerAvatar: string) => void;
+
   clearError: () => void;
 }
 
@@ -693,6 +878,7 @@ export const useWorldInfoStore = create<WorldInfoState>((set, get) => ({
       id: generateId('wibook'),
       name: trimmed,
       entries: [],
+      ownerCharacterAvatar: null,
       createdAt: now,
       updatedAt: now,
     };
@@ -724,6 +910,8 @@ export const useWorldInfoStore = create<WorldInfoState>((set, get) => ({
     const original = get().books.find((b) => b.id === bookId);
     if (!original) return null;
     const now = Date.now();
+    // Duplicates are always standalone globals so they don't collide with
+    // the original character's embedded-book link.
     const copy: WorldInfoBook = {
       id: generateId('wibook'),
       name: `${original.name} (Copy)`,
@@ -733,6 +921,7 @@ export const useWorldInfoStore = create<WorldInfoState>((set, get) => ({
         createdAt: now,
         updatedAt: now,
       })),
+      ownerCharacterAvatar: null,
       createdAt: now,
       updatedAt: now,
     };
@@ -869,6 +1058,54 @@ export const useWorldInfoStore = create<WorldInfoState>((set, get) => ({
       });
       return null;
     }
+  },
+
+  upsertCharacterBook: (ownerAvatar, raw, fallbackName) => {
+    const existing = get().books.find(
+      (b) => b.ownerCharacterAvatar === ownerAvatar
+    );
+    const now = Date.now();
+    if (existing) {
+      // Preserve the book id (keeps linked-books references stable) and
+      // swap in the freshly-parsed entries + name.
+      const fresh = bookFromCharacterBookV2(raw, fallbackName, ownerAvatar);
+      const updated: WorldInfoBook = {
+        ...existing,
+        name: fresh.name,
+        entries: fresh.entries,
+        ownerCharacterAvatar: ownerAvatar,
+        updatedAt: now,
+      };
+      const next = get().books.map((b) =>
+        b.id === existing.id ? updated : b
+      );
+      saveBooks(next);
+      set({ books: next });
+      return updated;
+    }
+    const book = bookFromCharacterBookV2(raw, fallbackName, ownerAvatar);
+    const next = [...get().books, book];
+    saveBooks(next);
+    set({ books: next });
+    return book;
+  },
+
+  getCharacterBook: (ownerAvatar) => {
+    return (
+      get().books.find((b) => b.ownerCharacterAvatar === ownerAvatar) || null
+    );
+  },
+
+  deleteCharacterBook: (ownerAvatar) => {
+    const existing = get().books.find(
+      (b) => b.ownerCharacterAvatar === ownerAvatar
+    );
+    if (!existing) return;
+    const next = get().books.filter((b) => b.id !== existing.id);
+    const activeNext = get().activeBookIds.filter((id) => id !== existing.id);
+    saveBooks(next);
+    saveActiveBooks(activeNext);
+    set({ books: next, activeBookIds: activeNext });
   },
 
   clearError: () => set({ error: null }),

--- a/src/utils/characterCard.ts
+++ b/src/utils/characterCard.ts
@@ -3,6 +3,38 @@
 
 import type { CharacterInfo } from '../api/client';
 
+// Character Book V2 spec format (embedded inside a character card).
+// This is the on-disk/wire format used by SillyTavern for
+// `data.character_book`. Our internal representation
+// (`WorldInfoBook` / `WorldInfoEntry`) is converted to/from this shape
+// in `worldInfoStore.ts`.
+export interface CharacterBookEntryV2 {
+  keys: string[];
+  content: string;
+  extensions?: Record<string, unknown>;
+  enabled?: boolean;
+  insertion_order?: number;
+  case_sensitive?: boolean;
+  name?: string;
+  priority?: number;
+  id?: number;
+  comment?: string;
+  selective?: boolean;
+  secondary_keys?: string[];
+  constant?: boolean;
+  position?: 'before_char' | 'after_char';
+}
+
+export interface CharacterBookV2 {
+  name?: string;
+  description?: string;
+  scan_depth?: number;
+  token_budget?: number;
+  recursive_scanning?: boolean;
+  extensions?: Record<string, unknown>;
+  entries: CharacterBookEntryV2[];
+}
+
 // Character Card V2 specification format
 export interface CharacterCardV2 {
   spec: 'chara_card_v2';
@@ -21,7 +53,7 @@ export interface CharacterCardV2 {
     system_prompt?: string;
     post_history_instructions?: string;
     alternate_greetings?: string[];
-    character_book?: unknown;
+    character_book?: CharacterBookV2;
     extensions?: {
       depth_prompt?: {
         prompt?: string;
@@ -60,9 +92,15 @@ export interface CharacterExportData {
 }
 
 /**
- * Convert CharacterInfo to Character Card V2 format
+ * Convert CharacterInfo to Character Card V2 format.
+ *
+ * If the caller supplies `characterBook`, it is embedded at
+ * `data.character_book` so the V2 card is self-contained.
  */
-export function characterToCardV2(character: CharacterInfo): CharacterCardV2 {
+export function characterToCardV2(
+  character: CharacterInfo,
+  characterBook?: CharacterBookV2
+): CharacterCardV2 {
   const extensions: CharacterCardV2['data']['extensions'] = {
     ...(character.data?.extensions || {}),
   };
@@ -97,9 +135,28 @@ export function characterToCardV2(character: CharacterInfo): CharacterCardV2 {
       post_history_instructions:
         character.post_history_instructions || character.data?.post_history_instructions || '',
       alternate_greetings: character.alternate_greetings || character.data?.alternate_greetings || [],
+      ...(characterBook ? { character_book: characterBook } : {}),
       extensions,
     },
   };
+}
+
+/**
+ * Pull the embedded character_book off an imported card (if any).
+ * Returns null when the data is missing or malformed.
+ */
+export function extractCharacterBook(
+  card: CharacterCardV2 | CharacterExportData | null | undefined
+): CharacterBookV2 | null {
+  if (!card) return null;
+  if ('spec' in card && card.spec === 'chara_card_v2') {
+    const book = card.data.character_book;
+    if (!book || typeof book !== 'object') return null;
+    const entries = (book as CharacterBookV2).entries;
+    if (!Array.isArray(entries)) return null;
+    return book as CharacterBookV2;
+  }
+  return null;
 }
 
 /**
@@ -342,7 +399,8 @@ function createTextChunk(keyword: string, text: string): Uint8Array {
  */
 export async function embedCharacterInPNG(
   imageBlob: Blob,
-  character: CharacterInfo
+  character: CharacterInfo,
+  characterBook?: CharacterBookV2
 ): Promise<Blob> {
   const buffer = await imageBlob.arrayBuffer();
   const data = new Uint8Array(buffer);
@@ -356,7 +414,7 @@ export async function embedCharacterInPNG(
   }
 
   // Convert character to V2 card and encode as base64
-  const cardData = characterToCardV2(character);
+  const cardData = characterToCardV2(character, characterBook);
   const jsonString = JSON.stringify(cardData);
   const base64Data = btoa(jsonString);
 
@@ -401,8 +459,11 @@ export async function embedCharacterInPNG(
 /**
  * Export character as JSON file (as Character Card V2 so advanced fields survive)
  */
-export function exportCharacterAsJSON(character: CharacterInfo): Blob {
-  const cardV2 = characterToCardV2(character);
+export function exportCharacterAsJSON(
+  character: CharacterInfo,
+  characterBook?: CharacterBookV2
+): Blob {
+  const cardV2 = characterToCardV2(character, characterBook);
   const jsonString = JSON.stringify(cardV2, null, 2);
   return new Blob([jsonString], { type: 'application/json' });
 }


### PR DESCRIPTION
Character Card V2 cards can now round-trip embedded lorebooks (`data.character_book`), and characters can link extra global lorebooks that auto-activate alongside the embedded one whenever the character is the scan target. The global `activeBookIds` list is never mutated per-character — character book ids are merged into the scan list at call-time in `buildConversationContext`.

- Typed `CharacterBookV2` / `CharacterBookEntryV2` in characterCard.ts (replacing `character_book?: unknown`); added `extractCharacterBook`
  + extended `characterToCardV2`, `embedCharacterInPNG`, `exportCharacterAsJSON` to embed the book on export.
- Added `ownerCharacterAvatar` to `WorldInfoBook` with loadBooks backfill + V2 spec converters that pack ST-specific fields (depth, scanDepth, probability, groups, recursion flags, full numeric position) into `entry.extensions` for roundtrip.
- New WI CRUD: `upsertCharacterBook` (idempotent — preserves book id across re-imports), `getCharacterBook`, `deleteCharacterBook`.
- characterStore tracks `linkedBookIdsByAvatar` in localStorage, with a validation guard that rejects linking another character's embedded book. Exposes `getActiveBookIdsForCharacter(avatar)` which returns `[embeddedId?, ...linkedIds]` for the scanner.
- `deleteCharacter` cleans up both the embedded book and linked refs.
- CharacterImport shows an embedded-book banner and calls `registerEmbeddedBookFromCard` after the server assigns the avatar.
- New `CharacterLorebookSection` in CharacterEdit surfaces the embedded book (Edit button opens WorldInfoBookEditor) and a multi-select of linkable global books.
- WorldInfoPage hides character-owned books from the global list and shows a footer note when any are hidden.