### PR TITLE
Add Phase 5.1: group chat activation strategies

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -132,15 +132,19 @@ Features are grouped into **phases** ordered by user impact and dependency. Each
 ## Phase 5: Group Chat Enhancements
 *Goal: Bring group chats to ST-level functionality.*
 
-### 5.1 Activation Strategies
-- **Gap:** Basic sequential group chat exists. No activation mode selection.
-- **ST Feature:** Natural Order (name mentions + talkativeness), List Order, Pooled Order, Manual trigger.
-- **Work:** Add activation strategy selector. Implement Natural Order (parse last message for name mentions, use talkativeness field). Pooled Order (random from non-recent speakers). Manual mode with character trigger buttons.
+### 5.1 Activation Strategies ✅
+- Three strategies selectable per group chat, persisted on the `GroupChatInfo` record:
+  - **List** (default, legacy): every member replies in order on each user turn.
+  - **Natural**: scans the last non-system message for a member name mention (word-boundary, case-insensitive). On match, that member replies; on multi-match, a weighted roll within the matches. With no mention, falls back to a weighted roll across the full pool. Weights come from `character.data.extensions.talkativeness` (string "0"–"1", default 0.5 when absent/invalid/out-of-range).
+  - **Pooled**: weighted random pick, excluding the N most-recent distinct AI speakers (N configurable via slider, default 1). Pool-empty falls back to the full candidate set.
+- Per-member **mute toggle** ships with 5.1 (partner to 5.2). Muted avatars are filtered out before speaker selection in every strategy.
+- UI: collapsible controls panel in the group chat header with segmented strategy picker, pooled exclude-recent slider, and per-member mute list showing each member's current talkativeness.
+- Manual trigger is deferred (tracked as a follow-up).
 
 ### 5.2 Group Chat Controls
-- **Gap:** Can add characters but no mute, reorder, force-talk, or auto-mode.
+- **Gap:** Can add characters, and mute toggle ships with 5.1. No reorder, force-talk, or auto-mode yet.
 - **ST Feature:** Mute/unmute members, force individual response, auto-mode (continuous generation), character reordering, allow self-responses toggle.
-- **Work:** Add mute toggle per member. Force-talk button. Auto-mode with configurable delay. Drag-to-reorder member list. Group scenario override.
+- **Work:** Mute toggle per member ✅ (landed with 5.1). Force-talk button. Auto-mode with configurable delay. Drag-to-reorder member list. Group scenario override.
 
 ### 5.3 Character Card Handling in Groups
 - **Gap:** Basic per-character system prompts. No join mode.

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useRef, useMemo, useState, useCallback } from 'react';
-import { MessageSquare, Users } from 'lucide-react';
+import { MessageSquare, Users, Settings2 } from 'lucide-react';
 import { useCharacterStore } from '../../stores/characterStore';
 import { useChatStore } from '../../stores/chatStore';
 import { ChatMessage } from './ChatMessage';
 import { ChatInput } from './ChatInput';
 import { ChatActionBar } from './ChatActionBar';
+import { GroupChatControls } from './GroupChatControls';
 import { useCharacterSprites } from '../../hooks/useCharacterSprites';
 import {
   getExpressionThumbnailUrl,
@@ -35,12 +36,14 @@ export function ChatView() {
     continueMessage,
     impersonate,
     stopGeneration,
+    currentChatFile,
   } = useChatStore();
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const lastCharacterRef = useRef<string | null>(null);
   const [failedExpressions, setFailedExpressions] = useState<Set<string>>(new Set());
   const [prefillText, setPrefillText] = useState<string | undefined>(undefined);
   const [prefillNonce, setPrefillNonce] = useState(0);
+  const [showGroupControls, setShowGroupControls] = useState(false);
 
   const { getSpritePath, availableEmotions } = useCharacterSprites(selectedCharacter?.avatar);
 
@@ -174,29 +177,50 @@ export function ChatView() {
 
   return (
     <div className="h-full flex flex-col overflow-hidden">
-      {/* Mobile Header */}
+      {/* Group Chat Header (always visible when in group mode) */}
       {isGroupChatMode ? (
-        <div className="lg:hidden h-20 relative bg-gradient-to-b from-[var(--color-bg-tertiary)] to-[var(--color-bg-primary)] overflow-hidden px-4 py-3">
-          <div className="flex items-center gap-3">
-            <div className="w-12 h-12 rounded-full bg-[var(--color-primary)]/20 flex items-center justify-center">
-              <Users size={24} className="text-[var(--color-primary)]" />
+        <>
+          <div className="h-20 relative bg-gradient-to-b from-[var(--color-bg-tertiary)] to-[var(--color-bg-primary)] overflow-hidden px-4 py-3">
+            <div className="flex items-center gap-3">
+              <div className="w-12 h-12 rounded-full bg-[var(--color-primary)]/20 flex items-center justify-center">
+                <Users size={24} className="text-[var(--color-primary)]" />
+              </div>
+              <div className="flex-1 min-w-0">
+                <h2 className="text-lg font-semibold text-[var(--color-text-primary)] truncate">
+                  Group Chat
+                </h2>
+                <p className="text-xs text-[var(--color-text-secondary)] truncate">
+                  {groupChatCharacters.map((c) => c.name).join(', ')}
+                </p>
+              </div>
+              <button
+                onClick={() => setShowGroupControls((v) => !v)}
+                className={`p-1.5 rounded-full transition-colors ${
+                  showGroupControls
+                    ? 'bg-[var(--color-primary)]/20 text-[var(--color-primary)]'
+                    : 'text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-tertiary)]'
+                }`}
+                aria-label="Group chat settings"
+                aria-expanded={showGroupControls}
+                title="Activation strategy & mute"
+              >
+                <Settings2 size={18} />
+              </button>
+              <button
+                onClick={exitGroupChat}
+                className="text-xs px-3 py-1.5 rounded-full bg-[var(--color-bg-tertiary)] text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-primary)]"
+              >
+                Exit
+              </button>
             </div>
-            <div className="flex-1 min-w-0">
-              <h2 className="text-lg font-semibold text-[var(--color-text-primary)] truncate">
-                Group Chat
-              </h2>
-              <p className="text-xs text-[var(--color-text-secondary)] truncate">
-                {groupChatCharacters.map((c) => c.name).join(', ')}
-              </p>
-            </div>
-            <button
-              onClick={exitGroupChat}
-              className="text-xs px-3 py-1.5 rounded-full bg-[var(--color-bg-tertiary)] text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-primary)]"
-            >
-              Exit
-            </button>
           </div>
-        </div>
+          {showGroupControls && currentChatFile && (
+            <GroupChatControls
+              fileName={currentChatFile}
+              characters={groupChatCharacters}
+            />
+          )}
+        </>
       ) : selectedCharacter ? (
         <div className="lg:hidden h-[30vh] min-h-[150px] max-h-[250px] relative bg-gradient-to-b from-[var(--color-bg-tertiary)] to-[var(--color-bg-primary)] overflow-hidden">
           <img

--- a/src/components/chat/GroupChatControls.tsx
+++ b/src/components/chat/GroupChatControls.tsx
@@ -1,0 +1,167 @@
+import { useMemo } from 'react';
+import { Volume2, VolumeX } from 'lucide-react';
+import type { CharacterInfo } from '../../api/client';
+import {
+  useChatStore,
+  getTalkativeness,
+  type GroupActivationStrategy,
+} from '../../stores/chatStore';
+
+interface GroupChatControlsProps {
+  fileName: string;
+  characters: CharacterInfo[];
+}
+
+const STRATEGY_OPTIONS: Array<{
+  value: GroupActivationStrategy;
+  label: string;
+  hint: string;
+}> = [
+  {
+    value: 'list',
+    label: 'List',
+    hint: 'Every member replies in order (default).',
+  },
+  {
+    value: 'natural',
+    label: 'Natural',
+    hint: 'Pick who was mentioned, else weighted by talkativeness.',
+  },
+  {
+    value: 'pooled',
+    label: 'Pooled',
+    hint: 'Weighted random, skipping the most recent speaker(s).',
+  },
+];
+
+/**
+ * Collapsible controls for the active group chat: activation strategy,
+ * pooled exclusion window, and per-member mute toggles. All changes are
+ * written straight to the persisted group chat record.
+ */
+export function GroupChatControls({ fileName, characters }: GroupChatControlsProps) {
+  const groupChat = useChatStore((s) =>
+    s.groupChats.find((g) => g.fileName === fileName) || null
+  );
+  const setGroupActivationStrategy = useChatStore((s) => s.setGroupActivationStrategy);
+  const toggleGroupMute = useChatStore((s) => s.toggleGroupMute);
+  const setGroupPooledExcludeRecent = useChatStore((s) => s.setGroupPooledExcludeRecent);
+
+  const mutedSet = useMemo(
+    () => new Set(groupChat?.mutedAvatars ?? []),
+    [groupChat?.mutedAvatars]
+  );
+
+  if (!groupChat) return null;
+
+  const strategy = groupChat.activationStrategy;
+  const excludeRecent = groupChat.pooledExcludeRecent;
+  // Pooled N must stay below the pool size so we always have a valid fallback.
+  const maxExclude = Math.max(0, characters.length - 1);
+  const activeHint =
+    STRATEGY_OPTIONS.find((o) => o.value === strategy)?.hint ?? '';
+
+  return (
+    <div className="border-b border-[var(--color-border)] bg-[var(--color-bg-secondary)] px-4 py-3 space-y-3">
+      <div>
+        <div className="flex items-center justify-between mb-1.5">
+          <label className="text-xs font-semibold uppercase tracking-wide text-[var(--color-text-secondary)]">
+            Activation strategy
+          </label>
+        </div>
+        <div className="grid grid-cols-3 gap-1 rounded-lg bg-[var(--color-bg-tertiary)] p-1">
+          {STRATEGY_OPTIONS.map((opt) => {
+            const active = opt.value === strategy;
+            return (
+              <button
+                key={opt.value}
+                type="button"
+                onClick={() => setGroupActivationStrategy(fileName, opt.value)}
+                className={`rounded-md px-2 py-1.5 text-xs font-medium transition-colors ${
+                  active
+                    ? 'bg-[var(--color-primary)] text-white shadow-sm'
+                    : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]'
+                }`}
+              >
+                {opt.label}
+              </button>
+            );
+          })}
+        </div>
+        <p className="mt-1.5 text-xs text-[var(--color-text-secondary)]">
+          {activeHint}
+        </p>
+      </div>
+
+      {strategy === 'pooled' && (
+        <div>
+          <label className="block text-xs font-semibold uppercase tracking-wide text-[var(--color-text-secondary)] mb-1.5">
+            Skip last {excludeRecent} speaker{excludeRecent === 1 ? '' : 's'}
+          </label>
+          <input
+            type="range"
+            min={0}
+            max={maxExclude}
+            step={1}
+            value={Math.min(excludeRecent, maxExclude)}
+            onChange={(e) =>
+              setGroupPooledExcludeRecent(fileName, Number(e.target.value))
+            }
+            className="w-full"
+            aria-label="Pooled exclude-recent count"
+          />
+          <p className="mt-1 text-xs text-[var(--color-text-secondary)]">
+            Members who spoke in the last {excludeRecent} turn
+            {excludeRecent === 1 ? '' : 's'} are skipped by the pooled roll.
+          </p>
+        </div>
+      )}
+
+      <div>
+        <label className="block text-xs font-semibold uppercase tracking-wide text-[var(--color-text-secondary)] mb-1.5">
+          Members ({characters.length - mutedSet.size}/{characters.length} active)
+        </label>
+        <ul className="space-y-1">
+          {characters.map((c) => {
+            const muted = mutedSet.has(c.avatar);
+            const talk = getTalkativeness(c);
+            return (
+              <li key={c.avatar}>
+                <button
+                  type="button"
+                  onClick={() => toggleGroupMute(fileName, c.avatar)}
+                  className={`w-full flex items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors ${
+                    muted
+                      ? 'bg-[var(--color-bg-tertiary)] text-[var(--color-text-secondary)] opacity-70'
+                      : 'bg-[var(--color-bg-tertiary)]/50 text-[var(--color-text-primary)] hover:bg-[var(--color-bg-tertiary)]'
+                  }`}
+                  aria-pressed={muted}
+                  title={muted ? `Unmute ${c.name}` : `Mute ${c.name}`}
+                >
+                  {muted ? (
+                    <VolumeX size={16} className="text-red-400 flex-shrink-0" />
+                  ) : (
+                    <Volume2
+                      size={16}
+                      className="text-[var(--color-primary)] flex-shrink-0"
+                    />
+                  )}
+                  <span
+                    className={`flex-1 text-left truncate ${
+                      muted ? 'line-through' : ''
+                    }`}
+                  >
+                    {c.name}
+                  </span>
+                  <span className="text-xs text-[var(--color-text-secondary)] tabular-nums flex-shrink-0">
+                    t={talk.toFixed(2)}
+                  </span>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -39,20 +39,71 @@ interface ChatFile {
   lastMessage: string;
 }
 
+/**
+ * Strategies that decide which group-chat member(s) respond on each user turn.
+ * - list: every member speaks in order (legacy behavior, preserved as default).
+ * - natural: pick the member mentioned in the last message, else weighted roll
+ *   by talkativeness. Exactly one member responds.
+ * - pooled: weighted random pick from the pool, excluding the N most recent
+ *   speakers. Exactly one member responds.
+ */
+export type GroupActivationStrategy = 'list' | 'natural' | 'pooled';
+
+export const DEFAULT_GROUP_ACTIVATION_STRATEGY: GroupActivationStrategy = 'list';
+export const DEFAULT_POOLED_EXCLUDE_RECENT = 1;
+
 export interface GroupChatInfo {
   fileName: string;
   characterNames: string[];
   characterAvatars: string[];
   lastMessage: string;
   createdAt: number;
+  /** How the next speaker is chosen each turn. Added in Phase 5.1. */
+  activationStrategy: GroupActivationStrategy;
+  /** Avatars of members whose turns are skipped. Added in Phase 5.1. */
+  mutedAvatars: string[];
+  /** Recent-speaker exclusion window for pooled strategy (N≥0). */
+  pooledExcludeRecent: number;
 }
 
 const GROUP_CHATS_KEY = 'sillytavern_group_chats';
 
+/**
+ * Fill defaults for pre-Phase-5.1 records so the rest of the code can assume
+ * the new fields are always present.
+ */
+function migrateGroupChat(raw: Partial<GroupChatInfo> & {
+  fileName: string;
+  characterNames: string[];
+  characterAvatars: string[];
+}): GroupChatInfo {
+  return {
+    fileName: raw.fileName,
+    characterNames: raw.characterNames ?? [],
+    characterAvatars: raw.characterAvatars ?? [],
+    lastMessage: raw.lastMessage ?? '',
+    createdAt: raw.createdAt ?? Date.now(),
+    activationStrategy:
+      raw.activationStrategy === 'natural' ||
+      raw.activationStrategy === 'pooled' ||
+      raw.activationStrategy === 'list'
+        ? raw.activationStrategy
+        : DEFAULT_GROUP_ACTIVATION_STRATEGY,
+    mutedAvatars: Array.isArray(raw.mutedAvatars) ? raw.mutedAvatars : [],
+    pooledExcludeRecent:
+      typeof raw.pooledExcludeRecent === 'number' && raw.pooledExcludeRecent >= 0
+        ? Math.floor(raw.pooledExcludeRecent)
+        : DEFAULT_POOLED_EXCLUDE_RECENT,
+  };
+}
+
 function loadGroupChatsFromStorage(): GroupChatInfo[] {
   try {
     const stored = localStorage.getItem(GROUP_CHATS_KEY);
-    return stored ? JSON.parse(stored) : [];
+    if (!stored) return [];
+    const parsed = JSON.parse(stored);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.map(migrateGroupChat);
   } catch {
     return [];
   }
@@ -60,6 +111,97 @@ function loadGroupChatsFromStorage(): GroupChatInfo[] {
 
 function saveGroupChatsToStorage(groupChats: GroupChatInfo[]) {
   localStorage.setItem(GROUP_CHATS_KEY, JSON.stringify(groupChats));
+}
+
+/** Parse the per-character "talkativeness" extension, clamped to [0, 1].
+ *  Falls back to 0.5 when absent, not a number, or out of range. */
+export function getTalkativeness(character: CharacterInfo): number {
+  const raw = character.data?.extensions?.talkativeness;
+  if (typeof raw !== 'string') return 0.5;
+  const n = parseFloat(raw);
+  if (!isFinite(n)) return 0.5;
+  if (n < 0) return 0;
+  if (n > 1) return 1;
+  return n;
+}
+
+function escapeRegExp(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** Weighted random pick using talkativeness. Falls back to uniform when all
+ *  weights are zero or the pool has a single entry. */
+function weightedRandomPick(
+  pool: CharacterInfo[],
+  rng: () => number = Math.random
+): CharacterInfo | null {
+  if (pool.length === 0) return null;
+  if (pool.length === 1) return pool[0];
+  const weights = pool.map(getTalkativeness);
+  const total = weights.reduce((a, b) => a + b, 0);
+  if (total <= 0) {
+    return pool[Math.floor(rng() * pool.length)];
+  }
+  let r = rng() * total;
+  for (let i = 0; i < pool.length; i++) {
+    r -= weights[i];
+    if (r <= 0) return pool[i];
+  }
+  return pool[pool.length - 1];
+}
+
+/** Natural Order: pick the character whose name appears in the last
+ *  non-system message. If multiple match, weighted roll within the matches.
+ *  If none match, weighted roll across the full pool. */
+export function selectNaturalOrderSpeaker(
+  candidates: CharacterInfo[],
+  messages: ChatMessage[],
+  rng: () => number = Math.random
+): CharacterInfo | null {
+  if (candidates.length === 0) return null;
+
+  const lastMeaningful = [...messages].reverse().find((m) => !m.isSystem);
+  if (!lastMeaningful || !lastMeaningful.content.trim()) {
+    return weightedRandomPick(candidates, rng);
+  }
+
+  const haystack = lastMeaningful.content;
+  const mentioned = candidates.filter((c) => {
+    const name = (c.name || '').trim();
+    if (!name) return false;
+    const pattern = new RegExp(`\\b${escapeRegExp(name)}\\b`, 'i');
+    return pattern.test(haystack);
+  });
+
+  if (mentioned.length === 0) {
+    return weightedRandomPick(candidates, rng);
+  }
+  return weightedRandomPick(mentioned, rng);
+}
+
+/** Pooled Order: weighted random pick from the candidates, excluding
+ *  the N most recent distinct AI speakers. If exclusion empties the pool
+ *  the full candidate set is used as a safety fallback. */
+export function selectPooledOrderSpeaker(
+  candidates: CharacterInfo[],
+  messages: ChatMessage[],
+  excludeRecent: number,
+  rng: () => number = Math.random
+): CharacterInfo | null {
+  if (candidates.length === 0) return null;
+  const n = Math.max(0, Math.floor(excludeRecent));
+  if (n === 0) return weightedRandomPick(candidates, rng);
+
+  const recent: string[] = [];
+  for (let i = messages.length - 1; i >= 0 && recent.length < n; i--) {
+    const m = messages[i];
+    if (m.isUser || m.isSystem) continue;
+    if (!recent.includes(m.name)) recent.push(m.name);
+  }
+
+  const pool = candidates.filter((c) => !recent.includes(c.name));
+  if (pool.length === 0) return weightedRandomPick(candidates, rng);
+  return weightedRandomPick(pool, rng);
 }
 
 interface ChatState {
@@ -86,6 +228,12 @@ interface ChatState {
   clearChat: () => void;
   refreshGroupChats: () => void;
   deleteGroupChat: (fileName: string) => void;
+
+  // Phase 5.1: activation strategies + per-member mute
+  setGroupActivationStrategy: (fileName: string, strategy: GroupActivationStrategy) => void;
+  toggleGroupMute: (fileName: string, avatar: string) => void;
+  setGroupPooledExcludeRecent: (fileName: string, n: number) => void;
+  getGroupChatByFile: (fileName: string) => GroupChatInfo | null;
 
   // New Phase 1 actions
   stopGeneration: () => void;
@@ -740,6 +888,43 @@ export const useChatStore = create<ChatState>((set, get) => ({
     set({ groupChats: updated });
   },
 
+  // ---- Phase 5.1: activation strategies + mute ----
+  getGroupChatByFile: (fileName: string) => {
+    return get().groupChats.find((g) => g.fileName === fileName) || null;
+  },
+
+  setGroupActivationStrategy: (fileName, strategy) => {
+    const { groupChats } = get();
+    const updated = groupChats.map((g) =>
+      g.fileName === fileName ? { ...g, activationStrategy: strategy } : g
+    );
+    saveGroupChatsToStorage(updated);
+    set({ groupChats: updated });
+  },
+
+  toggleGroupMute: (fileName, avatar) => {
+    const { groupChats } = get();
+    const updated = groupChats.map((g) => {
+      if (g.fileName !== fileName) return g;
+      const muted = new Set(g.mutedAvatars);
+      if (muted.has(avatar)) muted.delete(avatar);
+      else muted.add(avatar);
+      return { ...g, mutedAvatars: Array.from(muted) };
+    });
+    saveGroupChatsToStorage(updated);
+    set({ groupChats: updated });
+  },
+
+  setGroupPooledExcludeRecent: (fileName, n) => {
+    const clamped = Math.max(0, Math.floor(n));
+    const { groupChats } = get();
+    const updated = groupChats.map((g) =>
+      g.fileName === fileName ? { ...g, pooledExcludeRecent: clamped } : g
+    );
+    saveGroupChatsToStorage(updated);
+    set({ groupChats: updated });
+  },
+
   fetchChatFiles: async (avatarUrl: string) => {
     set({ isLoading: true, error: null });
     try {
@@ -855,6 +1040,9 @@ export const useChatStore = create<ChatState>((set, get) => ({
       characterAvatars: characters.map((c) => c.avatar),
       lastMessage: messages[messages.length - 1]?.content || '',
       createdAt: Date.now(),
+      activationStrategy: DEFAULT_GROUP_ACTIVATION_STRATEGY,
+      mutedAvatars: [],
+      pooledExcludeRecent: DEFAULT_POOLED_EXCLUDE_RECENT,
     };
     const updatedGroupChats = [...groupChats, newGroupChat];
     saveGroupChatsToStorage(updatedGroupChats);
@@ -1194,7 +1382,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
 
   // ---- Send Group Message (updated with abort support) ----
   sendGroupMessage: async (content: string, characters: CharacterInfo[]) => {
-    const { addMessage } = get();
+    const { addMessage, currentChatFile, getGroupChatByFile } = get();
 
     addMessage({
       name: 'You',
@@ -1204,13 +1392,52 @@ export const useChatStore = create<ChatState>((set, get) => ({
       timestamp: Date.now(),
     });
 
+    // Resolve strategy + mute from the persisted group chat record. Missing
+    // record (very old group chats not reloaded) falls back to list order
+    // with no mutes so the legacy behavior still ships.
+    const groupChat = currentChatFile ? getGroupChatByFile(currentChatFile) : null;
+    const strategy: GroupActivationStrategy =
+      groupChat?.activationStrategy ?? DEFAULT_GROUP_ACTIVATION_STRATEGY;
+    const mutedAvatars = new Set(groupChat?.mutedAvatars ?? []);
+    const pooledExcludeRecent =
+      groupChat?.pooledExcludeRecent ?? DEFAULT_POOLED_EXCLUDE_RECENT;
+
+    const activeCharacters = characters.filter((c) => !mutedAvatars.has(c.avatar));
+    if (activeCharacters.length === 0) {
+      set({ error: 'All group members are muted. Unmute someone to continue.' });
+      return;
+    }
+
+    // Build the speaker queue for this turn. List order keeps legacy behavior
+    // (everyone speaks once in order); natural/pooled produce exactly one
+    // speaker per user turn.
+    let speakerQueue: CharacterInfo[] = [];
+    if (strategy === 'list') {
+      speakerQueue = activeCharacters;
+    } else if (strategy === 'natural') {
+      const pick = selectNaturalOrderSpeaker(activeCharacters, get().messages);
+      if (pick) speakerQueue = [pick];
+    } else if (strategy === 'pooled') {
+      const pick = selectPooledOrderSpeaker(
+        activeCharacters,
+        get().messages,
+        pooledExcludeRecent
+      );
+      if (pick) speakerQueue = [pick];
+    }
+
+    if (speakerQueue.length === 0) {
+      set({ error: 'Could not select a speaker for this turn.' });
+      return;
+    }
+
     const abortController = new AbortController();
     set({ isSending: true, isStreaming: false, error: null, abortController });
 
     try {
       const { provider, model } = getProviderAndModel();
 
-      for (const character of characters) {
+      for (const character of speakerQueue) {
         if (!get().isSending) break; // Check if aborted between characters
 
         const updatedMessages = get().messages;


### PR DESCRIPTION
Three selectable strategies per group chat, persisted on the GroupChatInfo record with a load-time migration for pre-5.1 records:

- List (default, legacy): every member replies in order.
- Natural: pick the member mentioned in the last non-system message (word-boundary, case-insensitive); weighted roll within matches on multi-mention, weighted roll across the pool on no match. Weights from character.data.extensions.talkativeness, default 0.5.
- Pooled: weighted random pick excluding the N most-recent distinct AI speakers (default N=1). Falls back to the full pool when exclusion would empty it.

Per-member mute toggle ships with 5.1 (partner to 5.2). Muted avatars are filtered before speaker selection in all strategies, and an error surfaces if all members are muted.

UI: collapsible controls panel in the group chat header with a segmented strategy picker, pooled exclude-recent slider, and per-member mute list showing each member's current talkativeness.

Manual trigger is deferred as a follow-up.