### PR TITLE
Add Phase 5.2: group chat controls

### DIFF
--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -218,6 +218,7 @@ export function ChatView() {
             <GroupChatControls
               fileName={currentChatFile}
               characters={groupChatCharacters}
+              isSending={isSending}
             />
           )}
         </>

--- a/src/components/chat/GroupChatControls.tsx
+++ b/src/components/chat/GroupChatControls.tsx
@@ -1,15 +1,22 @@
-import { useMemo } from 'react';
-import { Volume2, VolumeX } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import {
+  Volume2,
+  VolumeX,
+  MessageCircle,
+  GripVertical,
+} from 'lucide-react';
 import type { CharacterInfo } from '../../api/client';
 import {
   useChatStore,
   getTalkativeness,
   type GroupActivationStrategy,
 } from '../../stores/chatStore';
+import { useCharacterStore } from '../../stores/characterStore';
 
 interface GroupChatControlsProps {
   fileName: string;
   characters: CharacterInfo[];
+  isSending: boolean;
 }
 
 const STRATEGY_OPTIONS: Array<{
@@ -32,34 +39,100 @@ const STRATEGY_OPTIONS: Array<{
     label: 'Pooled',
     hint: 'Weighted random, skipping the most recent speaker(s).',
   },
+  {
+    value: 'manual',
+    label: 'Manual',
+    hint: 'No auto-pick; use the talk-next buttons below.',
+  },
 ];
 
 /**
  * Collapsible controls for the active group chat: activation strategy,
- * pooled exclusion window, and per-member mute toggles. All changes are
- * written straight to the persisted group chat record.
+ * pooled exclusion window, per-member mute/force-talk, auto-mode loop,
+ * drag-to-reorder, and scenario override. All changes are written straight
+ * to the persisted group chat record.
  */
-export function GroupChatControls({ fileName, characters }: GroupChatControlsProps) {
+export function GroupChatControls({
+  fileName,
+  characters,
+  isSending,
+}: GroupChatControlsProps) {
   const groupChat = useChatStore((s) =>
     s.groupChats.find((g) => g.fileName === fileName) || null
   );
   const setGroupActivationStrategy = useChatStore((s) => s.setGroupActivationStrategy);
   const toggleGroupMute = useChatStore((s) => s.toggleGroupMute);
   const setGroupPooledExcludeRecent = useChatStore((s) => s.setGroupPooledExcludeRecent);
+  const setGroupAutoMode = useChatStore((s) => s.setGroupAutoMode);
+  const setGroupAutoModeDelay = useChatStore((s) => s.setGroupAutoModeDelay);
+  const setGroupScenarioOverride = useChatStore((s) => s.setGroupScenarioOverride);
+  const reorderGroupMembers = useChatStore((s) => s.reorderGroupMembers);
+  const forceGroupMemberTalk = useChatStore((s) => s.forceGroupMemberTalk);
+  const reorderGroupChatCharacters = useCharacterStore(
+    (s) => s.reorderGroupChatCharacters
+  );
 
   const mutedSet = useMemo(
     () => new Set(groupChat?.mutedAvatars ?? []),
     [groupChat?.mutedAvatars]
   );
 
+  // Local drag state — we only persist when the drop lands.
+  const [draggingAvatar, setDraggingAvatar] = useState<string | null>(null);
+  const [dragOverAvatar, setDragOverAvatar] = useState<string | null>(null);
+
   if (!groupChat) return null;
 
   const strategy = groupChat.activationStrategy;
   const excludeRecent = groupChat.pooledExcludeRecent;
+  const autoModeEnabled = groupChat.autoModeEnabled;
+  const autoModeDelayMs = groupChat.autoModeDelayMs;
+  const scenarioOverride = groupChat.scenarioOverride;
   // Pooled N must stay below the pool size so we always have a valid fallback.
   const maxExclude = Math.max(0, characters.length - 1);
   const activeHint =
     STRATEGY_OPTIONS.find((o) => o.value === strategy)?.hint ?? '';
+
+  const handleDragStart = (avatar: string) => {
+    if (isSending) return;
+    setDraggingAvatar(avatar);
+  };
+
+  const handleDragOver = (avatar: string, e: React.DragEvent) => {
+    if (isSending) return;
+    if (!draggingAvatar || draggingAvatar === avatar) return;
+    e.preventDefault();
+    setDragOverAvatar(avatar);
+  };
+
+  const handleDrop = (targetAvatar: string) => {
+    if (isSending) return;
+    if (!draggingAvatar || draggingAvatar === targetAvatar) {
+      setDraggingAvatar(null);
+      setDragOverAvatar(null);
+      return;
+    }
+    const currentOrder = characters.map((c) => c.avatar);
+    const srcIdx = currentOrder.indexOf(draggingAvatar);
+    const dstIdx = currentOrder.indexOf(targetAvatar);
+    if (srcIdx === -1 || dstIdx === -1) {
+      setDraggingAvatar(null);
+      setDragOverAvatar(null);
+      return;
+    }
+    const next = [...currentOrder];
+    next.splice(srcIdx, 1);
+    next.splice(dstIdx, 0, draggingAvatar);
+    reorderGroupMembers(fileName, next);
+    reorderGroupChatCharacters(next);
+    setDraggingAvatar(null);
+    setDragOverAvatar(null);
+  };
+
+  const handleDragEnd = () => {
+    setDraggingAvatar(null);
+    setDragOverAvatar(null);
+  };
 
   return (
     <div className="border-b border-[var(--color-border)] bg-[var(--color-bg-secondary)] px-4 py-3 space-y-3">
@@ -69,7 +142,7 @@ export function GroupChatControls({ fileName, characters }: GroupChatControlsPro
             Activation strategy
           </label>
         </div>
-        <div className="grid grid-cols-3 gap-1 rounded-lg bg-[var(--color-bg-tertiary)] p-1">
+        <div className="grid grid-cols-4 gap-1 rounded-lg bg-[var(--color-bg-tertiary)] p-1">
           {STRATEGY_OPTIONS.map((opt) => {
             const active = opt.value === strategy;
             return (
@@ -117,6 +190,73 @@ export function GroupChatControls({ fileName, characters }: GroupChatControlsPro
         </div>
       )}
 
+      {strategy !== 'manual' && (
+        <div>
+          <div className="flex items-center justify-between mb-1.5">
+            <label className="text-xs font-semibold uppercase tracking-wide text-[var(--color-text-secondary)]">
+              Auto-mode
+            </label>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={autoModeEnabled}
+              onClick={() => setGroupAutoMode(fileName, !autoModeEnabled)}
+              className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
+                autoModeEnabled
+                  ? 'bg-[var(--color-primary)]'
+                  : 'bg-[var(--color-bg-tertiary)]'
+              }`}
+            >
+              <span
+                className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white transition-transform ${
+                  autoModeEnabled ? 'translate-x-5' : 'translate-x-1'
+                }`}
+              />
+            </button>
+          </div>
+          <p className="text-xs text-[var(--color-text-secondary)]">
+            Keep generating next speakers after each reply. Stop button breaks
+            the loop.
+          </p>
+          {autoModeEnabled && (
+            <div className="mt-2">
+              <label className="block text-xs text-[var(--color-text-secondary)] mb-1">
+                Delay between turns: {(autoModeDelayMs / 1000).toFixed(1)}s
+              </label>
+              <input
+                type="range"
+                min={0}
+                max={10000}
+                step={500}
+                value={autoModeDelayMs}
+                onChange={(e) =>
+                  setGroupAutoModeDelay(fileName, Number(e.target.value))
+                }
+                className="w-full"
+                aria-label="Auto-mode delay between turns"
+              />
+            </div>
+          )}
+        </div>
+      )}
+
+      <div>
+        <label className="block text-xs font-semibold uppercase tracking-wide text-[var(--color-text-secondary)] mb-1.5">
+          Group scenario override
+        </label>
+        <textarea
+          value={scenarioOverride}
+          onChange={(e) => setGroupScenarioOverride(fileName, e.target.value)}
+          placeholder="Leave empty to use each member's own scenario."
+          rows={3}
+          className="w-full rounded-md bg-[var(--color-bg-tertiary)] text-sm text-[var(--color-text-primary)] border border-[var(--color-border)] px-2 py-1.5 placeholder:text-[var(--color-text-secondary)] focus:outline-none focus:ring-1 focus:ring-[var(--color-primary)]"
+        />
+        <p className="mt-1 text-xs text-[var(--color-text-secondary)]">
+          Macros like <code>{'{{user}}'}</code> work here.{' '}
+          <code>{'{{char}}'}</code> is empty in group context.
+        </p>
+      </div>
+
       <div>
         <label className="block text-xs font-semibold uppercase tracking-wide text-[var(--color-text-secondary)] mb-1.5">
           Members ({characters.length - mutedSet.size}/{characters.length} active)
@@ -125,15 +265,40 @@ export function GroupChatControls({ fileName, characters }: GroupChatControlsPro
           {characters.map((c) => {
             const muted = mutedSet.has(c.avatar);
             const talk = getTalkativeness(c);
+            const isDragTarget = dragOverAvatar === c.avatar;
+            const isDragged = draggingAvatar === c.avatar;
             return (
-              <li key={c.avatar}>
+              <li
+                key={c.avatar}
+                draggable={!isSending}
+                onDragStart={() => handleDragStart(c.avatar)}
+                onDragOver={(e) => handleDragOver(c.avatar, e)}
+                onDrop={() => handleDrop(c.avatar)}
+                onDragEnd={handleDragEnd}
+                className={`flex items-center gap-1 rounded-md transition-colors ${
+                  isDragTarget
+                    ? 'bg-[var(--color-primary)]/20'
+                    : 'bg-[var(--color-bg-tertiary)]/50'
+                } ${isDragged ? 'opacity-40' : ''}`}
+              >
+                <span
+                  className={`flex-shrink-0 pl-1.5 ${
+                    isSending
+                      ? 'text-[var(--color-text-secondary)]/40'
+                      : 'text-[var(--color-text-secondary)] cursor-grab active:cursor-grabbing'
+                  }`}
+                  title={isSending ? 'Reorder disabled while sending' : 'Drag to reorder'}
+                  aria-label="Drag handle"
+                >
+                  <GripVertical size={14} />
+                </span>
                 <button
                   type="button"
                   onClick={() => toggleGroupMute(fileName, c.avatar)}
-                  className={`w-full flex items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors ${
+                  className={`flex-1 flex items-center gap-2 px-1 py-1.5 text-sm transition-colors ${
                     muted
-                      ? 'bg-[var(--color-bg-tertiary)] text-[var(--color-text-secondary)] opacity-70'
-                      : 'bg-[var(--color-bg-tertiary)]/50 text-[var(--color-text-primary)] hover:bg-[var(--color-bg-tertiary)]'
+                      ? 'text-[var(--color-text-secondary)] opacity-70'
+                      : 'text-[var(--color-text-primary)] hover:opacity-80'
                   }`}
                   aria-pressed={muted}
                   title={muted ? `Unmute ${c.name}` : `Mute ${c.name}`}
@@ -156,6 +321,16 @@ export function GroupChatControls({ fileName, characters }: GroupChatControlsPro
                   <span className="text-xs text-[var(--color-text-secondary)] tabular-nums flex-shrink-0">
                     t={talk.toFixed(2)}
                   </span>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => forceGroupMemberTalk(c, characters)}
+                  disabled={isSending}
+                  className="flex-shrink-0 p-1.5 mr-1 rounded-md text-[var(--color-primary)] hover:bg-[var(--color-bg-tertiary)] disabled:opacity-40 disabled:cursor-not-allowed"
+                  title={`Make ${c.name} respond next`}
+                  aria-label={`Force ${c.name} to respond`}
+                >
+                  <MessageCircle size={16} />
                 </button>
               </li>
             );

--- a/src/stores/characterStore.ts
+++ b/src/stores/characterStore.ts
@@ -99,6 +99,8 @@ interface CharacterState {
   exitGroupChat: () => void;
   isCharacterInGroup: (avatar: string) => boolean;
   setGroupChatCharacters: (avatars: string[]) => Promise<void>;
+  /** Reorder the in-memory group roster without hitting the API. */
+  reorderGroupChatCharacters: (avatars: string[]) => void;
   // Import/Export actions
   importCharacter: (
     file: File
@@ -491,6 +493,22 @@ export const useCharacterStore = create<CharacterState>((set, get) => ({
       isGroupChatMode: true,
       selectedCharacter: null,
     });
+  },
+
+  reorderGroupChatCharacters: (avatars: string[]) => {
+    const { groupChatCharacters } = get();
+    const byAvatar = new Map(groupChatCharacters.map((c) => [c.avatar, c]));
+    const reordered: CharacterInfo[] = [];
+    for (const a of avatars) {
+      const c = byAvatar.get(a);
+      if (c) reordered.push(c);
+    }
+    // Append any members not included in the incoming list so we never lose
+    // a participant to a stale payload.
+    for (const c of groupChatCharacters) {
+      if (!avatars.includes(c.avatar)) reordered.push(c);
+    }
+    set({ groupChatCharacters: reordered });
   },
 
   // Import/Export actions

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -46,11 +46,13 @@ interface ChatFile {
  *   by talkativeness. Exactly one member responds.
  * - pooled: weighted random pick from the pool, excluding the N most recent
  *   speakers. Exactly one member responds.
+ * - manual: no auto-selection; user must force-talk a specific member.
  */
-export type GroupActivationStrategy = 'list' | 'natural' | 'pooled';
+export type GroupActivationStrategy = 'list' | 'natural' | 'pooled' | 'manual';
 
 export const DEFAULT_GROUP_ACTIVATION_STRATEGY: GroupActivationStrategy = 'list';
 export const DEFAULT_POOLED_EXCLUDE_RECENT = 1;
+export const DEFAULT_AUTO_MODE_DELAY_MS = 1500;
 
 export interface GroupChatInfo {
   fileName: string;
@@ -64,6 +66,12 @@ export interface GroupChatInfo {
   mutedAvatars: string[];
   /** Recent-speaker exclusion window for pooled strategy (N≥0). */
   pooledExcludeRecent: number;
+  /** Phase 5.2: auto-continue generation after each AI turn. */
+  autoModeEnabled: boolean;
+  /** Phase 5.2: delay between auto-mode turns in milliseconds. */
+  autoModeDelayMs: number;
+  /** Phase 5.2: optional group-wide scenario replacing per-character scenario. */
+  scenarioOverride: string;
 }
 
 const GROUP_CHATS_KEY = 'sillytavern_group_chats';
@@ -86,7 +94,8 @@ function migrateGroupChat(raw: Partial<GroupChatInfo> & {
     activationStrategy:
       raw.activationStrategy === 'natural' ||
       raw.activationStrategy === 'pooled' ||
-      raw.activationStrategy === 'list'
+      raw.activationStrategy === 'list' ||
+      raw.activationStrategy === 'manual'
         ? raw.activationStrategy
         : DEFAULT_GROUP_ACTIVATION_STRATEGY,
     mutedAvatars: Array.isArray(raw.mutedAvatars) ? raw.mutedAvatars : [],
@@ -94,6 +103,14 @@ function migrateGroupChat(raw: Partial<GroupChatInfo> & {
       typeof raw.pooledExcludeRecent === 'number' && raw.pooledExcludeRecent >= 0
         ? Math.floor(raw.pooledExcludeRecent)
         : DEFAULT_POOLED_EXCLUDE_RECENT,
+    autoModeEnabled:
+      typeof raw.autoModeEnabled === 'boolean' ? raw.autoModeEnabled : false,
+    autoModeDelayMs:
+      typeof raw.autoModeDelayMs === 'number' && raw.autoModeDelayMs >= 0
+        ? Math.floor(raw.autoModeDelayMs)
+        : DEFAULT_AUTO_MODE_DELAY_MS,
+    scenarioOverride:
+      typeof raw.scenarioOverride === 'string' ? raw.scenarioOverride : '',
   };
 }
 
@@ -224,6 +241,8 @@ interface ChatState {
   addMessage: (message: Omit<ChatMessage, 'id' | 'swipes' | 'swipeId'>) => void;
   sendMessage: (content: string, character: CharacterInfo, availableEmotions?: string[]) => Promise<void>;
   sendGroupMessage: (content: string, characters: CharacterInfo[]) => Promise<void>;
+  /** Phase 5.2: force a single member to respond next, bypassing strategy + mute. */
+  forceGroupMemberTalk: (character: CharacterInfo, characters: CharacterInfo[]) => Promise<void>;
   editMessageAndRegenerate: (messageId: string, newContent: string, character: CharacterInfo, availableEmotions?: string[]) => Promise<void>;
   clearChat: () => void;
   refreshGroupChats: () => void;
@@ -234,6 +253,12 @@ interface ChatState {
   toggleGroupMute: (fileName: string, avatar: string) => void;
   setGroupPooledExcludeRecent: (fileName: string, n: number) => void;
   getGroupChatByFile: (fileName: string) => GroupChatInfo | null;
+
+  // Phase 5.2: auto-mode, reorder, scenario override
+  setGroupAutoMode: (fileName: string, enabled: boolean) => void;
+  setGroupAutoModeDelay: (fileName: string, delayMs: number) => void;
+  setGroupScenarioOverride: (fileName: string, scenario: string) => void;
+  reorderGroupMembers: (fileName: string, avatars: string[]) => void;
 
   // New Phase 1 actions
   stopGeneration: () => void;
@@ -680,7 +705,8 @@ Choose the emotion that best matches how ${character.name} would feel based on t
 function buildGroupConversationContext(
   messages: ChatMessage[],
   characters: CharacterInfo[],
-  currentCharacter: CharacterInfo
+  currentCharacter: CharacterInfo,
+  scenarioOverride?: string
 ): { role: 'user' | 'assistant' | 'system'; content: string }[] {
   const context: { role: 'user' | 'assistant' | 'system'; content: string }[] = [];
 
@@ -692,12 +718,41 @@ function buildGroupConversationContext(
     return `- ${char.name}: ${details || 'A character in the conversation'}`;
   }).join('\n');
 
+  // Resolve scenario: override wins, else falls back to current character's
+  // scenario. Macros are processed on the override, but {{char}} is ambiguous
+  // in a group (multiple speakers), so we scrub char-specific substitutions
+  // by passing an empty charName + character fields.
+  let scenarioText = '';
+  if (scenarioOverride && scenarioOverride.trim()) {
+    const persona = usePersonaStore
+      .getState()
+      .getPersonaForContext(currentCharacter.avatar);
+    const personaName = persona?.name || 'You';
+    const { activeModel } = useSettingsStore.getState();
+    scenarioText = processMacros(scenarioOverride, {
+      charName: '',
+      userName: personaName,
+      personaName,
+      personaDescription: persona?.description || '',
+      characterDescription: '',
+      characterPersonality: '',
+      characterScenario: '',
+      lastMessage: '',
+      lastUserMessage: '',
+      lastCharMessage: '',
+      model: activeModel,
+    }).trim();
+  } else {
+    scenarioText =
+      currentCharacter.scenario || currentCharacter.data?.scenario || '';
+  }
+
   const systemPrompt = `This is a group chat with multiple characters. You are playing ${currentCharacter.name}.
 
 Characters in this conversation:
 ${characterDescriptions}
 
-${currentCharacter.scenario ? `Current scenario: ${currentCharacter.scenario}\n` : ''}
+${scenarioText ? `Current scenario: ${scenarioText}\n` : ''}
 IMPORTANT:
 - Stay in character as ${currentCharacter.name}
 - React naturally to what other characters and the user say
@@ -720,6 +775,86 @@ IMPORTANT:
   }
 
   return context;
+}
+
+// Phase 5.2: shared helper that runs a single group-chat turn (build context,
+// call API, stream, finalize). Both `sendGroupMessage` and `forceGroupMemberTalk`
+// delegate to this to avoid drift in the streaming + parsing path. Returns
+// `false` if the turn was aborted or never produced a stream, `true` otherwise.
+async function generateGroupTurn(
+  character: CharacterInfo,
+  characters: CharacterInfo[],
+  scenarioOverride: string | undefined,
+  abortController: AbortController,
+  get: () => ChatState,
+  set: (partial: Partial<ChatState> | ((state: ChatState) => Partial<ChatState>)) => void
+): Promise<boolean> {
+  const { provider, model } = getProviderAndModel();
+  const updatedMessages = get().messages;
+  const context = buildGroupConversationContext(
+    updatedMessages,
+    characters,
+    character,
+    scenarioOverride
+  );
+
+  const finalContext = maybeApplyInstructMode(context);
+  const stream = await api.generateMessage(
+    finalContext,
+    character.name,
+    provider,
+    model,
+    abortController.signal,
+    getGenerationOptions()
+  );
+
+  if (!stream) return false;
+
+  const aiMessageId = generateId();
+  set((state) => ({
+    isStreaming: false,
+    messages: [
+      ...state.messages,
+      {
+        id: aiMessageId,
+        name: character.name,
+        isUser: false,
+        isSystem: false,
+        content: '',
+        timestamp: Date.now(),
+        characterAvatar: character.avatar,
+        swipes: [''],
+        swipeId: 0,
+      },
+    ],
+  }));
+
+  let responseText = '';
+  for await (const token of parseSSEStream(stream)) {
+    if (!get().isSending) break;
+    responseText += token;
+    if (!get().isStreaming) set({ isStreaming: true });
+    set((state) => ({
+      messages: state.messages.map((msg) =>
+        msg.id === aiMessageId
+          ? { ...msg, content: responseText, swipes: [responseText] }
+          : msg
+      ),
+    }));
+  }
+
+  const emotion = parseEmotion(responseText);
+  const cleanedContent = stripEmotionTag(responseText);
+
+  set((state) => ({
+    messages: state.messages.map((msg) =>
+      msg.id === aiMessageId
+        ? { ...msg, content: cleanedContent, emotion, swipes: [cleanedContent] }
+        : msg
+    ),
+  }));
+
+  return get().isSending;
 }
 
 // Helper: get provider/model with auto-switch
@@ -925,6 +1060,60 @@ export const useChatStore = create<ChatState>((set, get) => ({
     set({ groupChats: updated });
   },
 
+  // ---- Phase 5.2: auto-mode, reorder, scenario override ----
+  setGroupAutoMode: (fileName, enabled) => {
+    const { groupChats } = get();
+    const updated = groupChats.map((g) =>
+      g.fileName === fileName ? { ...g, autoModeEnabled: enabled } : g
+    );
+    saveGroupChatsToStorage(updated);
+    set({ groupChats: updated });
+  },
+
+  setGroupAutoModeDelay: (fileName, delayMs) => {
+    const clamped = Math.max(0, Math.floor(delayMs));
+    const { groupChats } = get();
+    const updated = groupChats.map((g) =>
+      g.fileName === fileName ? { ...g, autoModeDelayMs: clamped } : g
+    );
+    saveGroupChatsToStorage(updated);
+    set({ groupChats: updated });
+  },
+
+  setGroupScenarioOverride: (fileName, scenario) => {
+    const { groupChats } = get();
+    const updated = groupChats.map((g) =>
+      g.fileName === fileName ? { ...g, scenarioOverride: scenario } : g
+    );
+    saveGroupChatsToStorage(updated);
+    set({ groupChats: updated });
+  },
+
+  reorderGroupMembers: (fileName, avatars) => {
+    const { groupChats } = get();
+    const updated = groupChats.map((g) => {
+      if (g.fileName !== fileName) return g;
+      // Reorder characterAvatars + characterNames in lockstep. Skip any avatar
+      // in the payload that isn't in the record, and preserve any existing
+      // members missing from the payload by appending them in original order.
+      const oldAvatars = g.characterAvatars;
+      const oldNames = g.characterNames;
+      const nameByAvatar = new Map<string, string>();
+      oldAvatars.forEach((a, i) => nameByAvatar.set(a, oldNames[i] ?? ''));
+      const validAvatars = avatars.filter((a) => nameByAvatar.has(a));
+      const missing = oldAvatars.filter((a) => !validAvatars.includes(a));
+      const nextAvatars = [...validAvatars, ...missing];
+      const nextNames = nextAvatars.map((a) => nameByAvatar.get(a) ?? '');
+      return {
+        ...g,
+        characterAvatars: nextAvatars,
+        characterNames: nextNames,
+      };
+    });
+    saveGroupChatsToStorage(updated);
+    set({ groupChats: updated });
+  },
+
   fetchChatFiles: async (avatarUrl: string) => {
     set({ isLoading: true, error: null });
     try {
@@ -1043,6 +1232,9 @@ export const useChatStore = create<ChatState>((set, get) => ({
       activationStrategy: DEFAULT_GROUP_ACTIVATION_STRATEGY,
       mutedAvatars: [],
       pooledExcludeRecent: DEFAULT_POOLED_EXCLUDE_RECENT,
+      autoModeEnabled: false,
+      autoModeDelayMs: DEFAULT_AUTO_MODE_DELAY_MS,
+      scenarioOverride: '',
     };
     const updatedGroupChats = [...groupChats, newGroupChat];
     saveGroupChatsToStorage(updatedGroupChats);
@@ -1401,6 +1593,26 @@ export const useChatStore = create<ChatState>((set, get) => ({
     const mutedAvatars = new Set(groupChat?.mutedAvatars ?? []);
     const pooledExcludeRecent =
       groupChat?.pooledExcludeRecent ?? DEFAULT_POOLED_EXCLUDE_RECENT;
+    const autoModeEnabled = groupChat?.autoModeEnabled ?? false;
+    const autoModeDelayMs =
+      groupChat?.autoModeDelayMs ?? DEFAULT_AUTO_MODE_DELAY_MS;
+    const scenarioOverride = groupChat?.scenarioOverride;
+
+    // Manual strategy: just post the user message and wait for force-talk.
+    // Auto-mode is ignored when the strategy is manual — the user is in
+    // full control.
+    if (strategy === 'manual') {
+      if (currentChatFile && characters.length > 0) {
+        await saveChatToBackend(
+          get().messages,
+          characters[0],
+          currentChatFile,
+          true,
+          characters
+        );
+      }
+      return;
+    }
 
     const activeCharacters = characters.filter((c) => !mutedAvatars.has(c.avatar));
     if (activeCharacters.length === 0) {
@@ -1408,25 +1620,27 @@ export const useChatStore = create<ChatState>((set, get) => ({
       return;
     }
 
-    // Build the speaker queue for this turn. List order keeps legacy behavior
-    // (everyone speaks once in order); natural/pooled produce exactly one
-    // speaker per user turn.
-    let speakerQueue: CharacterInfo[] = [];
-    if (strategy === 'list') {
-      speakerQueue = activeCharacters;
-    } else if (strategy === 'natural') {
-      const pick = selectNaturalOrderSpeaker(activeCharacters, get().messages);
-      if (pick) speakerQueue = [pick];
-    } else if (strategy === 'pooled') {
-      const pick = selectPooledOrderSpeaker(
-        activeCharacters,
-        get().messages,
-        pooledExcludeRecent
-      );
-      if (pick) speakerQueue = [pick];
-    }
+    // Pick the initial speaker queue. List replays the legacy behavior
+    // (everyone speaks once in order); natural/pooled pick one.
+    const pickSpeakers = (): CharacterInfo[] => {
+      if (strategy === 'list') return activeCharacters;
+      if (strategy === 'natural') {
+        const pick = selectNaturalOrderSpeaker(activeCharacters, get().messages);
+        return pick ? [pick] : [];
+      }
+      if (strategy === 'pooled') {
+        const pick = selectPooledOrderSpeaker(
+          activeCharacters,
+          get().messages,
+          pooledExcludeRecent
+        );
+        return pick ? [pick] : [];
+      }
+      return [];
+    };
 
-    if (speakerQueue.length === 0) {
+    const initialQueue = pickSpeakers();
+    if (initialQueue.length === 0) {
       set({ error: 'Could not select a speaker for this turn.' });
       return;
     }
@@ -1435,70 +1649,105 @@ export const useChatStore = create<ChatState>((set, get) => ({
     set({ isSending: true, isStreaming: false, error: null, abortController });
 
     try {
-      const { provider, model } = getProviderAndModel();
-
-      for (const character of speakerQueue) {
-        if (!get().isSending) break; // Check if aborted between characters
-
-        const updatedMessages = get().messages;
-        const context = buildGroupConversationContext(updatedMessages, characters, character);
-
-        const finalContext = maybeApplyInstructMode(context);
-        const stream = await api.generateMessage(finalContext, character.name, provider, model, abortController.signal, getGenerationOptions());
-
-        if (stream) {
-          const aiMessageId = generateId();
-          set((state) => ({
-            isStreaming: false,
-            messages: [
-              ...state.messages,
-              {
-                id: aiMessageId,
-                name: character.name,
-                isUser: false,
-                isSystem: false,
-                content: '',
-                timestamp: Date.now(),
-                characterAvatar: character.avatar,
-                swipes: [''],
-                swipeId: 0,
-              },
-            ],
-          }));
-
-          let responseText = '';
-          for await (const token of parseSSEStream(stream)) {
-            if (!get().isSending) break;
-            responseText += token;
-            if (!get().isStreaming) set({ isStreaming: true });
-            set((state) => ({
-              messages: state.messages.map((msg) =>
-                msg.id === aiMessageId ? { ...msg, content: responseText, swipes: [responseText] } : msg
-              ),
-            }));
-          }
-
-          const emotion = parseEmotion(responseText);
-          const cleanedContent = stripEmotionTag(responseText);
-
-          set((state) => ({
-            messages: state.messages.map((msg) =>
-              msg.id === aiMessageId
-                ? { ...msg, content: cleanedContent, emotion, swipes: [cleanedContent] }
-                : msg
-            ),
-          }));
+      // Run the user-kicked turn(s) first, then loop while auto-mode is on
+      // and the user hasn't stopped us. Each loop tick re-runs pickSpeakers:
+      // for list-mode this still replays the whole roster each tick (that's
+      // what list means — a single "turn" for list is all members speaking
+      // once), and natural/pooled pick one speaker per tick.
+      let queue: CharacterInfo[] = initialQueue;
+      while (queue.length > 0 && get().isSending) {
+        for (const character of queue) {
+          if (!get().isSending) break;
+          const continued = await generateGroupTurn(
+            character,
+            characters,
+            scenarioOverride,
+            abortController,
+            get,
+            set
+          );
+          if (!continued) break;
         }
+
+        if (!autoModeEnabled || !get().isSending) break;
+
+        // Delay between auto-mode ticks. Poll isSending so stop breaks the
+        // wait promptly rather than leaving a dangling timer.
+        const delay = Math.max(0, autoModeDelayMs);
+        if (delay > 0) {
+          const start = Date.now();
+          while (Date.now() - start < delay && get().isSending) {
+            await new Promise((r) => setTimeout(r, Math.min(100, delay)));
+          }
+        }
+        if (!get().isSending) break;
+        queue = pickSpeakers();
       }
 
       // Save group chat
-      const { currentChatFile } = get();
-      if (currentChatFile && characters.length > 0) {
-        await saveChatToBackend(get().messages, characters[0], currentChatFile, true, characters);
+      const { currentChatFile: finalChatFile } = get();
+      if (finalChatFile && characters.length > 0) {
+        await saveChatToBackend(
+          get().messages,
+          characters[0],
+          finalChatFile,
+          true,
+          characters
+        );
       }
     } catch (error) {
       if ((error as Error).name !== 'AbortError') {
         set({ error: error instanceof Error ? error.message : 'Failed to send group message' });
+      }
+    } finally {
+      set({ isSending: false, isStreaming: false, abortController: null });
+    }
+  },
+
+  // ---- Force Group Member Talk (Phase 5.2) ----
+  // Makes the given member respond next, bypassing the activation strategy
+  // and mute state for exactly one turn. Intended to be wired to per-member
+  // "talk next" buttons in the group controls panel.
+  forceGroupMemberTalk: async (
+    character: CharacterInfo,
+    characters: CharacterInfo[]
+  ) => {
+    if (get().isSending) return; // caller should also gate the button
+    const { currentChatFile, getGroupChatByFile } = get();
+    const groupChat = currentChatFile ? getGroupChatByFile(currentChatFile) : null;
+    const scenarioOverride = groupChat?.scenarioOverride;
+
+    const abortController = new AbortController();
+    set({ isSending: true, isStreaming: false, error: null, abortController });
+
+    try {
+      await generateGroupTurn(
+        character,
+        characters,
+        scenarioOverride,
+        abortController,
+        get,
+        set
+      );
+
+      const { currentChatFile: finalChatFile } = get();
+      if (finalChatFile && characters.length > 0) {
+        await saveChatToBackend(
+          get().messages,
+          characters[0],
+          finalChatFile,
+          true,
+          characters
+        );
+      }
+    } catch (error) {
+      if ((error as Error).name !== 'AbortError') {
+        set({
+          error:
+            error instanceof Error
+              ? error.message
+              : 'Failed to force member to respond',
+        });
       }
     } finally {
       set({ isSending: false, isStreaming: false, abortController: null });


### PR DESCRIPTION
Force-talk, auto-mode continuous generation, manual activation strategy, drag-to-reorder members, and per-group scenario override.

- New `manual` strategy: sendGroupMessage no-ops so force-talk buttons are the only way to generate.
- New `autoModeEnabled` + `autoModeDelayMs` fields drive a continuous generation loop that picks the next speaker via the current strategy each tick. stopGeneration cleanly breaks the loop via polled isSending.
- New `scenarioOverride` field replaces per-character scenario in buildGroupConversationContext. Macros run, but `{{char}}` is blanked because it's ambiguous in a group.
- Drag-to-reorder round-trips through characterAvatars on GroupChatInfo plus an in-memory reorderGroupChatCharacters on characterStore so the order survives reload and reflects immediately.
- Extracted generateGroupTurn helper — shared by sendGroupMessage and forceGroupMemberTalk so the stream/finalize path can't drift.
- GroupChatInfo migration fills defaults for all new fields.