### PR TITLE
Add Phase 5.3: group chat polish

### DIFF
--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useMemo, useState, useCallback } from 'react';
-import { MessageSquare, Users, Settings2 } from 'lucide-react';
+import { MessageSquare, Users, Settings2, Pencil } from 'lucide-react';
 import { useCharacterStore } from '../../stores/characterStore';
 import { useChatStore } from '../../stores/chatStore';
 import { ChatMessage } from './ChatMessage';
@@ -37,13 +37,23 @@ export function ChatView() {
     impersonate,
     stopGeneration,
     currentChatFile,
+    currentSpeakerName,
+    setGroupTitle,
   } = useChatStore();
+  // Subscribe to the current group-chat record for title + strategy display.
+  const groupChatRecord = useChatStore((s) =>
+    isGroupChatMode && currentChatFile
+      ? s.groupChats.find((g) => g.fileName === currentChatFile) || null
+      : null
+  );
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const lastCharacterRef = useRef<string | null>(null);
   const [failedExpressions, setFailedExpressions] = useState<Set<string>>(new Set());
   const [prefillText, setPrefillText] = useState<string | undefined>(undefined);
   const [prefillNonce, setPrefillNonce] = useState(0);
   const [showGroupControls, setShowGroupControls] = useState(false);
+  const [isEditingTitle, setIsEditingTitle] = useState(false);
+  const [titleDraft, setTitleDraft] = useState('');
 
   const { getSpritePath, availableEmotions } = useCharacterSprites(selectedCharacter?.avatar);
 
@@ -171,9 +181,24 @@ export function ChatView() {
     );
   }
 
+  const membersLabel = groupChatCharacters.map((c) => c.name).join(', ');
+  const groupTitle =
+    groupChatRecord?.title && groupChatRecord.title.trim().length > 0
+      ? groupChatRecord.title
+      : membersLabel;
   const displayName = isGroupChatMode
-    ? groupChatCharacters.map((c) => c.name).join(', ')
+    ? groupTitle
     : selectedCharacter?.name ?? '';
+
+  const commitTitle = () => {
+    if (!currentChatFile) {
+      setIsEditingTitle(false);
+      return;
+    }
+    setGroupTitle(currentChatFile, titleDraft);
+    setIsEditingTitle(false);
+  };
+  const cancelTitleEdit = () => setIsEditingTitle(false);
 
   return (
     <div className="h-full flex flex-col overflow-hidden">
@@ -186,11 +211,47 @@ export function ChatView() {
                 <Users size={24} className="text-[var(--color-primary)]" />
               </div>
               <div className="flex-1 min-w-0">
-                <h2 className="text-lg font-semibold text-[var(--color-text-primary)] truncate">
-                  Group Chat
-                </h2>
+                {isEditingTitle ? (
+                  <input
+                    type="text"
+                    value={titleDraft}
+                    onChange={(e) => setTitleDraft(e.target.value)}
+                    onBlur={commitTitle}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') {
+                        e.preventDefault();
+                        commitTitle();
+                      } else if (e.key === 'Escape') {
+                        e.preventDefault();
+                        cancelTitleEdit();
+                      }
+                    }}
+                    placeholder={membersLabel}
+                    className="w-full bg-transparent text-lg font-semibold text-[var(--color-text-primary)] border-b border-[var(--color-primary)] focus:outline-none"
+                    autoFocus
+                    aria-label="Edit group chat title"
+                  />
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setTitleDraft(groupChatRecord?.title ?? '');
+                      setIsEditingTitle(true);
+                    }}
+                    className="flex items-center gap-1.5 group max-w-full"
+                    title="Edit title"
+                  >
+                    <h2 className="text-lg font-semibold text-[var(--color-text-primary)] truncate">
+                      {groupTitle || 'Group Chat'}
+                    </h2>
+                    <Pencil
+                      size={12}
+                      className="text-[var(--color-text-secondary)] opacity-0 group-hover:opacity-100 flex-shrink-0 transition-opacity"
+                    />
+                  </button>
+                )}
                 <p className="text-xs text-[var(--color-text-secondary)] truncate">
-                  {groupChatCharacters.map((c) => c.name).join(', ')}
+                  {membersLabel}
                 </p>
               </div>
               <button
@@ -326,10 +387,11 @@ export function ChatView() {
               </div>
             )}
 
-            {/* Typing indicator (only before first token) */}
+            {/* Typing indicator (only before first token). In group chats,
+                label with the speaker name so the user knows who is drafting. */}
             {isSending && !isStreaming && (
-              <div className="flex gap-3 px-4 py-3">
-                <div className="w-10 h-10 rounded-full bg-[var(--color-bg-tertiary)] flex items-center justify-center">
+              <div className="flex gap-3 px-4 py-3 items-center">
+                <div className="w-10 h-10 rounded-full bg-[var(--color-bg-tertiary)] flex items-center justify-center flex-shrink-0">
                   <div className="flex gap-1">
                     <span className="w-2 h-2 bg-[var(--color-text-secondary)] rounded-full animate-bounce" />
                     <span
@@ -342,6 +404,11 @@ export function ChatView() {
                     />
                   </div>
                 </div>
+                {isGroupChatMode && currentSpeakerName && (
+                  <span className="text-sm text-[var(--color-text-secondary)] italic truncate">
+                    {currentSpeakerName} is typing...
+                  </span>
+                )}
               </div>
             )}
 
@@ -371,6 +438,16 @@ export function ChatView() {
         prefillText={prefillText}
         prefillNonce={prefillNonce}
       />
+
+      {/* Manual-strategy hint: auto-pick is disabled, so user has to force-talk. */}
+      {isGroupChatMode &&
+        groupChatRecord?.activationStrategy === 'manual' &&
+        !isSending && (
+          <div className="px-4 pb-2 text-xs text-[var(--color-text-secondary)] italic border-t border-[var(--color-border)]/30 pt-2">
+            Manual mode: open settings{' '}
+            <Settings2 size={10} className="inline -mt-0.5" /> and tap a talk icon to choose who speaks next.
+          </div>
+        )}
     </div>
   );
 }

--- a/src/components/chat/GroupChatControls.tsx
+++ b/src/components/chat/GroupChatControls.tsx
@@ -4,6 +4,8 @@ import {
   VolumeX,
   MessageCircle,
   GripVertical,
+  UserPlus,
+  X,
 } from 'lucide-react';
 import type { CharacterInfo } from '../../api/client';
 import {
@@ -12,6 +14,8 @@ import {
   type GroupActivationStrategy,
 } from '../../stores/chatStore';
 import { useCharacterStore } from '../../stores/characterStore';
+import { Modal } from '../ui/Modal';
+import { getDefaultAvatarUrl } from '../../utils/emotions';
 
 interface GroupChatControlsProps {
   fileName: string;
@@ -68,18 +72,34 @@ export function GroupChatControls({
   const setGroupScenarioOverride = useChatStore((s) => s.setGroupScenarioOverride);
   const reorderGroupMembers = useChatStore((s) => s.reorderGroupMembers);
   const forceGroupMemberTalk = useChatStore((s) => s.forceGroupMemberTalk);
+  const setGroupTalkativenessOverride = useChatStore(
+    (s) => s.setGroupTalkativenessOverride
+  );
+  const addGroupChatMember = useChatStore((s) => s.addGroupChatMember);
+  const removeGroupChatMember = useChatStore((s) => s.removeGroupChatMember);
   const reorderGroupChatCharacters = useCharacterStore(
     (s) => s.reorderGroupChatCharacters
   );
+  const toggleGroupChatCharacter = useCharacterStore(
+    (s) => s.toggleGroupChatCharacter
+  );
+  const allCharacters = useCharacterStore((s) => s.characters);
 
   const mutedSet = useMemo(
     () => new Set(groupChat?.mutedAvatars ?? []),
     [groupChat?.mutedAvatars]
   );
+  const overrides = useMemo(
+    () => groupChat?.talkativenessOverrides ?? {},
+    [groupChat?.talkativenessOverrides]
+  );
 
   // Local drag state — we only persist when the drop lands.
   const [draggingAvatar, setDraggingAvatar] = useState<string | null>(null);
   const [dragOverAvatar, setDragOverAvatar] = useState<string | null>(null);
+  // Member add modal
+  const [showAddMemberModal, setShowAddMemberModal] = useState(false);
+  const [addMemberQuery, setAddMemberQuery] = useState('');
 
   if (!groupChat) return null;
 
@@ -132,6 +152,54 @@ export function GroupChatControls({
   const handleDragEnd = () => {
     setDraggingAvatar(null);
     setDragOverAvatar(null);
+  };
+
+  // Talkativeness slider: map [0, 100] UI range to [0, 1] stored value. A
+  // "reset" button clears the override back to the card's default.
+  const handleTalkSliderChange = (avatar: string, uiValue: number) => {
+    const clamped = Math.max(0, Math.min(1, uiValue / 100));
+    setGroupTalkativenessOverride(fileName, avatar, clamped);
+  };
+  const handleTalkReset = (avatar: string) => {
+    setGroupTalkativenessOverride(fileName, avatar, null);
+  };
+
+  // Filter out characters already in the group when rendering the add modal.
+  // The picker list mirrors the sidebar's sort: just alphabetical by name.
+  const inGroupAvatars = new Set(characters.map((c) => c.avatar));
+  const pickableCharacters = allCharacters
+    .filter((c) => !inGroupAvatars.has(c.avatar))
+    .filter((c) => {
+      const q = addMemberQuery.trim().toLowerCase();
+      if (!q) return true;
+      return (c.name || '').toLowerCase().includes(q);
+    })
+    .sort((a, b) => (a.name || '').localeCompare(b.name || ''));
+
+  const handleAddMember = async (character: CharacterInfo) => {
+    // 1) Add to the live roster (fetches full card data if needed)
+    await toggleGroupChatCharacter(character.avatar);
+    // 2) Pull the enriched character back out of the store and update the
+    //    persisted group + post greeting. toggleGroupChatCharacter has
+    //    resolved full-data by now.
+    const enriched =
+      useCharacterStore
+        .getState()
+        .groupChatCharacters.find((c) => c.avatar === character.avatar) ||
+      character;
+    addGroupChatMember(fileName, enriched);
+    setShowAddMemberModal(false);
+    setAddMemberQuery('');
+  };
+
+  const handleRemoveMember = (avatar: string) => {
+    if (isSending) return;
+    if (characters.length <= 2) return; // groups need 2+
+    // Remove from persisted record + live roster in lockstep. Use the direct
+    // avatar-based remove rather than toggle, which is order-sensitive.
+    removeGroupChatMember(fileName, avatar);
+    // toggleGroupChatCharacter on an in-group avatar removes it.
+    toggleGroupChatCharacter(avatar);
   };
 
   return (
@@ -258,15 +326,31 @@ export function GroupChatControls({
       </div>
 
       <div>
-        <label className="block text-xs font-semibold uppercase tracking-wide text-[var(--color-text-secondary)] mb-1.5">
-          Members ({characters.length - mutedSet.size}/{characters.length} active)
-        </label>
-        <ul className="space-y-1">
+        <div className="flex items-center justify-between mb-1.5">
+          <label className="text-xs font-semibold uppercase tracking-wide text-[var(--color-text-secondary)]">
+            Members ({characters.length - mutedSet.size}/{characters.length} active)
+          </label>
+          <button
+            type="button"
+            onClick={() => setShowAddMemberModal(true)}
+            disabled={isSending}
+            className="flex items-center gap-1 text-xs px-2 py-1 rounded-md bg-[var(--color-bg-tertiary)] text-[var(--color-text-primary)] hover:bg-[var(--color-bg-primary)] disabled:opacity-40 disabled:cursor-not-allowed"
+            title="Add a member"
+            aria-label="Add member"
+          >
+            <UserPlus size={12} />
+            <span>Add</span>
+          </button>
+        </div>
+        <ul className="space-y-2">
           {characters.map((c) => {
             const muted = mutedSet.has(c.avatar);
-            const talk = getTalkativeness(c);
+            const hasOverride =
+              typeof overrides[c.avatar] === 'number';
+            const talk = getTalkativeness(c, overrides[c.avatar]);
             const isDragTarget = dragOverAvatar === c.avatar;
             const isDragged = draggingAvatar === c.avatar;
+            const canRemove = characters.length > 2 && !isSending;
             return (
               <li
                 key={c.avatar}
@@ -275,68 +359,164 @@ export function GroupChatControls({
                 onDragOver={(e) => handleDragOver(c.avatar, e)}
                 onDrop={() => handleDrop(c.avatar)}
                 onDragEnd={handleDragEnd}
-                className={`flex items-center gap-1 rounded-md transition-colors ${
+                className={`rounded-md transition-colors ${
                   isDragTarget
                     ? 'bg-[var(--color-primary)]/20'
                     : 'bg-[var(--color-bg-tertiary)]/50'
                 } ${isDragged ? 'opacity-40' : ''}`}
               >
-                <span
-                  className={`flex-shrink-0 pl-1.5 ${
-                    isSending
-                      ? 'text-[var(--color-text-secondary)]/40'
-                      : 'text-[var(--color-text-secondary)] cursor-grab active:cursor-grabbing'
-                  }`}
-                  title={isSending ? 'Reorder disabled while sending' : 'Drag to reorder'}
-                  aria-label="Drag handle"
-                >
-                  <GripVertical size={14} />
-                </span>
-                <button
-                  type="button"
-                  onClick={() => toggleGroupMute(fileName, c.avatar)}
-                  className={`flex-1 flex items-center gap-2 px-1 py-1.5 text-sm transition-colors ${
-                    muted
-                      ? 'text-[var(--color-text-secondary)] opacity-70'
-                      : 'text-[var(--color-text-primary)] hover:opacity-80'
-                  }`}
-                  aria-pressed={muted}
-                  title={muted ? `Unmute ${c.name}` : `Mute ${c.name}`}
-                >
-                  {muted ? (
-                    <VolumeX size={16} className="text-red-400 flex-shrink-0" />
-                  ) : (
-                    <Volume2
-                      size={16}
-                      className="text-[var(--color-primary)] flex-shrink-0"
-                    />
-                  )}
+                <div className="flex items-center gap-1">
                   <span
-                    className={`flex-1 text-left truncate ${
-                      muted ? 'line-through' : ''
+                    className={`flex-shrink-0 pl-1.5 ${
+                      isSending
+                        ? 'text-[var(--color-text-secondary)]/40'
+                        : 'text-[var(--color-text-secondary)] cursor-grab active:cursor-grabbing'
                     }`}
+                    title={isSending ? 'Reorder disabled while sending' : 'Drag to reorder'}
+                    aria-label="Drag handle"
                   >
-                    {c.name}
+                    <GripVertical size={14} />
                   </span>
-                  <span className="text-xs text-[var(--color-text-secondary)] tabular-nums flex-shrink-0">
+                  <button
+                    type="button"
+                    onClick={() => toggleGroupMute(fileName, c.avatar)}
+                    className={`flex-1 flex items-center gap-2 px-1 py-1.5 text-sm transition-colors ${
+                      muted
+                        ? 'text-[var(--color-text-secondary)] opacity-70'
+                        : 'text-[var(--color-text-primary)] hover:opacity-80'
+                    }`}
+                    aria-pressed={muted}
+                    title={muted ? `Unmute ${c.name}` : `Mute ${c.name}`}
+                  >
+                    {muted ? (
+                      <VolumeX size={16} className="text-red-400 flex-shrink-0" />
+                    ) : (
+                      <Volume2
+                        size={16}
+                        className="text-[var(--color-primary)] flex-shrink-0"
+                      />
+                    )}
+                    <span
+                      className={`flex-1 text-left truncate ${
+                        muted ? 'line-through' : ''
+                      }`}
+                    >
+                      {c.name}
+                    </span>
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => forceGroupMemberTalk(c, characters)}
+                    disabled={isSending}
+                    className="flex-shrink-0 p-1.5 rounded-md text-[var(--color-primary)] hover:bg-[var(--color-bg-tertiary)] disabled:opacity-40 disabled:cursor-not-allowed"
+                    title={`Make ${c.name} respond next`}
+                    aria-label={`Force ${c.name} to respond`}
+                  >
+                    <MessageCircle size={16} />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleRemoveMember(c.avatar)}
+                    disabled={!canRemove}
+                    className="flex-shrink-0 p-1.5 mr-1 rounded-md text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-tertiary)] hover:text-red-400 disabled:opacity-30 disabled:cursor-not-allowed"
+                    title={
+                      characters.length <= 2
+                        ? 'Groups need at least 2 members'
+                        : `Remove ${c.name} from group`
+                    }
+                    aria-label={`Remove ${c.name} from group`}
+                  >
+                    <X size={14} />
+                  </button>
+                </div>
+                <div className="flex items-center gap-2 pl-6 pr-2 pb-2">
+                  <input
+                    type="range"
+                    min={0}
+                    max={100}
+                    step={5}
+                    value={Math.round(talk * 100)}
+                    onChange={(e) =>
+                      handleTalkSliderChange(c.avatar, Number(e.target.value))
+                    }
+                    className="flex-1 h-1 accent-[var(--color-primary)]"
+                    aria-label={`Talkativeness for ${c.name}`}
+                    title="Adjust talkativeness for this group only"
+                  />
+                  <span className="text-xs text-[var(--color-text-secondary)] tabular-nums flex-shrink-0 w-12 text-right">
                     t={talk.toFixed(2)}
+                    {hasOverride && (
+                      <span className="text-[var(--color-primary)]">*</span>
+                    )}
                   </span>
-                </button>
-                <button
-                  type="button"
-                  onClick={() => forceGroupMemberTalk(c, characters)}
-                  disabled={isSending}
-                  className="flex-shrink-0 p-1.5 mr-1 rounded-md text-[var(--color-primary)] hover:bg-[var(--color-bg-tertiary)] disabled:opacity-40 disabled:cursor-not-allowed"
-                  title={`Make ${c.name} respond next`}
-                  aria-label={`Force ${c.name} to respond`}
-                >
-                  <MessageCircle size={16} />
-                </button>
+                  {hasOverride && (
+                    <button
+                      type="button"
+                      onClick={() => handleTalkReset(c.avatar)}
+                      className="text-[10px] uppercase tracking-wide text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] px-1.5 py-0.5 rounded"
+                      title="Clear override, use card value"
+                    >
+                      reset
+                    </button>
+                  )}
+                </div>
               </li>
             );
           })}
         </ul>
       </div>
+
+      {showAddMemberModal && (
+        <Modal
+          isOpen={showAddMemberModal}
+          onClose={() => {
+            setShowAddMemberModal(false);
+            setAddMemberQuery('');
+          }}
+          title="Add member to group"
+          size="md"
+        >
+          <div className="space-y-3">
+            <input
+              type="text"
+              value={addMemberQuery}
+              onChange={(e) => setAddMemberQuery(e.target.value)}
+              placeholder="Search characters..."
+              className="w-full rounded-md bg-[var(--color-bg-tertiary)] text-sm text-[var(--color-text-primary)] border border-[var(--color-border)] px-3 py-2 placeholder:text-[var(--color-text-secondary)] focus:outline-none focus:ring-1 focus:ring-[var(--color-primary)]"
+              autoFocus
+            />
+            {pickableCharacters.length === 0 ? (
+              <p className="text-sm text-[var(--color-text-secondary)] text-center py-6">
+                {addMemberQuery.trim()
+                  ? 'No matching characters.'
+                  : 'All your characters are already in this group.'}
+              </p>
+            ) : (
+              <ul className="space-y-1 max-h-[50vh] overflow-y-auto">
+                {pickableCharacters.map((c) => (
+                  <li key={c.avatar}>
+                    <button
+                      type="button"
+                      onClick={() => handleAddMember(c)}
+                      className="w-full flex items-center gap-3 px-2 py-2 rounded-md text-left text-sm text-[var(--color-text-primary)] hover:bg-[var(--color-bg-tertiary)] transition-colors"
+                    >
+                      <img
+                        src={getDefaultAvatarUrl(c.avatar)}
+                        alt=""
+                        className="w-8 h-8 rounded-full object-cover bg-[var(--color-bg-tertiary)] flex-shrink-0"
+                        onError={(e) => {
+                          e.currentTarget.style.visibility = 'hidden';
+                        }}
+                      />
+                      <span className="flex-1 truncate">{c.name}</span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </Modal>
+      )}
     </div>
   );
 }

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -72,6 +72,11 @@ export interface GroupChatInfo {
   autoModeDelayMs: number;
   /** Phase 5.2: optional group-wide scenario replacing per-character scenario. */
   scenarioOverride: string;
+  /** Phase 5.3: per-member talkativeness override (avatar → [0,1]). Does not
+   *  mutate the card; only applies inside this group for weighted strategies. */
+  talkativenessOverrides: Record<string, number>;
+  /** Phase 5.3: user-editable chat title. Falls back to comma-joined names. */
+  title?: string;
 }
 
 const GROUP_CHATS_KEY = 'sillytavern_group_chats';
@@ -111,7 +116,27 @@ function migrateGroupChat(raw: Partial<GroupChatInfo> & {
         : DEFAULT_AUTO_MODE_DELAY_MS,
     scenarioOverride:
       typeof raw.scenarioOverride === 'string' ? raw.scenarioOverride : '',
+    talkativenessOverrides: sanitizeTalkativenessOverrides(
+      (raw as Partial<GroupChatInfo>).talkativenessOverrides
+    ),
+    title:
+      typeof (raw as Partial<GroupChatInfo>).title === 'string'
+        ? (raw as Partial<GroupChatInfo>).title
+        : undefined,
   };
+}
+
+function sanitizeTalkativenessOverrides(
+  raw: unknown
+): Record<string, number> {
+  if (!raw || typeof raw !== 'object') return {};
+  const out: Record<string, number> = {};
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof value !== 'number' || !isFinite(value)) continue;
+    const clamped = value < 0 ? 0 : value > 1 ? 1 : value;
+    out[key] = clamped;
+  }
+  return out;
 }
 
 function loadGroupChatsFromStorage(): GroupChatInfo[] {
@@ -131,8 +156,19 @@ function saveGroupChatsToStorage(groupChats: GroupChatInfo[]) {
 }
 
 /** Parse the per-character "talkativeness" extension, clamped to [0, 1].
- *  Falls back to 0.5 when absent, not a number, or out of range. */
-export function getTalkativeness(character: CharacterInfo): number {
+ *  Falls back to 0.5 when absent, not a number, or out of range.
+ *
+ *  Phase 5.3: optional `override` (0..1) wins when supplied — this is how
+ *  group-level talkativeness sliders take effect without mutating the card. */
+export function getTalkativeness(
+  character: CharacterInfo,
+  override?: number
+): number {
+  if (typeof override === 'number' && isFinite(override)) {
+    if (override < 0) return 0;
+    if (override > 1) return 1;
+    return override;
+  }
   const raw = character.data?.extensions?.talkativeness;
   if (typeof raw !== 'string') return 0.5;
   const n = parseFloat(raw);
@@ -147,14 +183,18 @@ function escapeRegExp(str: string): string {
 }
 
 /** Weighted random pick using talkativeness. Falls back to uniform when all
- *  weights are zero or the pool has a single entry. */
+ *  weights are zero or the pool has a single entry.
+ *
+ *  Phase 5.3: `overrides` (avatar → weight) lets the caller inject group-scope
+ *  talkativeness values without mutating the card. */
 function weightedRandomPick(
   pool: CharacterInfo[],
+  overrides: Record<string, number> | undefined,
   rng: () => number = Math.random
 ): CharacterInfo | null {
   if (pool.length === 0) return null;
   if (pool.length === 1) return pool[0];
-  const weights = pool.map(getTalkativeness);
+  const weights = pool.map((c) => getTalkativeness(c, overrides?.[c.avatar]));
   const total = weights.reduce((a, b) => a + b, 0);
   if (total <= 0) {
     return pool[Math.floor(rng() * pool.length)];
@@ -173,13 +213,14 @@ function weightedRandomPick(
 export function selectNaturalOrderSpeaker(
   candidates: CharacterInfo[],
   messages: ChatMessage[],
+  overrides?: Record<string, number>,
   rng: () => number = Math.random
 ): CharacterInfo | null {
   if (candidates.length === 0) return null;
 
   const lastMeaningful = [...messages].reverse().find((m) => !m.isSystem);
   if (!lastMeaningful || !lastMeaningful.content.trim()) {
-    return weightedRandomPick(candidates, rng);
+    return weightedRandomPick(candidates, overrides, rng);
   }
 
   const haystack = lastMeaningful.content;
@@ -191,9 +232,9 @@ export function selectNaturalOrderSpeaker(
   });
 
   if (mentioned.length === 0) {
-    return weightedRandomPick(candidates, rng);
+    return weightedRandomPick(candidates, overrides, rng);
   }
-  return weightedRandomPick(mentioned, rng);
+  return weightedRandomPick(mentioned, overrides, rng);
 }
 
 /** Pooled Order: weighted random pick from the candidates, excluding
@@ -203,11 +244,12 @@ export function selectPooledOrderSpeaker(
   candidates: CharacterInfo[],
   messages: ChatMessage[],
   excludeRecent: number,
+  overrides?: Record<string, number>,
   rng: () => number = Math.random
 ): CharacterInfo | null {
   if (candidates.length === 0) return null;
   const n = Math.max(0, Math.floor(excludeRecent));
-  if (n === 0) return weightedRandomPick(candidates, rng);
+  if (n === 0) return weightedRandomPick(candidates, overrides, rng);
 
   const recent: string[] = [];
   for (let i = messages.length - 1; i >= 0 && recent.length < n; i--) {
@@ -217,8 +259,8 @@ export function selectPooledOrderSpeaker(
   }
 
   const pool = candidates.filter((c) => !recent.includes(c.name));
-  if (pool.length === 0) return weightedRandomPick(candidates, rng);
-  return weightedRandomPick(pool, rng);
+  if (pool.length === 0) return weightedRandomPick(candidates, overrides, rng);
+  return weightedRandomPick(pool, overrides, rng);
 }
 
 interface ChatState {
@@ -231,6 +273,9 @@ interface ChatState {
   isStreaming: boolean;
   error: string | null;
   abortController: AbortController | null;
+  /** Phase 5.3: name of the character currently drafting a reply, surfaced
+   *  in the group-chat typing indicator. `null` when nobody is typing. */
+  currentSpeakerName: string | null;
 
   // Existing actions
   fetchChatFiles: (avatarUrl: string) => Promise<void>;
@@ -259,6 +304,16 @@ interface ChatState {
   setGroupAutoModeDelay: (fileName: string, delayMs: number) => void;
   setGroupScenarioOverride: (fileName: string, scenario: string) => void;
   reorderGroupMembers: (fileName: string, avatars: string[]) => void;
+
+  // Phase 5.3: per-member talkativeness overrides, title, live add/remove
+  setGroupTalkativenessOverride: (
+    fileName: string,
+    avatar: string,
+    value: number | null
+  ) => void;
+  setGroupTitle: (fileName: string, title: string) => void;
+  addGroupChatMember: (fileName: string, character: CharacterInfo) => void;
+  removeGroupChatMember: (fileName: string, avatar: string) => void;
 
   // New Phase 1 actions
   stopGeneration: () => void;
@@ -789,6 +844,12 @@ async function generateGroupTurn(
   get: () => ChatState,
   set: (partial: Partial<ChatState> | ((state: ChatState) => Partial<ChatState>)) => void
 ): Promise<boolean> {
+  // Surface this speaker to the typing indicator before the API call so the
+  // "X is typing..." row shows during the request, not just after the first
+  // token. Reset isStreaming so the indicator isn't masked by the prior
+  // speaker's tail streaming state.
+  set({ isStreaming: false, currentSpeakerName: character.name });
+
   const { provider, model } = getProviderAndModel();
   const updatedMessages = get().messages;
   const context = buildGroupConversationContext(
@@ -812,7 +873,6 @@ async function generateGroupTurn(
 
   const aiMessageId = generateId();
   set((state) => ({
-    isStreaming: false,
     messages: [
       ...state.messages,
       {
@@ -974,6 +1034,25 @@ function createMessage(data: Omit<ChatMessage, 'id' | 'swipes' | 'swipeId'>): Ch
   };
 }
 
+/** Reset streaming flags in a `finally` block only when the local controller
+ *  is still the active one. Prevents a slow-unwinding generator from wiping
+ *  the state of a newer operation the user kicked off (e.g. stop → force-talk
+ *  in quick succession). */
+function resetStreamingStateIfOwner(
+  localController: AbortController,
+  get: () => ChatState,
+  set: (partial: Partial<ChatState>) => void
+) {
+  if (get().abortController === localController) {
+    set({
+      isSending: false,
+      isStreaming: false,
+      abortController: null,
+      currentSpeakerName: null,
+    });
+  }
+}
+
 // Helper: normalize loaded messages to always have swipes
 function normalizeMessage(msg: {
   name: string;
@@ -1011,6 +1090,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
   isStreaming: false,
   error: null,
   abortController: null,
+  currentSpeakerName: null,
 
   refreshGroupChats: () => {
     set({ groupChats: loadGroupChatsFromStorage() });
@@ -1110,6 +1190,111 @@ export const useChatStore = create<ChatState>((set, get) => ({
         characterNames: nextNames,
       };
     });
+    saveGroupChatsToStorage(updated);
+    set({ groupChats: updated });
+  },
+
+  // ---- Phase 5.3: per-member talkativeness, title, live add/remove ----
+  setGroupTalkativenessOverride: (fileName, avatar, value) => {
+    const { groupChats } = get();
+    const updated = groupChats.map((g) => {
+      if (g.fileName !== fileName) return g;
+      const nextOverrides = { ...(g.talkativenessOverrides || {}) };
+      if (value === null || typeof value !== 'number' || !isFinite(value)) {
+        delete nextOverrides[avatar];
+      } else {
+        const clamped = value < 0 ? 0 : value > 1 ? 1 : value;
+        nextOverrides[avatar] = clamped;
+      }
+      return { ...g, talkativenessOverrides: nextOverrides };
+    });
+    saveGroupChatsToStorage(updated);
+    set({ groupChats: updated });
+  },
+
+  setGroupTitle: (fileName, title) => {
+    const trimmed = title.trim();
+    const { groupChats } = get();
+    const updated = groupChats.map((g) =>
+      g.fileName === fileName
+        ? { ...g, title: trimmed.length > 0 ? trimmed : undefined }
+        : g
+    );
+    saveGroupChatsToStorage(updated);
+    set({ groupChats: updated });
+  },
+
+  addGroupChatMember: (fileName, character) => {
+    const { groupChats, messages } = get();
+    const existing = groupChats.find((g) => g.fileName === fileName);
+    if (!existing) return;
+    if (existing.characterAvatars.includes(character.avatar)) return;
+
+    // Persist roster change.
+    const updated = groupChats.map((g) =>
+      g.fileName === fileName
+        ? {
+            ...g,
+            characterNames: [...g.characterNames, character.name],
+            characterAvatars: [...g.characterAvatars, character.avatar],
+          }
+        : g
+    );
+    saveGroupChatsToStorage(updated);
+
+    // Post greeting so the new member exists in context before being asked
+    // to speak. Use first_mes when available, otherwise a neutral join marker.
+    const firstMes = character.first_mes || character.data?.first_mes || '';
+    const greeting: ChatMessage = firstMes.trim()
+      ? createMessage({
+          name: character.name,
+          isUser: false,
+          isSystem: false,
+          content: firstMes,
+          timestamp: Date.now(),
+          characterAvatar: character.avatar,
+        })
+      : createMessage({
+          name: 'System',
+          isUser: false,
+          isSystem: true,
+          content: `${character.name} joined the chat.`,
+          timestamp: Date.now(),
+        });
+
+    set({
+      groupChats: updated,
+      messages: [...messages, greeting],
+    });
+  },
+
+  removeGroupChatMember: (fileName, avatar) => {
+    const { groupChats } = get();
+    const existing = groupChats.find((g) => g.fileName === fileName);
+    if (!existing) return;
+    if (!existing.characterAvatars.includes(avatar)) return;
+    // Refuse if removing would drop the group below 2 members — a group of 1
+    // is indistinguishable from a solo chat and breaks several assumptions.
+    if (existing.characterAvatars.length <= 2) return;
+
+    const idx = existing.characterAvatars.indexOf(avatar);
+    const nextAvatars = existing.characterAvatars.filter((_, i) => i !== idx);
+    const nextNames = existing.characterNames.filter((_, i) => i !== idx);
+    const nextMuted = existing.mutedAvatars.filter((a) => a !== avatar);
+    const nextOverrides = { ...(existing.talkativenessOverrides || {}) };
+    delete nextOverrides[avatar];
+
+    const updated = groupChats.map((g) =>
+      g.fileName === fileName
+        ? {
+            ...g,
+            characterAvatars: nextAvatars,
+            characterNames: nextNames,
+            mutedAvatars: nextMuted,
+            talkativenessOverrides: nextOverrides,
+          }
+        : g
+    );
     saveGroupChatsToStorage(updated);
     set({ groupChats: updated });
   },
@@ -1235,6 +1420,8 @@ export const useChatStore = create<ChatState>((set, get) => ({
       autoModeEnabled: false,
       autoModeDelayMs: DEFAULT_AUTO_MODE_DELAY_MS,
       scenarioOverride: '',
+      talkativenessOverrides: {},
+      title: undefined,
     };
     const updatedGroupChats = [...groupChats, newGroupChat];
     saveGroupChatsToStorage(updatedGroupChats);
@@ -1258,7 +1445,15 @@ export const useChatStore = create<ChatState>((set, get) => ({
     if (abortController) {
       abortController.abort();
     }
-    set({ isSending: false, isStreaming: false, abortController: null });
+    // Clear abortController + sending flags synchronously so the next action
+    // (e.g. force-talk after stop) sees clean state immediately. The in-flight
+    // generation's `finally` block guards against trampling a newer controller.
+    set({
+      isSending: false,
+      isStreaming: false,
+      abortController: null,
+      currentSpeakerName: null,
+    });
   },
 
   // ---- Edit Message (save only, no regeneration) ----
@@ -1597,6 +1792,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
     const autoModeDelayMs =
       groupChat?.autoModeDelayMs ?? DEFAULT_AUTO_MODE_DELAY_MS;
     const scenarioOverride = groupChat?.scenarioOverride;
+    const talkativenessOverrides = groupChat?.talkativenessOverrides;
 
     // Manual strategy: just post the user message and wait for force-talk.
     // Auto-mode is ignored when the strategy is manual — the user is in
@@ -1625,14 +1821,19 @@ export const useChatStore = create<ChatState>((set, get) => ({
     const pickSpeakers = (): CharacterInfo[] => {
       if (strategy === 'list') return activeCharacters;
       if (strategy === 'natural') {
-        const pick = selectNaturalOrderSpeaker(activeCharacters, get().messages);
+        const pick = selectNaturalOrderSpeaker(
+          activeCharacters,
+          get().messages,
+          talkativenessOverrides
+        );
         return pick ? [pick] : [];
       }
       if (strategy === 'pooled') {
         const pick = selectPooledOrderSpeaker(
           activeCharacters,
           get().messages,
-          pooledExcludeRecent
+          pooledExcludeRecent,
+          talkativenessOverrides
         );
         return pick ? [pick] : [];
       }
@@ -1700,7 +1901,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
         set({ error: error instanceof Error ? error.message : 'Failed to send group message' });
       }
     } finally {
-      set({ isSending: false, isStreaming: false, abortController: null });
+      resetStreamingStateIfOwner(abortController, get, set);
     }
   },
 
@@ -1750,7 +1951,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
         });
       }
     } finally {
-      set({ isSending: false, isStreaming: false, abortController: null });
+      resetStreamingStateIfOwner(abortController, get, set);
     }
   },
 


### PR DESCRIPTION
Per-member talkativeness overrides, live member add/remove, editable group titles, speaker-aware typing indicator, manual-mode hint, and a fix for the stop→force-talk abort race.

- GroupChatInfo gains talkativenessOverrides (avatar → [0,1]) and a user-editable title. Overrides flow through getTalkativeness / weightedRandomPick / selectNaturalOrderSpeaker / selectPooledOrderSpeaker so weighted strategies respect the in-group setting without mutating the card.
- addGroupChatMember posts the new member's first_mes (or a "X joined" system message) so they exist in context before being asked to speak. removeGroupChatMember cleans up the muted + override maps and refuses below 2 members. Live roster + persisted GroupChatInfo stay in lockstep.
- currentSpeakerName is set in generateGroupTurn *before* the API call so the group typing indicator shows "X is typing..." during the request, not just once the first token arrives.
- resetStreamingStateIfOwner guards every streaming finally block so a slow-unwinding generator can't wipe the abortController / isSending that a newer action (stop → force-talk) just installed.
- GroupChatControls: talkativeness slider per member (with reset when overridden), + Add modal with character picker, X remove button (disabled with tooltip at the 2-member floor).
- ChatView: click-to-edit title in the header (Enter commits, Escape cancels, falls back to comma-joined names), inline manual-strategy hint under the input telling the user to open settings + force-talk.