### PR TITLE
Add Phase 6.1: chat attachments & file uploads

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -139,6 +139,14 @@ export interface GenerationOptions {
   stopStrings?: string[];
 }
 
+/** Phase 6.1 — image attachment sent with generateMessage. `base64` is
+ *  the raw payload (NO `data:...;base64,` prefix); the API client folds
+ *  these into OpenAI-style content parts before POST. */
+export interface GenerationImage {
+  mimeType: string;
+  base64: string;
+}
+
 export const api = {
   // Auth endpoints
   async getUsers(): Promise<UserInfo[]> {
@@ -408,14 +416,48 @@ export const api = {
     provider?: string,
     model?: string,
     signal?: AbortSignal,
-    generationOptions?: GenerationOptions
+    generationOptions?: GenerationOptions,
+    images?: GenerationImage[]
   ): Promise<ReadableStream<Uint8Array> | null> {
     const token = await getCsrfToken();
+
+    // Phase 6.1: when the caller passed images, fold them into the LAST
+    // user message as OpenAI-style content parts. The SillyTavern backend
+    // at /api/backends/chat-completions/generate translates these to
+    // each provider's native multimodal format (Claude: base64 source,
+    // Gemini: inline_data parts), so we only need to emit one shape here.
+    let messagesToSend: unknown[] = messages;
+    if (images && images.length > 0) {
+      const lastUserIdx = (() => {
+        for (let i = messages.length - 1; i >= 0; i--) {
+          if (messages[i].role === 'user') return i;
+        }
+        return -1;
+      })();
+      if (lastUserIdx >= 0) {
+        const target = messages[lastUserIdx];
+        const parts: Array<Record<string, unknown>> = [];
+        if (target.content) {
+          parts.push({ type: 'text', text: target.content });
+        }
+        for (const img of images) {
+          parts.push({
+            type: 'image_url',
+            image_url: {
+              url: `data:${img.mimeType};base64,${img.base64}`,
+            },
+          });
+        }
+        messagesToSend = messages.map((m, i) =>
+          i === lastUserIdx ? { role: m.role, content: parts } : m
+        );
+      }
+    }
 
     // Build request body with optional sampler params.
     // Unknown fields are ignored by most providers.
     const body: Record<string, unknown> = {
-      messages,
+      messages: messagesToSend,
       stream: true,
       max_tokens: generationOptions?.maxTokens ?? 1024,
       temperature: generationOptions?.temperature ?? 0.9,

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -1,13 +1,25 @@
 import { useState, useRef, useEffect } from 'react';
-import { Send, Mic, Paperclip } from 'lucide-react';
+import { Send, Mic, Paperclip, X } from 'lucide-react';
 import { Button } from '../ui';
+import {
+  compressImageFiles,
+  ACCEPTED_IMAGE_MIMES,
+  MAX_IMAGES_PER_MESSAGE,
+} from '../../utils/images';
 
 interface ChatInputProps {
-  onSend: (message: string) => void;
+  /** Called with the trimmed text plus any staged image data URLs. */
+  onSend: (message: string, images?: string[]) => void;
   disabled?: boolean;
   placeholder?: string;
   prefillText?: string;
   prefillNonce?: number;
+  /** Phase 6.1: drag-dropped images from the chat scroll region. Parent
+   *  passes a fresh array each time it wants to APPEND to the staged
+   *  set; the nonce is bumped on every drop so the same payload retriggers
+   *  the effect. Passing an empty array with a new nonce is a no-op. */
+  droppedImages?: string[];
+  droppedImagesNonce?: number;
 }
 
 export function ChatInput({
@@ -16,9 +28,15 @@ export function ChatInput({
   placeholder = 'Type a message...',
   prefillText,
   prefillNonce,
+  droppedImages,
+  droppedImagesNonce,
 }: ChatInputProps) {
   const [message, setMessage] = useState('');
+  const [images, setImages] = useState<string[]>([]);
+  const [attachmentError, setAttachmentError] = useState<string | null>(null);
+  const [isCompressing, setIsCompressing] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   // Handle prefill text (e.g. from impersonate) - nonce lets parent trigger re-prefill
   useEffect(() => {
@@ -28,6 +46,25 @@ export function ChatInput({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [prefillNonce]);
+
+  // Merge drag-dropped images from parent, respecting the per-message cap.
+  useEffect(() => {
+    if (droppedImagesNonce === undefined) return;
+    if (!droppedImages || droppedImages.length === 0) return;
+    setImages((prev) => {
+      const next = [...prev, ...droppedImages].slice(0, MAX_IMAGES_PER_MESSAGE);
+      if (
+        prev.length + droppedImages.length > MAX_IMAGES_PER_MESSAGE &&
+        next.length === MAX_IMAGES_PER_MESSAGE
+      ) {
+        setAttachmentError(
+          `Max ${MAX_IMAGES_PER_MESSAGE} images per message`
+        );
+      }
+      return next;
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [droppedImagesNonce]);
 
   // Auto-resize textarea
   useEffect(() => {
@@ -40,9 +77,13 @@ export function ChatInput({
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (message.trim() && !disabled) {
-      onSend(message.trim());
+    const hasText = message.trim().length > 0;
+    const hasImages = images.length > 0;
+    if ((hasText || hasImages) && !disabled && !isCompressing) {
+      onSend(message.trim(), hasImages ? images : undefined);
       setMessage('');
+      setImages([]);
+      setAttachmentError(null);
     }
   };
 
@@ -53,11 +94,117 @@ export function ChatInput({
     }
   };
 
+  const handlePickFiles = () => {
+    if (disabled || isCompressing) return;
+    fileInputRef.current?.click();
+  };
+
+  const handleFilesSelected = async (
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const files = Array.from(e.target.files ?? []);
+    // Reset the input value so picking the SAME file twice in a row still
+    // fires change (useful after a user cancels a preview and re-picks).
+    e.target.value = '';
+    if (files.length === 0) return;
+
+    const remainingSlots = Math.max(0, MAX_IMAGES_PER_MESSAGE - images.length);
+    if (remainingSlots === 0) {
+      setAttachmentError(`Max ${MAX_IMAGES_PER_MESSAGE} images per message`);
+      return;
+    }
+    const accepted = files.slice(0, remainingSlots);
+    const overflow = files.length - accepted.length;
+
+    setAttachmentError(null);
+    setIsCompressing(true);
+    try {
+      const { dataUrls, errors } = await compressImageFiles(accepted);
+      if (dataUrls.length > 0) {
+        setImages((prev) =>
+          [...prev, ...dataUrls].slice(0, MAX_IMAGES_PER_MESSAGE)
+        );
+      }
+      const parts: string[] = [];
+      if (overflow > 0) {
+        parts.push(
+          `Only kept first ${accepted.length} of ${files.length} (max ${MAX_IMAGES_PER_MESSAGE}).`
+        );
+      }
+      if (errors.length > 0) {
+        parts.push(errors.join('; '));
+      }
+      if (parts.length > 0) setAttachmentError(parts.join(' '));
+    } finally {
+      setIsCompressing(false);
+    }
+  };
+
+  const handleRemoveImage = (index: number) => {
+    setImages((prev) => prev.filter((_, i) => i !== index));
+    setAttachmentError(null);
+  };
+
+  const canSubmit = (message.trim().length > 0 || images.length > 0) && !isCompressing;
+
   return (
     <form
       onSubmit={handleSubmit}
       className="border-t border-[var(--color-border)] bg-[var(--color-bg-secondary)] p-3 pb-4 input-safe-bottom"
     >
+      {/* Hidden file picker, driven by the paperclip button. */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept={ACCEPTED_IMAGE_MIMES.join(',')}
+        multiple
+        onChange={handleFilesSelected}
+        className="hidden"
+        aria-hidden="true"
+      />
+
+      {/* Preview strip for staged images. Shown above the input row so the
+          send button alignment stays consistent when attachments exist. */}
+      {images.length > 0 && (
+        <div
+          className="flex gap-2 mb-2 overflow-x-auto pb-1"
+          aria-label="Staged image attachments"
+        >
+          {images.map((dataUrl, idx) => (
+            <div
+              key={idx}
+              className="relative flex-shrink-0 w-16 h-16 rounded-lg overflow-hidden bg-[var(--color-bg-tertiary)] border border-[var(--color-border)]"
+            >
+              <img
+                src={dataUrl}
+                alt={`Attachment ${idx + 1}`}
+                className="w-full h-full object-cover"
+              />
+              <button
+                type="button"
+                onClick={() => handleRemoveImage(idx)}
+                className="absolute top-0.5 right-0.5 w-5 h-5 rounded-full bg-black/70 hover:bg-black/90 flex items-center justify-center transition-colors"
+                aria-label={`Remove attachment ${idx + 1}`}
+                title="Remove"
+              >
+                <X size={12} className="text-white" />
+              </button>
+            </div>
+          ))}
+          {isCompressing && (
+            <div className="flex-shrink-0 w-16 h-16 rounded-lg bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] flex items-center justify-center">
+              <span className="text-[10px] text-[var(--color-text-secondary)]">...</span>
+            </div>
+          )}
+        </div>
+      )}
+
+      {attachmentError && (
+        <div className="mb-2 text-xs text-red-400" role="alert">
+          {attachmentError}
+        </div>
+      )}
+
       <div className="flex items-end gap-2">
         {/* Attachment Button */}
         <Button
@@ -65,7 +212,9 @@ export function ChatInput({
           variant="ghost"
           size="sm"
           className="p-2 flex-shrink-0"
-          aria-label="Attach file"
+          aria-label="Attach image"
+          onClick={handlePickFiles}
+          disabled={disabled || isCompressing || images.length >= MAX_IMAGES_PER_MESSAGE}
         >
           <Paperclip size={20} />
         </Button>
@@ -85,12 +234,12 @@ export function ChatInput({
         </div>
 
         {/* Voice/Send Button */}
-        {message.trim() ? (
+        {canSubmit ? (
           <Button
             type="submit"
             variant="primary"
             size="sm"
-            disabled={disabled}
+            disabled={disabled || isCompressing}
             className="p-2 rounded-full flex-shrink-0"
             aria-label="Send message"
           >

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -12,6 +12,8 @@ interface ChatMessageProps {
   avatar?: string;
   timestamp?: number;
   disabled?: boolean;
+  /** Phase 6.1: attached image data URLs shown as a grid above content. */
+  images?: string[];
   // Swipe support (only for AI messages)
   swipes?: string[];
   swipeId?: number;
@@ -98,6 +100,7 @@ export function ChatMessage({
   avatar,
   timestamp,
   disabled,
+  images,
   swipes,
   swipeId,
   showSwipeControl,
@@ -243,6 +246,33 @@ export function ChatMessage({
               ${isEditing ? 'w-full' : ''}
             `}
           >
+            {/* Phase 6.1: image attachments render above the text content.
+                Grid scales column count to keep thumbnails reasonable. */}
+            {!isEditing && images && images.length > 0 && (
+              <div
+                className={`grid gap-1 ${content.length > 0 ? 'mb-2' : ''} ${
+                  images.length === 1 ? 'grid-cols-1' : 'grid-cols-2'
+                }`}
+              >
+                {images.map((src, idx) => (
+                  <a
+                    key={idx}
+                    href={src}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="block rounded-lg overflow-hidden"
+                    aria-label={`View attachment ${idx + 1}`}
+                  >
+                    <img
+                      src={src}
+                      alt={`Attachment ${idx + 1}`}
+                      className="w-full h-auto max-h-60 object-cover block"
+                      loading="lazy"
+                    />
+                  </a>
+                ))}
+              </div>
+            )}
             {isEditing ? (
               <div className="flex flex-col gap-2">
                 <textarea
@@ -298,11 +328,11 @@ export function ChatMessage({
                   )}
                 </div>
               </div>
-            ) : (
+            ) : content.length > 0 ? (
               <div className="text-sm whitespace-pre-wrap break-words">
                 <FormattedContent content={content} isUser={isUser} />
               </div>
-            )}
+            ) : null}
           </div>
         </div>
 

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -12,6 +12,10 @@ import {
   getDefaultAvatarUrl,
   type Emotion,
 } from '../../utils/emotions';
+import {
+  compressImageFiles,
+  ACCEPTED_IMAGE_MIMES,
+} from '../../utils/images';
 
 export function ChatView() {
   const { selectedCharacter, isGroupChatMode, groupChatCharacters, exitGroupChat } = useCharacterStore();
@@ -54,6 +58,12 @@ export function ChatView() {
   const [showGroupControls, setShowGroupControls] = useState(false);
   const [isEditingTitle, setIsEditingTitle] = useState(false);
   const [titleDraft, setTitleDraft] = useState('');
+  // Phase 6.1: drag-drop staging — data URLs to append to ChatInput's
+  // attachment set, re-triggered by the nonce so identical payloads fire.
+  const [droppedImages, setDroppedImages] = useState<string[]>([]);
+  const [droppedImagesNonce, setDroppedImagesNonce] = useState(0);
+  const [isDragOver, setIsDragOver] = useState(false);
+  const dragCounter = useRef(0);
 
   const { getSpritePath, availableEmotions } = useCharacterSprites(selectedCharacter?.avatar);
 
@@ -127,13 +137,55 @@ export function ChatView() {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages]);
 
-  const handleSend = (content: string) => {
+  const handleSend = (content: string, images?: string[]) => {
     if (isGroupChatMode && groupChatCharacters.length >= 2) {
-      sendGroupMessage(content, groupChatCharacters);
+      sendGroupMessage(content, groupChatCharacters, images);
     } else if (selectedCharacter) {
-      sendMessage(content, selectedCharacter, availableEmotions);
+      sendMessage(content, selectedCharacter, availableEmotions, images);
     }
   };
+
+  // Phase 6.1: drag-and-drop image staging. Only `image/*` files are
+  // accepted — everything else falls through to the browser. Nested
+  // drag-enter/leave events use a counter so the overlay doesn't flicker
+  // when dragging over child elements.
+  const handleDragEnter = useCallback((e: React.DragEvent) => {
+    if (!e.dataTransfer.types.includes('Files')) return;
+    e.preventDefault();
+    dragCounter.current += 1;
+    setIsDragOver(true);
+  }, []);
+
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    if (!e.dataTransfer.types.includes('Files')) return;
+    e.preventDefault();
+    dragCounter.current = Math.max(0, dragCounter.current - 1);
+    if (dragCounter.current === 0) setIsDragOver(false);
+  }, []);
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    if (!e.dataTransfer.types.includes('Files')) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'copy';
+  }, []);
+
+  const handleDrop = useCallback(async (e: React.DragEvent) => {
+    if (!e.dataTransfer.types.includes('Files')) return;
+    e.preventDefault();
+    dragCounter.current = 0;
+    setIsDragOver(false);
+
+    const files = Array.from(e.dataTransfer.files ?? []).filter((f) =>
+      (ACCEPTED_IMAGE_MIMES as readonly string[]).includes(f.type)
+    );
+    if (files.length === 0) return;
+
+    const { dataUrls } = await compressImageFiles(files);
+    if (dataUrls.length > 0) {
+      setDroppedImages(dataUrls);
+      setDroppedImagesNonce((n) => n + 1);
+    }
+  }, []);
 
   const handleRegenerate = () => {
     if (selectedCharacter && !isGroupChatMode) {
@@ -312,7 +364,23 @@ export function ChatView() {
       ) : null}
 
       {/* Messages Area */}
-      <div className="flex-1 min-h-0 overflow-y-auto">
+      <div
+        className={`flex-1 min-h-0 overflow-y-auto relative ${
+          isDragOver ? 'ring-2 ring-[var(--color-primary)] ring-inset' : ''
+        }`}
+        onDragEnter={handleDragEnter}
+        onDragLeave={handleDragLeave}
+        onDragOver={handleDragOver}
+        onDrop={handleDrop}
+      >
+        {/* Drag-drop overlay — non-interactive, just a visual cue. */}
+        {isDragOver && (
+          <div className="absolute inset-0 z-10 pointer-events-none flex items-center justify-center bg-[var(--color-primary)]/10 backdrop-blur-sm">
+            <div className="px-4 py-2 rounded-lg bg-[var(--color-bg-secondary)] border border-[var(--color-primary)] text-sm text-[var(--color-text-primary)] shadow-lg">
+              Drop images to attach
+            </div>
+          </div>
+        )}
         {messages.length === 0 ? (
           <div className="h-full flex flex-col items-center justify-center text-center p-8">
             <div className="w-20 h-20 rounded-full bg-[var(--color-bg-tertiary)] flex items-center justify-center mb-4">
@@ -356,6 +424,7 @@ export function ChatView() {
                   avatar={messageAvatar}
                   timestamp={message.timestamp}
                   disabled={isSending}
+                  images={message.images}
                   swipes={message.swipes}
                   swipeId={message.swipeId}
                   showSwipeControl={showSwipeControl}
@@ -437,6 +506,8 @@ export function ChatView() {
         placeholder={isGroupChatMode ? `Message the group...` : `Message ${displayName}...`}
         prefillText={prefillText}
         prefillNonce={prefillNonce}
+        droppedImages={droppedImages}
+        droppedImagesNonce={droppedImagesNonce}
       />
 
       {/* Manual-strategy hint: auto-pick is disabled, so user has to force-talk. */}

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -1,5 +1,10 @@
 import { create } from 'zustand';
-import { api, type CharacterInfo, type GenerationOptions } from '../api/client';
+import {
+  api,
+  type CharacterInfo,
+  type GenerationOptions,
+  type GenerationImage,
+} from '../api/client';
 import { useSettingsStore } from './settingsStore';
 import { usePersonaStore } from './personaStore';
 import { useGenerationStore } from './generationStore';
@@ -11,6 +16,7 @@ import {
   type MatchedEntry,
 } from './worldInfoStore';
 import { parseEmotion, stripEmotionTag, type Emotion } from '../utils/emotions';
+import { dataUrlToPart, supportsVision } from '../utils/images';
 import { processMacros, type MacroContext } from '../utils/macros';
 import {
   estimateConversationTokens,
@@ -31,6 +37,11 @@ export interface ChatMessage {
   characterAvatar?: string;
   swipes: string[];
   swipeId: number;
+  /** Phase 6.1: user-attached images as data URLs (e.g. data:image/jpeg;base64,...).
+   *  Rendered as a grid above content in ChatMessage.tsx and folded into the
+   *  provider's multimodal content parts on the LAST user turn when calling
+   *  generateMessage. Persisted into the JSONL record's `extra.images` field. */
+  images?: string[];
 }
 
 interface ChatFile {
@@ -284,8 +295,17 @@ interface ChatState {
   startNewChat: (character: CharacterInfo) => Promise<void>;
   startNewGroupChat: (characters: CharacterInfo[]) => Promise<void>;
   addMessage: (message: Omit<ChatMessage, 'id' | 'swipes' | 'swipeId'>) => void;
-  sendMessage: (content: string, character: CharacterInfo, availableEmotions?: string[]) => Promise<void>;
-  sendGroupMessage: (content: string, characters: CharacterInfo[]) => Promise<void>;
+  sendMessage: (
+    content: string,
+    character: CharacterInfo,
+    availableEmotions?: string[],
+    images?: string[]
+  ) => Promise<void>;
+  sendGroupMessage: (
+    content: string,
+    characters: CharacterInfo[],
+    images?: string[]
+  ) => Promise<void>;
   /** Phase 5.2: force a single member to respond next, bypassing strategy + mute. */
   forceGroupMemberTalk: (character: CharacterInfo, characters: CharacterInfo[]) => Promise<void>;
   editMessageAndRegenerate: (messageId: string, newContent: string, character: CharacterInfo, availableEmotions?: string[]) => Promise<void>;
@@ -842,7 +862,8 @@ async function generateGroupTurn(
   scenarioOverride: string | undefined,
   abortController: AbortController,
   get: () => ChatState,
-  set: (partial: Partial<ChatState> | ((state: ChatState) => Partial<ChatState>)) => void
+  set: (partial: Partial<ChatState> | ((state: ChatState) => Partial<ChatState>)) => void,
+  images?: GenerationImage[]
 ): Promise<boolean> {
   // Surface this speaker to the typing indicator before the API call so the
   // "X is typing..." row shows during the request, not just after the first
@@ -866,7 +887,8 @@ async function generateGroupTurn(
     provider,
     model,
     abortController.signal,
-    getGenerationOptions()
+    getGenerationOptions(),
+    images
   );
 
   if (!stream) return false;
@@ -1010,6 +1032,17 @@ async function saveChatToBackend(
       swipes: msg.swipes,
       swipe_id: msg.swipeId,
       ...(msg.characterAvatar ? { character_avatar: msg.characterAvatar } : {}),
+      // Phase 6.1: persist image attachments into extra.images (array) and
+      // extra.image (first element, SillyTavern-compat fallback for any
+      // code path that still reads the scalar form).
+      ...(msg.images && msg.images.length > 0
+        ? {
+            extra: {
+              images: msg.images,
+              image: msg.images[0],
+            },
+          }
+        : {}),
     })),
   ];
 
@@ -1032,6 +1065,40 @@ function createMessage(data: Omit<ChatMessage, 'id' | 'swipes' | 'swipeId'>): Ch
     swipes: [data.content],
     swipeId: 0,
   };
+}
+
+/** Phase 6.1: convert stored data-URL images into the provider-neutral
+ *  `{mimeType, base64}` form the API client expects. Malformed entries
+ *  are silently dropped — callers already staged valid data URLs. */
+function resolveImagesForSend(
+  images: string[] | undefined
+): GenerationImage[] | undefined {
+  if (!images || images.length === 0) return undefined;
+  const parts: GenerationImage[] = [];
+  for (const url of images) {
+    const part = dataUrlToPart(url);
+    if (part) parts.push(part);
+  }
+  return parts.length > 0 ? parts : undefined;
+}
+
+/** Phase 6.1: pull the most recent user message's images from a history
+ *  so follow-up generations (swipe/regen/continue/edit-and-regen) keep the
+ *  multimodal attachment in play even when the caller didn't pass images
+ *  directly. Returns undefined if the model can't see images or the last
+ *  user message has none. */
+function imagesFromLastUserMessage(
+  messages: ChatMessage[],
+  provider: string,
+  model: string
+): GenerationImage[] | undefined {
+  if (!supportsVision(provider, model)) return undefined;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i];
+    if (!m.isUser) continue;
+    return resolveImagesForSend(m.images);
+  }
+  return undefined;
 }
 
 /** Reset streaming flags in a `finally` block only when the local controller
@@ -1063,10 +1130,31 @@ function normalizeMessage(msg: {
   swipes?: string[];
   swipe_id?: number;
   character_avatar?: string;
+  // Phase 6.1: vision attachments persisted via extra.images (our field)
+  // with a fallback to extra.image (single-item, SillyTavern-compat).
+  extra?: {
+    images?: unknown;
+    image?: unknown;
+    [key: string]: unknown;
+  };
 }): ChatMessage {
   const content = msg.swipes && msg.swipe_id !== undefined
     ? msg.swipes[msg.swipe_id] ?? msg.mes
     : msg.mes;
+
+  // Recover image attachments. Array form wins; scalar `extra.image`
+  // (SillyTavern single-image legacy) is promoted to a 1-element array.
+  let images: string[] | undefined;
+  const rawImages = msg.extra?.images;
+  if (Array.isArray(rawImages)) {
+    const arr = rawImages.filter(
+      (x): x is string => typeof x === 'string' && x.startsWith('data:')
+    );
+    if (arr.length > 0) images = arr;
+  } else if (typeof msg.extra?.image === 'string' && msg.extra.image.startsWith('data:')) {
+    images = [msg.extra.image];
+  }
+
   return {
     id: generateId(),
     name: msg.name,
@@ -1077,6 +1165,7 @@ function normalizeMessage(msg: {
     swipes: msg.swipes && msg.swipes.length > 0 ? msg.swipes : [msg.mes],
     swipeId: msg.swipe_id ?? 0,
     characterAvatar: msg.character_avatar,
+    images,
   };
 }
 
@@ -1516,7 +1605,15 @@ export const useChatStore = create<ChatState>((set, get) => ({
       const { provider, model } = getProviderAndModel();
 
       const finalContext = maybeApplyInstructMode(context);
-      const stream = await api.generateMessage(finalContext, character.name, provider, model, abortController.signal, getGenerationOptions());
+      const stream = await api.generateMessage(
+        finalContext,
+        character.name,
+        provider,
+        model,
+        abortController.signal,
+        getGenerationOptions(),
+        imagesFromLastUserMessage(contextMessages, provider, model)
+      );
       if (!stream) return;
 
       // Add new empty swipe
@@ -1596,7 +1693,15 @@ export const useChatStore = create<ChatState>((set, get) => ({
 
       const { provider, model } = getProviderAndModel();
       const finalContext = maybeApplyInstructMode(context);
-      const stream = await api.generateMessage(finalContext, character.name, provider, model, abortController.signal, getGenerationOptions());
+      const stream = await api.generateMessage(
+        finalContext,
+        character.name,
+        provider,
+        model,
+        abortController.signal,
+        getGenerationOptions(),
+        imagesFromLastUserMessage(messages, provider, model)
+      );
       if (!stream) return;
 
       const existingContent = lastAiMsg.content;
@@ -1692,8 +1797,25 @@ export const useChatStore = create<ChatState>((set, get) => ({
   },
 
   // ---- Send Message (updated with abort support) ----
-  sendMessage: async (content: string, character: CharacterInfo, availableEmotions?: string[]) => {
+  sendMessage: async (
+    content: string,
+    character: CharacterInfo,
+    availableEmotions?: string[],
+    images?: string[]
+  ) => {
     const { addMessage } = get();
+
+    // Phase 6.1: non-vision model guard. Refuse to send images to a model
+    // that can't read them — otherwise the backend turns the content-part
+    // payload into an opaque 400/500. The user-facing message still posts
+    // (minus attachments) so the user can retry after switching models.
+    const { provider, model } = getProviderAndModel();
+    let attachedImages = images;
+    let visionError: string | null = null;
+    if (attachedImages && attachedImages.length > 0 && !supportsVision(provider, model)) {
+      visionError = `${model || provider || 'This model'} can't see images. Switch to a vision-capable model (GPT-4o, Claude 3+, Gemini) to send attachments.`;
+      attachedImages = undefined;
+    }
 
     addMessage({
       name: 'You',
@@ -1701,18 +1823,26 @@ export const useChatStore = create<ChatState>((set, get) => ({
       isSystem: false,
       content,
       timestamp: Date.now(),
+      images: attachedImages,
     });
 
     const abortController = new AbortController();
-    set({ isSending: true, isStreaming: false, error: null, abortController });
+    set({ isSending: true, isStreaming: false, error: visionError, abortController });
 
     try {
       const updatedMessages = get().messages;
       const context = buildConversationContext(updatedMessages, character, availableEmotions);
-      const { provider, model } = getProviderAndModel();
 
       const finalContext = maybeApplyInstructMode(context);
-      const stream = await api.generateMessage(finalContext, character.name, provider, model, abortController.signal, getGenerationOptions());
+      const stream = await api.generateMessage(
+        finalContext,
+        character.name,
+        provider,
+        model,
+        abortController.signal,
+        getGenerationOptions(),
+        resolveImagesForSend(attachedImages)
+      );
 
       if (stream) {
         const aiMessageId = generateId();
@@ -1768,8 +1898,25 @@ export const useChatStore = create<ChatState>((set, get) => ({
   },
 
   // ---- Send Group Message (updated with abort support) ----
-  sendGroupMessage: async (content: string, characters: CharacterInfo[]) => {
+  sendGroupMessage: async (
+    content: string,
+    characters: CharacterInfo[],
+    images?: string[]
+  ) => {
     const { addMessage, currentChatFile, getGroupChatByFile } = get();
+
+    // Phase 6.1: non-vision model guard — same as single-character send.
+    const { provider, model } = getProviderAndModel();
+    let attachedImages = images;
+    let visionError: string | null = null;
+    if (
+      attachedImages &&
+      attachedImages.length > 0 &&
+      !supportsVision(provider, model)
+    ) {
+      visionError = `${model || provider || 'This model'} can't see images. Switch to a vision-capable model (GPT-4o, Claude 3+, Gemini) to send attachments.`;
+      attachedImages = undefined;
+    }
 
     addMessage({
       name: 'You',
@@ -1777,7 +1924,12 @@ export const useChatStore = create<ChatState>((set, get) => ({
       isSystem: false,
       content,
       timestamp: Date.now(),
+      images: attachedImages,
     });
+
+    if (visionError) {
+      set({ error: visionError });
+    }
 
     // Resolve strategy + mute from the persisted group chat record. Missing
     // record (very old group chats not reloaded) falls back to list order
@@ -1847,7 +1999,15 @@ export const useChatStore = create<ChatState>((set, get) => ({
     }
 
     const abortController = new AbortController();
-    set({ isSending: true, isStreaming: false, error: null, abortController });
+    // Preserve visionError from the pre-send guard — the turn is still
+    // attempted (without images), but we keep the inline warning visible.
+    set({
+      isSending: true,
+      isStreaming: false,
+      error: visionError,
+      abortController,
+    });
+    const resolvedImages = resolveImagesForSend(attachedImages);
 
     try {
       // Run the user-kicked turn(s) first, then loop while auto-mode is on
@@ -1856,17 +2016,24 @@ export const useChatStore = create<ChatState>((set, get) => ({
       // what list means — a single "turn" for list is all members speaking
       // once), and natural/pooled pick one speaker per tick.
       let queue: CharacterInfo[] = initialQueue;
+      let isFirstTurn = true;
       while (queue.length > 0 && get().isSending) {
         for (const character of queue) {
           if (!get().isSending) break;
+          // Only the first turn of the first tick gets images — subsequent
+          // characters in the same round are responding to the prior speaker,
+          // not to the user's attachment. (We'd re-send the same bytes to
+          // each character otherwise.)
           const continued = await generateGroupTurn(
             character,
             characters,
             scenarioOverride,
             abortController,
             get,
-            set
+            set,
+            isFirstTurn ? resolvedImages : undefined
           );
+          isFirstTurn = false;
           if (!continued) break;
         }
 
@@ -1922,13 +2089,15 @@ export const useChatStore = create<ChatState>((set, get) => ({
     set({ isSending: true, isStreaming: false, error: null, abortController });
 
     try {
+      const { provider, model } = getProviderAndModel();
       await generateGroupTurn(
         character,
         characters,
         scenarioOverride,
         abortController,
         get,
-        set
+        set,
+        imagesFromLastUserMessage(get().messages, provider, model)
       );
 
       const { currentChatFile: finalChatFile } = get();
@@ -1975,7 +2144,15 @@ export const useChatStore = create<ChatState>((set, get) => ({
       const { provider, model } = getProviderAndModel();
 
       const finalContext = maybeApplyInstructMode(context);
-      const stream = await api.generateMessage(finalContext, character.name, provider, model, abortController.signal, getGenerationOptions());
+      const stream = await api.generateMessage(
+        finalContext,
+        character.name,
+        provider,
+        model,
+        abortController.signal,
+        getGenerationOptions(),
+        imagesFromLastUserMessage(updatedMessages, provider, model)
+      );
 
       if (stream) {
         const aiMessageId = generateId();

--- a/src/utils/images.ts
+++ b/src/utils/images.ts
@@ -1,0 +1,211 @@
+// Phase 6.1 — image attachments for chat messages.
+//
+// This module owns three concerns:
+//   1. Shrinking user-picked images to a sane payload size before we ship
+//      base64 across the wire (max edge + JPEG re-encode).
+//   2. Parsing/serializing between data-URL form (what we store on
+//      ChatMessage.images + render in <img src>) and {mimeType, base64}
+//      tuples (what the API client folds into provider content parts).
+//   3. Deciding whether the current provider+model can actually *see*
+//      images — non-vision models get a friendly inline error instead of
+//      a silent 400 from the backend.
+
+/** Largest edge (pixels) after resize. Bigger images get scaled down
+ *  proportionally; smaller ones pass through untouched. */
+export const MAX_IMAGE_EDGE = 1024;
+/** JPEG quality used when we have to re-encode. Tuned for "looks fine on
+ *  a phone screen" without blowing up the base64 payload. */
+export const IMAGE_JPEG_QUALITY = 0.85;
+/** Reject files larger than this pre-compression. Users will understand
+ *  a clear error faster than a 10s hang on a 40MB raw camera capture. */
+export const MAX_IMAGE_BYTES = 10 * 1024 * 1024; // 10 MB
+/** Hard cap on number of attachments per message. Mostly a UX choice —
+ *  the grid render falls apart beyond ~6, and token budgets do too. */
+export const MAX_IMAGES_PER_MESSAGE = 4;
+/** Accepted MIME types the picker will filter down to. Keep aligned with
+ *  the `accept=` string on the file input. */
+export const ACCEPTED_IMAGE_MIMES = [
+  'image/png',
+  'image/jpeg',
+  'image/webp',
+  'image/gif',
+] as const;
+
+export interface ImagePart {
+  mimeType: string;
+  /** Pure base64 payload, NO `data:...;base64,` prefix. */
+  base64: string;
+}
+
+/** Split a data URL into `{mimeType, base64}`. Returns `null` for
+ *  malformed URLs so callers can filter out bad entries. */
+export function dataUrlToPart(dataUrl: string): ImagePart | null {
+  const match = /^data:([^;]+);base64,(.*)$/i.exec(dataUrl);
+  if (!match) return null;
+  return { mimeType: match[1], base64: match[2] };
+}
+
+export function partToDataUrl(part: ImagePart): string {
+  return `data:${part.mimeType};base64,${part.base64}`;
+}
+
+/** Read a File into a data URL via FileReader (simpler than fetch()/blob,
+ *  and resolves before the <img> load kicks off the canvas work). */
+function readFileAsDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result;
+      if (typeof result !== 'string') {
+        reject(new Error('Expected string result from FileReader'));
+        return;
+      }
+      resolve(result);
+    };
+    reader.onerror = () => reject(reader.error ?? new Error('Read failed'));
+    reader.readAsDataURL(file);
+  });
+}
+
+function loadImageFromDataUrl(dataUrl: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error('Image decode failed'));
+    img.src = dataUrl;
+  });
+}
+
+/**
+ * Compress a user-picked image into a JPEG data URL whose longest edge
+ * is ≤ MAX_IMAGE_EDGE. Small images skip the canvas round-trip.
+ *
+ * GIFs are rasterized to a single JPEG frame — animated GIF preservation
+ * is out of scope for Phase 6.1 (and providers don't consume animation
+ * anyway). Returns the compressed data URL.
+ */
+export async function compressImageFile(file: File): Promise<string> {
+  if (file.size > MAX_IMAGE_BYTES) {
+    throw new Error(
+      `Image too large (max ${Math.round(MAX_IMAGE_BYTES / 1024 / 1024)}MB)`
+    );
+  }
+
+  const originalDataUrl = await readFileAsDataUrl(file);
+  const img = await loadImageFromDataUrl(originalDataUrl);
+
+  // Bail out of the canvas round-trip for already-small images. Skipping
+  // is a win for PNGs with transparency where JPEG would be lossy.
+  const longestEdge = Math.max(img.naturalWidth, img.naturalHeight);
+  if (longestEdge <= MAX_IMAGE_EDGE && file.size <= 1024 * 1024) {
+    return originalDataUrl;
+  }
+
+  const scale = longestEdge > MAX_IMAGE_EDGE ? MAX_IMAGE_EDGE / longestEdge : 1;
+  const targetWidth = Math.max(1, Math.round(img.naturalWidth * scale));
+  const targetHeight = Math.max(1, Math.round(img.naturalHeight * scale));
+
+  const canvas = document.createElement('canvas');
+  canvas.width = targetWidth;
+  canvas.height = targetHeight;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('Canvas 2D context unavailable');
+
+  // Fill a white background so PNG transparency doesn't turn into black
+  // in the JPEG output.
+  ctx.fillStyle = '#ffffff';
+  ctx.fillRect(0, 0, targetWidth, targetHeight);
+  ctx.drawImage(img, 0, 0, targetWidth, targetHeight);
+
+  return canvas.toDataURL('image/jpeg', IMAGE_JPEG_QUALITY);
+}
+
+/** Bulk compress with per-file isolation — one bad file doesn't block
+ *  the rest of the batch. Returns successful data URLs only; callers get
+ *  a separate error list for UI surfacing. */
+export async function compressImageFiles(
+  files: File[]
+): Promise<{ dataUrls: string[]; errors: string[] }> {
+  const dataUrls: string[] = [];
+  const errors: string[] = [];
+  for (const file of files) {
+    try {
+      const dataUrl = await compressImageFile(file);
+      dataUrls.push(dataUrl);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'compression failed';
+      errors.push(`${file.name}: ${msg}`);
+    }
+  }
+  return { dataUrls, errors };
+}
+
+// ---------------- Vision capability detection ----------------
+
+/**
+ * Allow-list of (provider, model-pattern) tuples that can see images.
+ * Matched substring-insensitively against `${provider}:${model}` so we
+ * don't need to enumerate every point-release.
+ *
+ * Kept narrow on purpose — better to fail-closed (fall back to the
+ * non-vision inline error) than to send a vision payload to a model
+ * that returns a 400 three seconds later.
+ */
+const VISION_MODEL_PATTERNS: Array<{ provider: string; modelContains: string[] }> = [
+  // OpenAI: gpt-4o family + gpt-4-vision + gpt-4-turbo (all see images)
+  {
+    provider: 'openai',
+    modelContains: ['gpt-4o', 'gpt-4-vision', 'gpt-4-turbo', 'gpt-4.1', 'o1', 'o3', 'o4'],
+  },
+  // Claude: any claude-3+ (all modern Claude models are multimodal)
+  {
+    provider: 'claude',
+    modelContains: ['claude-3', 'claude-sonnet-4', 'claude-opus-4', 'claude-haiku-4'],
+  },
+  // Gemini: all modern Gemini models handle inline_data
+  {
+    provider: 'makersuite',
+    modelContains: ['gemini-1.5', 'gemini-2', 'gemini-pro-vision'],
+  },
+  // Mistral: Pixtral variants only
+  {
+    provider: 'mistralai',
+    modelContains: ['pixtral'],
+  },
+  // OpenRouter: model id embeds provider/model — reuse the substrings
+  // above under the openrouter provider bucket.
+  {
+    provider: 'openrouter',
+    modelContains: [
+      'gpt-4o',
+      'gpt-4-vision',
+      'gpt-4-turbo',
+      'gpt-4.1',
+      'claude-3',
+      'claude-sonnet-4',
+      'claude-opus-4',
+      'claude-haiku-4',
+      'gemini-1.5',
+      'gemini-2',
+      'pixtral',
+      'vision',
+    ],
+  },
+  // Groq: llama-4 + llama-3.2 vision variants
+  {
+    provider: 'groq',
+    modelContains: ['llama-4', 'llama-3.2-11b-vision', 'llama-3.2-90b-vision'],
+  },
+];
+
+export function supportsVision(provider: string, model: string): boolean {
+  const p = (provider || '').toLowerCase();
+  const m = (model || '').toLowerCase();
+  for (const entry of VISION_MODEL_PATTERNS) {
+    if (entry.provider !== p) continue;
+    for (const needle of entry.modelContains) {
+      if (m.includes(needle.toLowerCase())) return true;
+    }
+  }
+  return false;
+}


### PR DESCRIPTION
Users can now attach images to messages via paperclip, drag-and-drop, or multi-file picker. Images are compressed client-side (max edge 1024, JPEG q=0.85), folded into OpenAI-style content parts on the wire, and persisted to the JSONL record's extra.images field so they survive save/load. A non-vision-model guard surfaces an inline warning instead of sending attachments to a model that will reject them.