### PR TITLE
Add Phase 6.2: voice input & speech-to-text

### DIFF
--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -1,11 +1,13 @@
-import { useState, useRef, useEffect } from 'react';
-import { Send, Mic, Paperclip, X } from 'lucide-react';
+import { useState, useRef, useEffect, useCallback } from 'react';
+import { Send, Mic, Paperclip, Square, X } from 'lucide-react';
 import { Button } from '../ui';
 import {
   compressImageFiles,
   ACCEPTED_IMAGE_MIMES,
   MAX_IMAGES_PER_MESSAGE,
 } from '../../utils/images';
+import { useSpeechRecognition } from '../../hooks/useSpeechRecognition';
+import { getSpeechLanguage } from '../../hooks/speechLanguage';
 
 interface ChatInputProps {
   /** Called with the trimmed text plus any staged image data URLs. */
@@ -20,6 +22,21 @@ interface ChatInputProps {
    *  the effect. Passing an empty array with a new nonce is a no-op. */
   droppedImages?: string[];
   droppedImagesNonce?: number;
+}
+
+/** How long a mic button press must be held before it flips from
+ *  tap-to-toggle into push-to-talk mode. 300ms is long enough to avoid
+ *  accidental PTT from slightly-long taps but short enough that holding
+ *  down feels responsive. */
+const LONG_PRESS_MS = 300;
+
+/** Prefix a base message with a separator so appended dictation reads
+ *  naturally. No space added if baseText is empty or already ends in
+ *  whitespace. */
+function composeWithBase(baseText: string, transcript: string): string {
+  if (!baseText) return transcript;
+  if (/\s$/.test(baseText)) return baseText + transcript;
+  return baseText + ' ' + transcript;
 }
 
 export function ChatInput({
@@ -37,6 +54,187 @@ export function ChatInput({
   const [isCompressing, setIsCompressing] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Speech-to-text. Snapshot the textarea contents when start() fires so
+  // dictation APPENDS rather than replacing. baseTextRef is the only place
+  // this is tracked — message itself gets live-overwritten by interim
+  // results while listening, and either reverts to baseText (abort/error)
+  // or commits to baseText+finalText (normal stop).
+  const baseTextRef = useRef('');
+  // Flipped true whenever the hook emits a final transcript; read after
+  // isListening→false to decide whether to preserve or discard interim.
+  const gotFinalRef = useRef(false);
+  const handleFinalResult = useCallback((transcript: string) => {
+    gotFinalRef.current = true;
+    setMessage(composeWithBase(baseTextRef.current, transcript));
+  }, []);
+  const {
+    isSupported: isSpeechSupported,
+    isListening,
+    interimTranscript,
+    permissionState,
+    error: speechError,
+    start: startListening,
+    stop: stopListening,
+    abort: abortListening,
+  } = useSpeechRecognition({
+    lang: getSpeechLanguage(),
+    onFinalResult: handleFinalResult,
+  });
+
+  // Mirror interim transcript into the textarea as dictation streams in.
+  // The hook clears interimTranscript on end, at which point the final
+  // callback has already committed the real text — so we skip mirroring
+  // once isListening flips false.
+  useEffect(() => {
+    if (isListening) {
+      setMessage(composeWithBase(baseTextRef.current, interimTranscript));
+    }
+  }, [isListening, interimTranscript]);
+
+  // Handle isListening transitions: reset the final-received flag on
+  // start, and revert to baseText on end if no final was emitted (abort,
+  // error, or empty dictation). Separate from the mirror effect so it
+  // runs only at the edges.
+  const prevListeningRef = useRef(false);
+  useEffect(() => {
+    const wasListening = prevListeningRef.current;
+    prevListeningRef.current = isListening;
+    if (isListening && !wasListening) {
+      gotFinalRef.current = false;
+    } else if (!isListening && wasListening) {
+      if (!gotFinalRef.current) {
+        setMessage(baseTextRef.current);
+      }
+    }
+  }, [isListening]);
+
+  // Begin a dictation session. Factored out because tap, long-press, and
+  // Ctrl+Space all funnel through it. We read `message` via a ref so the
+  // callback identity stays stable across keystrokes — otherwise the
+  // global keyboard-shortcut effect would re-run on every character
+  // typed.
+  const messageRef = useRef(message);
+  useEffect(() => {
+    messageRef.current = message;
+  }, [message]);
+  const beginDictation = useCallback(() => {
+    if (!isSpeechSupported || disabled) return;
+    baseTextRef.current = messageRef.current;
+    startListening();
+  }, [isSpeechSupported, disabled, startListening]);
+
+  // Long-press / pointer state for PTT. pttTimerRef is the arming timer;
+  // if it fires we start listening and flip pttActiveRef so pointerup
+  // becomes a PTT release rather than a second toggle.
+  const pttTimerRef = useRef<number | null>(null);
+  const pttActiveRef = useRef(false);
+
+  const clearPttTimer = () => {
+    if (pttTimerRef.current !== null) {
+      window.clearTimeout(pttTimerRef.current);
+      pttTimerRef.current = null;
+    }
+  };
+
+  const handleMicPointerDown = (e: React.PointerEvent) => {
+    if (!isSpeechSupported || disabled) return;
+    // Ignore right-click and middle-click.
+    if (e.button !== 0) return;
+    // If already listening, the pointerdown is a stop-tap — handled on
+    // pointerup to keep long-press logic simple.
+    if (isListening) return;
+    pttActiveRef.current = false;
+    clearPttTimer();
+    pttTimerRef.current = window.setTimeout(() => {
+      pttActiveRef.current = true;
+      beginDictation();
+    }, LONG_PRESS_MS);
+  };
+
+  const handleMicPointerUp = () => {
+    clearPttTimer();
+    if (pttActiveRef.current) {
+      // Long-press release: stop and commit.
+      pttActiveRef.current = false;
+      stopListening();
+    } else if (isListening) {
+      // Short tap while listening: stop and commit.
+      stopListening();
+    } else {
+      // Short tap while idle: start.
+      beginDictation();
+    }
+  };
+
+  const handleMicPointerCancel = () => {
+    clearPttTimer();
+    if (pttActiveRef.current) {
+      // Treat cancel (pointer left button, gesture interrupted) as PTT
+      // release so the user's dictation still lands in the textarea.
+      pttActiveRef.current = false;
+      stopListening();
+    }
+  };
+
+  const handleStopButtonClick = () => {
+    stopListening();
+  };
+
+  // Ctrl+Space push-to-talk. Global listener so it works from anywhere
+  // on the page, not just while the textarea is focused. kbdPttActiveRef
+  // lives OUTSIDE the effect closure so re-runs (due to beginDictation
+  // identity changes) don't wipe the in-flight PTT state.
+  const kbdPttActiveRef = useRef(false);
+  useEffect(() => {
+    if (!isSpeechSupported) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.code !== 'Space' || !e.ctrlKey) return;
+      if (e.repeat) return; // ignore auto-repeat while held
+      if (disabled) return;
+      e.preventDefault();
+      if (!kbdPttActiveRef.current) {
+        kbdPttActiveRef.current = true;
+        beginDictation();
+      }
+    };
+    const onKeyUp = (e: KeyboardEvent) => {
+      // Release on any Ctrl or Space keyup so partial chord release still
+      // ends the session cleanly.
+      if (!kbdPttActiveRef.current) return;
+      if (e.code === 'Space' || e.key === 'Control') {
+        kbdPttActiveRef.current = false;
+        stopListening();
+      }
+    };
+    // Tabbing away while holding Ctrl+Space swallows the keyup, which
+    // would strand kbdPttActiveRef=true until the user pressed the chord
+    // again. Release PTT on blur to recover.
+    const onBlur = () => {
+      if (kbdPttActiveRef.current) {
+        kbdPttActiveRef.current = false;
+        stopListening();
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    window.addEventListener('keyup', onKeyUp);
+    window.addEventListener('blur', onBlur);
+    return () => {
+      window.removeEventListener('keydown', onKeyDown);
+      window.removeEventListener('keyup', onKeyUp);
+      window.removeEventListener('blur', onBlur);
+    };
+  }, [isSpeechSupported, disabled, beginDictation, stopListening]);
+
+  // Abort any active dictation if the input becomes disabled (e.g. AI
+  // started streaming a response) so the user's speech isn't captured
+  // into a textarea they can't submit from. The transition effect above
+  // handles the baseText revert once isListening flips false.
+  useEffect(() => {
+    if (disabled && isListening) {
+      abortListening();
+    }
+  }, [disabled, isListening, abortListening]);
 
   // Handle prefill text (e.g. from impersonate) - nonce lets parent trigger re-prefill
   useEffect(() => {
@@ -79,7 +277,7 @@ export function ChatInput({
     e.preventDefault();
     const hasText = message.trim().length > 0;
     const hasImages = images.length > 0;
-    if ((hasText || hasImages) && !disabled && !isCompressing) {
+    if ((hasText || hasImages) && !disabled && !isCompressing && !isListening) {
       onSend(message.trim(), hasImages ? images : undefined);
       setMessage('');
       setImages([]);
@@ -145,7 +343,10 @@ export function ChatInput({
     setAttachmentError(null);
   };
 
-  const canSubmit = (message.trim().length > 0 || images.length > 0) && !isCompressing;
+  const canSubmit =
+    (message.trim().length > 0 || images.length > 0) &&
+    !isCompressing &&
+    !isListening;
 
   return (
     <form
@@ -205,6 +406,20 @@ export function ChatInput({
         </div>
       )}
 
+      {/* Speech errors surface here — the most actionable case is a
+          denied mic permission, which persists across presses until the
+          user fixes it in browser settings. */}
+      {speechError && (
+        <div className="mb-2 text-xs text-red-400" role="alert">
+          {speechError}
+          {permissionState === 'denied' && (
+            <span className="block text-[11px] text-[var(--color-text-secondary)] mt-0.5">
+              Click the mic/lock icon in your browser's address bar to re-enable.
+            </span>
+          )}
+        </div>
+      )}
+
       <div className="flex items-end gap-2">
         {/* Attachment Button */}
         <Button
@@ -214,7 +429,7 @@ export function ChatInput({
           className="p-2 flex-shrink-0"
           aria-label="Attach image"
           onClick={handlePickFiles}
-          disabled={disabled || isCompressing || images.length >= MAX_IMAGES_PER_MESSAGE}
+          disabled={disabled || isCompressing || images.length >= MAX_IMAGES_PER_MESSAGE || isListening}
         >
           <Paperclip size={20} />
         </Button>
@@ -226,15 +441,33 @@ export function ChatInput({
             value={message}
             onChange={(e) => setMessage(e.target.value)}
             onKeyDown={handleKeyDown}
-            placeholder={placeholder}
-            disabled={disabled}
+            placeholder={isListening ? 'Listening…' : placeholder}
+            disabled={disabled || isListening}
             rows={1}
             className="flex-1 bg-transparent text-[var(--color-text-primary)] placeholder-zinc-500 resize-none focus:outline-none text-sm max-h-[150px]"
           />
         </div>
 
-        {/* Voice/Send Button */}
-        {canSubmit ? (
+        {/* Voice / Stop / Send Button — mutually exclusive:
+             - Listening → pulsing red stop
+             - Ready to send → primary send
+             - Speech supported, idle → mic (tap or long-press for PTT)
+             - Speech unsupported, idle → nothing (send button wasn't
+               going to render here anyway since canSubmit is false) */}
+        {isListening ? (
+          <button
+            type="button"
+            onClick={handleStopButtonClick}
+            onPointerUp={handleMicPointerUp}
+            onPointerCancel={handleMicPointerCancel}
+            onPointerLeave={handleMicPointerCancel}
+            className="p-2 rounded-full flex-shrink-0 bg-red-600 text-white animate-pulse hover:bg-red-700 transition-colors focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 focus:ring-offset-[var(--color-bg-primary)]"
+            aria-label="Stop recording"
+            title="Stop recording"
+          >
+            <Square size={20} fill="currentColor" />
+          </button>
+        ) : canSubmit ? (
           <Button
             type="submit"
             variant="primary"
@@ -245,17 +478,23 @@ export function ChatInput({
           >
             <Send size={20} />
           </Button>
-        ) : (
+        ) : isSpeechSupported ? (
           <Button
             type="button"
             variant="ghost"
             size="sm"
-            className="p-2 flex-shrink-0"
-            aria-label="Voice input"
+            className="p-2 flex-shrink-0 touch-none select-none"
+            aria-label="Voice input (tap to dictate, hold for push-to-talk)"
+            title="Tap to dictate · hold for push-to-talk · Ctrl+Space from anywhere"
+            disabled={disabled}
+            onPointerDown={handleMicPointerDown}
+            onPointerUp={handleMicPointerUp}
+            onPointerCancel={handleMicPointerCancel}
+            onPointerLeave={handleMicPointerCancel}
           >
             <Mic size={20} />
           </Button>
-        )}
+        ) : null}
       </div>
     </form>
   );

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -1,9 +1,15 @@
 import { useEffect, useState } from 'react';
-import { ArrowLeft, BookOpen, Check, ChevronRight, Eye, EyeOff, Key, Loader2, Sliders, Trash2 } from 'lucide-react';
+import { ArrowLeft, BookOpen, Check, ChevronRight, Eye, EyeOff, Key, Loader2, Mic, Sliders, Trash2 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useSettingsStore } from '../../stores/settingsStore';
 import { PROVIDERS, type SecretState } from '../../api/client';
 import { Button, Input } from '../ui';
+import {
+  SPEECH_LANGUAGES,
+  getSpeechLanguage,
+  setSpeechLanguage,
+} from '../../hooks/speechLanguage';
+import { useSpeechRecognition } from '../../hooks/useSpeechRecognition';
 
 export function SettingsPage() {
   const navigate = useNavigate();
@@ -26,6 +32,8 @@ export function SettingsPage() {
 
   const [apiKeyInputs, setApiKeyInputs] = useState<Record<string, string>>({});
   const [showApiKey, setShowApiKey] = useState<Record<string, boolean>>({});
+  const [speechLang, setSpeechLangState] = useState<string>(() => getSpeechLanguage());
+  const { isSupported: isSpeechSupported } = useSpeechRecognition();
 
   useEffect(() => {
     fetchSecrets();
@@ -296,6 +304,39 @@ export function SettingsPage() {
                 <ChevronRight size={20} className="text-[var(--color-text-secondary)]" />
               </button>
             </section>
+
+            {/* Voice Input Language */}
+            {isSpeechSupported && (
+              <section className="bg-[var(--color-bg-secondary)] rounded-lg p-4">
+                <div className="flex items-center gap-2 mb-2">
+                  <Mic size={16} className="text-[var(--color-text-secondary)]" />
+                  <h2 className="text-sm font-semibold text-[var(--color-text-primary)]">
+                    Voice Input Language
+                  </h2>
+                </div>
+                <p className="text-xs text-[var(--color-text-secondary)] mb-3">
+                  Language used for speech-to-text dictation in the chat input.
+                </p>
+                <select
+                  value={speechLang}
+                  onChange={(e) => {
+                    const next = e.target.value;
+                    setSpeechLangState(next);
+                    setSpeechLanguage(next);
+                  }}
+                  className="w-full bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] rounded-lg px-3 py-2 text-[var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]"
+                >
+                  {SPEECH_LANGUAGES.some((l) => l.code === speechLang) ? null : (
+                    <option value={speechLang}>{speechLang} (current)</option>
+                  )}
+                  {SPEECH_LANGUAGES.map((lang) => (
+                    <option key={lang.code} value={lang.code}>
+                      {lang.label} ({lang.code})
+                    </option>
+                  ))}
+                </select>
+              </section>
+            )}
 
             {/* Help Text */}
             <section className="text-center py-4">

--- a/src/hooks/speechLanguage.ts
+++ b/src/hooks/speechLanguage.ts
@@ -1,0 +1,52 @@
+/**
+ * Persistent language preference for Web Speech API.
+ *
+ * Stored separately from React state so ChatInput and SettingsPage can
+ * both read/write without a shared store. Defaults to navigator.language
+ * on first use.
+ */
+
+const STORAGE_KEY = 'stm:speech-lang';
+
+/** Common BCP-47 language tags, shown in the settings dropdown. */
+export const SPEECH_LANGUAGES: { code: string; label: string }[] = [
+  { code: 'en-US', label: 'English (US)' },
+  { code: 'en-GB', label: 'English (UK)' },
+  { code: 'es-ES', label: 'Spanish (Spain)' },
+  { code: 'es-MX', label: 'Spanish (Mexico)' },
+  { code: 'fr-FR', label: 'French' },
+  { code: 'de-DE', label: 'German' },
+  { code: 'it-IT', label: 'Italian' },
+  { code: 'pt-BR', label: 'Portuguese (Brazil)' },
+  { code: 'ru-RU', label: 'Russian' },
+  { code: 'ja-JP', label: 'Japanese' },
+  { code: 'ko-KR', label: 'Korean' },
+  { code: 'zh-CN', label: 'Chinese (Mandarin)' },
+  { code: 'zh-TW', label: 'Chinese (Taiwan)' },
+  { code: 'ar-SA', label: 'Arabic' },
+  { code: 'hi-IN', label: 'Hindi' },
+  { code: 'nl-NL', label: 'Dutch' },
+  { code: 'pl-PL', label: 'Polish' },
+  { code: 'tr-TR', label: 'Turkish' },
+];
+
+export function getSpeechLanguage(): string {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) return stored;
+  } catch {
+    // ignore
+  }
+  if (typeof navigator !== 'undefined' && navigator.language) {
+    return navigator.language;
+  }
+  return 'en-US';
+}
+
+export function setSpeechLanguage(lang: string): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, lang);
+  } catch {
+    // ignore
+  }
+}

--- a/src/hooks/useSpeechRecognition.ts
+++ b/src/hooks/useSpeechRecognition.ts
@@ -1,0 +1,293 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/**
+ * Web Speech API wrapper for browser-native speech-to-text.
+ *
+ * Handles feature detection, permission state, and single-shot vs push-to-talk
+ * modes. Interim results stream to the caller via `interimTranscript`; the
+ * final transcript arrives via `onFinalResult` when recognition ends.
+ *
+ * Safari < 14.1 and older Firefox lack SpeechRecognition — `isSupported`
+ * will be false and the caller should hide the mic button entirely.
+ */
+
+// The Web Speech API types aren't in the stock TS DOM lib reliably across
+// versions, so we declare the shape we depend on ourselves.
+interface SpeechRecognitionAlternative {
+  readonly transcript: string;
+  readonly confidence: number;
+}
+interface SpeechRecognitionResult {
+  readonly isFinal: boolean;
+  readonly length: number;
+  item(index: number): SpeechRecognitionAlternative;
+  [index: number]: SpeechRecognitionAlternative;
+}
+interface SpeechRecognitionResultList {
+  readonly length: number;
+  item(index: number): SpeechRecognitionResult;
+  [index: number]: SpeechRecognitionResult;
+}
+interface SpeechRecognitionEvent extends Event {
+  readonly resultIndex: number;
+  readonly results: SpeechRecognitionResultList;
+}
+interface SpeechRecognitionErrorEvent extends Event {
+  readonly error:
+    | 'no-speech'
+    | 'aborted'
+    | 'audio-capture'
+    | 'network'
+    | 'not-allowed'
+    | 'service-not-allowed'
+    | 'bad-grammar'
+    | 'language-not-supported';
+  readonly message: string;
+}
+interface SpeechRecognitionInstance extends EventTarget {
+  lang: string;
+  continuous: boolean;
+  interimResults: boolean;
+  maxAlternatives: number;
+  start(): void;
+  stop(): void;
+  abort(): void;
+  onstart: ((this: SpeechRecognitionInstance, ev: Event) => void) | null;
+  onend: ((this: SpeechRecognitionInstance, ev: Event) => void) | null;
+  onerror:
+    | ((this: SpeechRecognitionInstance, ev: SpeechRecognitionErrorEvent) => void)
+    | null;
+  onresult:
+    | ((this: SpeechRecognitionInstance, ev: SpeechRecognitionEvent) => void)
+    | null;
+}
+interface SpeechRecognitionConstructor {
+  new (): SpeechRecognitionInstance;
+}
+declare global {
+  interface Window {
+    SpeechRecognition?: SpeechRecognitionConstructor;
+    webkitSpeechRecognition?: SpeechRecognitionConstructor;
+  }
+}
+
+function getSpeechRecognitionCtor(): SpeechRecognitionConstructor | null {
+  if (typeof window === 'undefined') return null;
+  return window.SpeechRecognition ?? window.webkitSpeechRecognition ?? null;
+}
+
+export type PermissionState = 'unknown' | 'granted' | 'denied';
+
+const PERMISSION_STORAGE_KEY = 'stm:speech-permission';
+
+function loadPermissionState(): PermissionState {
+  try {
+    const raw = localStorage.getItem(PERMISSION_STORAGE_KEY);
+    if (raw === 'granted' || raw === 'denied') return raw;
+  } catch {
+    // ignore
+  }
+  return 'unknown';
+}
+
+function savePermissionState(state: PermissionState) {
+  try {
+    if (state === 'unknown') localStorage.removeItem(PERMISSION_STORAGE_KEY);
+    else localStorage.setItem(PERMISSION_STORAGE_KEY, state);
+  } catch {
+    // ignore
+  }
+}
+
+export interface UseSpeechRecognitionOptions {
+  /** BCP-47 language tag (e.g. 'en-US', 'ja-JP'). Defaults to navigator.language. */
+  lang?: string;
+  /** If true, keep listening until explicitly stopped. Default: false (single-shot). */
+  continuous?: boolean;
+  /** Called once with the final transcript when recognition ends normally. */
+  onFinalResult?: (transcript: string) => void;
+}
+
+export interface UseSpeechRecognitionReturn {
+  /** Whether the browser supports Web Speech API at all. */
+  isSupported: boolean;
+  /** Whether recognition is currently active. */
+  isListening: boolean;
+  /** Live in-progress transcript (interim + final concatenated). */
+  interimTranscript: string;
+  /** Current mic permission state. */
+  permissionState: PermissionState;
+  /** Last error that occurred during recognition, if any. */
+  error: string | null;
+  /** Begin listening. Triggers browser mic permission prompt on first use. */
+  start: () => void;
+  /** Stop listening and emit final transcript via onFinalResult. */
+  stop: () => void;
+  /** Stop listening WITHOUT emitting final transcript (discards interim text). */
+  abort: () => void;
+}
+
+export function useSpeechRecognition(
+  options: UseSpeechRecognitionOptions = {}
+): UseSpeechRecognitionReturn {
+  const { lang, continuous = false, onFinalResult } = options;
+
+  const [isSupported] = useState<boolean>(() => getSpeechRecognitionCtor() !== null);
+  const [isListening, setIsListening] = useState(false);
+  const [interimTranscript, setInterimTranscript] = useState('');
+  const [permissionState, setPermissionState] = useState<PermissionState>(() =>
+    loadPermissionState()
+  );
+  const [error, setError] = useState<string | null>(null);
+
+  const recognitionRef = useRef<SpeechRecognitionInstance | null>(null);
+  // Track whether the most recent stop was an explicit abort so onend knows
+  // not to emit the accumulated transcript.
+  const abortedRef = useRef(false);
+  // Accumulated final pieces across a single session (continuous mode uses
+  // these; single-shot effectively just copies them once at the end).
+  const finalTranscriptRef = useRef('');
+  // Stable callback reference so recreating options doesn't churn the
+  // recognition instance.
+  const onFinalResultRef = useRef(onFinalResult);
+  useEffect(() => {
+    onFinalResultRef.current = onFinalResult;
+  }, [onFinalResult]);
+
+  // Cleanup on unmount — abort any active session so onresult fires don't
+  // reach a stale setState.
+  useEffect(() => {
+    return () => {
+      if (recognitionRef.current) {
+        try {
+          recognitionRef.current.abort();
+        } catch {
+          // ignore
+        }
+        recognitionRef.current = null;
+      }
+    };
+  }, []);
+
+  const start = useCallback(() => {
+    if (!isSupported) return;
+    // Re-entrancy guard — if we're already listening, the second start()
+    // would throw InvalidStateError.
+    if (recognitionRef.current) return;
+
+    const Ctor = getSpeechRecognitionCtor();
+    if (!Ctor) return;
+
+    const recognition = new Ctor();
+    recognition.lang = lang ?? navigator.language ?? 'en-US';
+    recognition.continuous = continuous;
+    recognition.interimResults = true;
+    recognition.maxAlternatives = 1;
+
+    abortedRef.current = false;
+    finalTranscriptRef.current = '';
+    setInterimTranscript('');
+    setError(null);
+
+    recognition.onstart = () => {
+      setIsListening(true);
+      // First successful start means the user granted mic permission.
+      setPermissionState((prev) => {
+        if (prev !== 'granted') {
+          savePermissionState('granted');
+          return 'granted';
+        }
+        return prev;
+      });
+    };
+
+    recognition.onresult = (event: SpeechRecognitionEvent) => {
+      let interim = '';
+      // resultIndex points at the first NEW result; everything before it has
+      // already been fed to us. We accumulate finals into the ref and rebuild
+      // the live transcript as (stable finals) + (current interim).
+      for (let i = event.resultIndex; i < event.results.length; i++) {
+        const result = event.results[i];
+        const alt = result[0];
+        if (result.isFinal) {
+          finalTranscriptRef.current += alt.transcript;
+        } else {
+          interim += alt.transcript;
+        }
+      }
+      setInterimTranscript(finalTranscriptRef.current + interim);
+    };
+
+    recognition.onerror = (event: SpeechRecognitionErrorEvent) => {
+      // 'aborted' fires from our own abort() call; don't surface as an error.
+      if (event.error === 'aborted') return;
+      if (event.error === 'not-allowed' || event.error === 'service-not-allowed') {
+        savePermissionState('denied');
+        setPermissionState('denied');
+        setError('Mic access blocked — enable in browser settings');
+      } else if (event.error === 'no-speech') {
+        setError('No speech detected');
+      } else if (event.error === 'audio-capture') {
+        setError('No microphone available');
+      } else if (event.error === 'network') {
+        setError('Network error');
+      } else {
+        setError(`Speech recognition error: ${event.error}`);
+      }
+    };
+
+    recognition.onend = () => {
+      setIsListening(false);
+      const wasAborted = abortedRef.current;
+      const finalText = finalTranscriptRef.current.trim();
+      recognitionRef.current = null;
+      if (!wasAborted && finalText) {
+        onFinalResultRef.current?.(finalText);
+      }
+      setInterimTranscript('');
+    };
+
+    try {
+      recognition.start();
+      recognitionRef.current = recognition;
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : 'Failed to start recognition'
+      );
+      recognitionRef.current = null;
+    }
+  }, [isSupported, lang, continuous]);
+
+  const stop = useCallback(() => {
+    const recognition = recognitionRef.current;
+    if (!recognition) return;
+    abortedRef.current = false;
+    try {
+      recognition.stop();
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  const abort = useCallback(() => {
+    const recognition = recognitionRef.current;
+    if (!recognition) return;
+    abortedRef.current = true;
+    try {
+      recognition.abort();
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  return {
+    isSupported,
+    isListening,
+    interimTranscript,
+    permissionState,
+    error,
+    start,
+    stop,
+    abort,
+  };
+}


### PR DESCRIPTION
Wire the mic button in ChatInput to the Web Speech API via a new useSpeechRecognition hook. Three activation modes: tap-to-toggle, long-press push-to-talk (300ms threshold), and global Ctrl+Space PTT with blur-safety. Interim results stream live into the textarea; final transcript commits on stop, abort reverts to base text.

Feature detection hides the mic on unsupported browsers. Permission state persists to localStorage so the browser prompt fires only once. Denied permissions surface an inline tooltip with recovery guidance.

Settings page gains a Voice Input Language dropdown (18 BCP-47 locales) gated behind the same feature-detection check, persisted to localStorage independently of server-side settings.