### PR TITLE
Add Phase 6.3: text-to-speech for AI responses

### DIFF
--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -1,10 +1,13 @@
 import { useState, useRef, useEffect, useMemo } from 'react';
-import { MoreHorizontal, Check, X } from 'lucide-react';
+import { MoreHorizontal, Check, X, Volume2, Square } from 'lucide-react';
 import { Avatar } from '../ui';
 import { MessageActionMenu } from './MessageActionMenu';
 import { SwipeControl } from './SwipeControl';
+import { useSpeechSynthesis } from '../../hooks/useSpeechSynthesis';
 
 interface ChatMessageProps {
+  /** Unique message id — used as TTS tracking key. */
+  messageId: string;
   name: string;
   content: string;
   isUser: boolean;
@@ -93,6 +96,7 @@ function FormattedContent({ content, isUser }: { content: string; isUser: boolea
 }
 
 export function ChatMessage({
+  messageId,
   name,
   content,
   isUser,
@@ -116,6 +120,10 @@ export function ChatMessage({
   const [showMenu, setShowMenu] = useState(false);
   const [showEditOptions, setShowEditOptions] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // Phase 6.3: TTS — only wired for non-user, non-system messages.
+  const { isSupported: ttsSupported, isSpeaking, speak, stop } = useSpeechSynthesis();
+  const showTtsButton = ttsSupported && !isUser && !isSystem && content.length > 0;
 
   useEffect(() => {
     if (isEditing && textareaRef.current) {
@@ -213,9 +221,9 @@ export function ChatMessage({
         </div>
 
         <div className="flex items-start gap-2 relative">
-          {/* Action menu button */}
+          {/* Action menu button + TTS button */}
           {!isEditing && (onEdit || onDelete) && (
-            <div className="relative">
+            <div className="relative flex flex-col gap-0.5">
               <button
                 onClick={() => setShowMenu(!showMenu)}
                 disabled={disabled}
@@ -234,6 +242,20 @@ export function ChatMessage({
                 showRegenerate={!isUser && !!onRegenerate}
                 anchorRight={isUser}
               />
+              {showTtsButton && (
+                <button
+                  onClick={() => isSpeaking ? stop() : speak(content, messageId)}
+                  className={`p-1.5 rounded-lg transition-all ${
+                    isSpeaking
+                      ? 'text-[var(--color-primary)] bg-[var(--color-primary)]/10 opacity-100'
+                      : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-tertiary)] opacity-0 group-hover:opacity-100 focus:opacity-100'
+                  }`}
+                  aria-label={isSpeaking ? 'Stop speaking' : 'Read aloud'}
+                  title={isSpeaking ? 'Stop' : 'Read aloud'}
+                >
+                  {isSpeaking ? <Square size={14} /> : <Volume2 size={14} />}
+                </button>
+              )}
             </div>
           )}
 

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -16,6 +16,8 @@ import {
   compressImageFiles,
   ACCEPTED_IMAGE_MIMES,
 } from '../../utils/images';
+import { getTtsAutoRead } from '../../hooks/speechLanguage';
+import { speakText } from '../../hooks/useSpeechSynthesis';
 
 export function ChatView() {
   const { selectedCharacter, isGroupChatMode, groupChatCharacters, exitGroupChat } = useCharacterStore();
@@ -136,6 +138,24 @@ export function ChatView() {
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages]);
+
+  // Phase 6.3: Auto-read — speak the last AI message when streaming completes.
+  const wasStreamingRef = useRef(false);
+  useEffect(() => {
+    if (isStreaming) {
+      wasStreamingRef.current = true;
+      return;
+    }
+    // Streaming just ended
+    if (wasStreamingRef.current) {
+      wasStreamingRef.current = false;
+      if (!getTtsAutoRead()) return;
+      const lastAi = [...messages].reverse().find((m) => !m.isUser && !m.isSystem);
+      if (lastAi && lastAi.content) {
+        speakText(lastAi.content);
+      }
+    }
+  }, [isStreaming, messages]);
 
   const handleSend = (content: string, images?: string[]) => {
     if (isGroupChatMode && groupChatCharacters.length >= 2) {
@@ -417,6 +437,7 @@ export function ChatView() {
               return (
                 <ChatMessage
                   key={message.id}
+                  messageId={message.id}
                   name={message.name}
                   content={message.content}
                   isUser={message.isUser}

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { ArrowLeft, BookOpen, Check, ChevronRight, Eye, EyeOff, Key, Loader2, Mic, Sliders, Trash2 } from 'lucide-react';
+import { ArrowLeft, BookOpen, Check, ChevronRight, Eye, EyeOff, Key, Loader2, Mic, Sliders, Trash2, Volume2 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useSettingsStore } from '../../stores/settingsStore';
 import { PROVIDERS, type SecretState } from '../../api/client';
@@ -8,8 +8,17 @@ import {
   SPEECH_LANGUAGES,
   getSpeechLanguage,
   setSpeechLanguage,
+  getTtsVoiceUri,
+  setTtsVoiceUri,
+  getTtsRate,
+  setTtsRate,
+  getTtsPitch,
+  setTtsPitch,
+  getTtsAutoRead,
+  setTtsAutoRead,
 } from '../../hooks/speechLanguage';
 import { useSpeechRecognition } from '../../hooks/useSpeechRecognition';
+import { useSpeechSynthesis } from '../../hooks/useSpeechSynthesis';
 
 export function SettingsPage() {
   const navigate = useNavigate();
@@ -34,6 +43,13 @@ export function SettingsPage() {
   const [showApiKey, setShowApiKey] = useState<Record<string, boolean>>({});
   const [speechLang, setSpeechLangState] = useState<string>(() => getSpeechLanguage());
   const { isSupported: isSpeechSupported } = useSpeechRecognition();
+
+  // Phase 6.3: TTS settings state
+  const { isSupported: isTtsSupported, voices: ttsVoices } = useSpeechSynthesis();
+  const [ttsVoiceUri, setTtsVoiceUriState] = useState<string>(() => getTtsVoiceUri());
+  const [ttsRate, setTtsRateState] = useState<number>(() => getTtsRate());
+  const [ttsPitch, setTtsPitchState] = useState<number>(() => getTtsPitch());
+  const [ttsAutoReadOn, setTtsAutoReadState] = useState<boolean>(() => getTtsAutoRead());
 
   useEffect(() => {
     fetchSecrets();
@@ -335,6 +351,107 @@ export function SettingsPage() {
                     </option>
                   ))}
                 </select>
+              </section>
+            )}
+
+            {/* Text-to-Speech (Phase 6.3) */}
+            {isTtsSupported && (
+              <section className="bg-[var(--color-bg-secondary)] rounded-lg p-4">
+                <div className="flex items-center gap-2 mb-2">
+                  <Volume2 size={16} className="text-[var(--color-text-secondary)]" />
+                  <h2 className="text-sm font-semibold text-[var(--color-text-primary)]">
+                    Text-to-Speech
+                  </h2>
+                </div>
+                <p className="text-xs text-[var(--color-text-secondary)] mb-3">
+                  Voice used when reading AI messages aloud.
+                </p>
+
+                {/* Voice picker */}
+                <label className="block text-xs text-[var(--color-text-secondary)] mb-1">
+                  Voice
+                </label>
+                <select
+                  value={ttsVoiceUri}
+                  onChange={(e) => {
+                    const uri = e.target.value;
+                    setTtsVoiceUriState(uri);
+                    setTtsVoiceUri(uri);
+                  }}
+                  className="w-full bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] rounded-lg px-3 py-2 text-[var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)] mb-4"
+                >
+                  <option value="">System default</option>
+                  {ttsVoices.map((v) => (
+                    <option key={v.voiceURI} value={v.voiceURI}>
+                      {v.name} ({v.lang})
+                    </option>
+                  ))}
+                </select>
+
+                {/* Rate slider */}
+                <label className="block text-xs text-[var(--color-text-secondary)] mb-1">
+                  Rate: {ttsRate.toFixed(1)}x
+                </label>
+                <input
+                  type="range"
+                  min="0.5"
+                  max="2.0"
+                  step="0.1"
+                  value={ttsRate}
+                  onChange={(e) => {
+                    const val = parseFloat(e.target.value);
+                    setTtsRateState(val);
+                    setTtsRate(val);
+                  }}
+                  className="w-full mb-4 accent-[var(--color-primary)]"
+                />
+
+                {/* Pitch slider */}
+                <label className="block text-xs text-[var(--color-text-secondary)] mb-1">
+                  Pitch: {ttsPitch.toFixed(1)}
+                </label>
+                <input
+                  type="range"
+                  min="0.5"
+                  max="2.0"
+                  step="0.1"
+                  value={ttsPitch}
+                  onChange={(e) => {
+                    const val = parseFloat(e.target.value);
+                    setTtsPitchState(val);
+                    setTtsPitch(val);
+                  }}
+                  className="w-full mb-4 accent-[var(--color-primary)]"
+                />
+
+                {/* Auto-read toggle */}
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-sm text-[var(--color-text-primary)]">Auto-read new messages</p>
+                    <p className="text-xs text-[var(--color-text-secondary)]">
+                      Automatically read each new AI message aloud
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    role="switch"
+                    aria-checked={ttsAutoReadOn}
+                    onClick={() => {
+                      const next = !ttsAutoReadOn;
+                      setTtsAutoReadState(next);
+                      setTtsAutoRead(next);
+                    }}
+                    className={`relative inline-flex h-6 w-11 shrink-0 rounded-full border-2 border-transparent transition-colors ${
+                      ttsAutoReadOn ? 'bg-[var(--color-primary)]' : 'bg-zinc-600'
+                    }`}
+                  >
+                    <span
+                      className={`pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow-sm transition-transform ${
+                        ttsAutoReadOn ? 'translate-x-5' : 'translate-x-0'
+                      }`}
+                    />
+                  </button>
+                </div>
               </section>
             )}
 

--- a/src/hooks/speechLanguage.ts
+++ b/src/hooks/speechLanguage.ts
@@ -1,5 +1,5 @@
 /**
- * Persistent language preference for Web Speech API.
+ * Persistent language preference for Web Speech API (STT & TTS).
  *
  * Stored separately from React state so ChatInput and SettingsPage can
  * both read/write without a shared store. Defaults to navigator.language
@@ -7,6 +7,10 @@
  */
 
 const STORAGE_KEY = 'stm:speech-lang';
+const TTS_VOICE_KEY = 'stm:tts-voice';
+const TTS_RATE_KEY = 'stm:tts-rate';
+const TTS_PITCH_KEY = 'stm:tts-pitch';
+const TTS_AUTOREAD_KEY = 'stm:tts-autoread';
 
 /** Common BCP-47 language tags, shown in the settings dropdown. */
 export const SPEECH_LANGUAGES: { code: string; label: string }[] = [
@@ -46,6 +50,82 @@ export function getSpeechLanguage(): string {
 export function setSpeechLanguage(lang: string): void {
   try {
     localStorage.setItem(STORAGE_KEY, lang);
+  } catch {
+    // ignore
+  }
+}
+
+// ---------------------------------------------------------------------------
+// TTS preferences
+// ---------------------------------------------------------------------------
+
+/** Get the persisted TTS voice URI (or empty string for default). */
+export function getTtsVoiceUri(): string {
+  try {
+    return localStorage.getItem(TTS_VOICE_KEY) ?? '';
+  } catch {
+    return '';
+  }
+}
+
+export function setTtsVoiceUri(uri: string): void {
+  try {
+    localStorage.setItem(TTS_VOICE_KEY, uri);
+  } catch {
+    // ignore
+  }
+}
+
+/** Get persisted TTS rate (0.5–2.0, default 1.0). */
+export function getTtsRate(): number {
+  try {
+    const v = parseFloat(localStorage.getItem(TTS_RATE_KEY) ?? '');
+    if (!Number.isNaN(v) && v >= 0.5 && v <= 2.0) return v;
+  } catch {
+    // ignore
+  }
+  return 1.0;
+}
+
+export function setTtsRate(rate: number): void {
+  try {
+    localStorage.setItem(TTS_RATE_KEY, String(Math.min(2, Math.max(0.5, rate))));
+  } catch {
+    // ignore
+  }
+}
+
+/** Get persisted TTS pitch (0.5–2.0, default 1.0). */
+export function getTtsPitch(): number {
+  try {
+    const v = parseFloat(localStorage.getItem(TTS_PITCH_KEY) ?? '');
+    if (!Number.isNaN(v) && v >= 0.5 && v <= 2.0) return v;
+  } catch {
+    // ignore
+  }
+  return 1.0;
+}
+
+export function setTtsPitch(pitch: number): void {
+  try {
+    localStorage.setItem(TTS_PITCH_KEY, String(Math.min(2, Math.max(0.5, pitch))));
+  } catch {
+    // ignore
+  }
+}
+
+/** Get auto-read toggle for new AI messages. */
+export function getTtsAutoRead(): boolean {
+  try {
+    return localStorage.getItem(TTS_AUTOREAD_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+export function setTtsAutoRead(on: boolean): void {
+  try {
+    localStorage.setItem(TTS_AUTOREAD_KEY, on ? 'true' : 'false');
   } catch {
     // ignore
   }

--- a/src/hooks/useSpeechSynthesis.ts
+++ b/src/hooks/useSpeechSynthesis.ts
@@ -1,0 +1,244 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  getTtsVoiceUri,
+  getTtsRate,
+  getTtsPitch,
+} from './speechLanguage';
+
+/**
+ * React hook wrapping the browser SpeechSynthesis API.
+ *
+ * - Feature-detects `window.speechSynthesis`; returns `isSupported = false`
+ *   when unavailable so callers can hide TTS controls.
+ * - Handles Chrome's async voice loading (`onvoiceschanged`).
+ * - Only one utterance plays at a time — calling `speak()` while another
+ *   utterance is active cancels the previous one first.
+ */
+
+// ---------------------------------------------------------------------------
+// Singleton playing-message tracker so only one message plays across all
+// mounted ChatMessage instances (each gets its own hook instance).
+// ---------------------------------------------------------------------------
+
+type PlayingListener = (id: string | null) => void;
+
+let _currentlyPlaying: string | null = null;
+const _listeners = new Set<PlayingListener>();
+
+function setCurrentlyPlaying(id: string | null) {
+  _currentlyPlaying = id;
+  _listeners.forEach((fn) => fn(id));
+}
+
+function subscribeCurrentlyPlaying(fn: PlayingListener): () => void {
+  _listeners.add(fn);
+  return () => { _listeners.delete(fn); };
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export interface UseSpeechSynthesisReturn {
+  /** Whether the browser supports the SpeechSynthesis API. */
+  isSupported: boolean;
+  /** Available TTS voices (populated async on Chrome). */
+  voices: SpeechSynthesisVoice[];
+  /** Whether this particular message is currently being spoken. */
+  isSpeaking: boolean;
+  /** Begin speaking `text`. Cancels any other active utterance first. */
+  speak: (text: string, messageId: string) => void;
+  /** Stop speaking (if this message is the one playing). */
+  stop: () => void;
+}
+
+export function useSpeechSynthesis(): UseSpeechSynthesisReturn {
+  const [isSupported] = useState<boolean>(
+    () => typeof window !== 'undefined' && 'speechSynthesis' in window
+  );
+  const [voices, setVoices] = useState<SpeechSynthesisVoice[]>([]);
+  const [isSpeaking, setIsSpeaking] = useState(false);
+
+  // Track which message *this* instance is speaking.
+  const activeIdRef = useRef<string | null>(null);
+  const utteranceRef = useRef<SpeechSynthesisUtterance | null>(null);
+
+  // --- Voice list (Chrome loads async) ---
+  useEffect(() => {
+    if (!isSupported) return;
+
+    const loadVoices = () => {
+      const v = speechSynthesis.getVoices();
+      if (v.length > 0) setVoices(v);
+    };
+
+    loadVoices();
+    speechSynthesis.addEventListener('voiceschanged', loadVoices);
+    return () => {
+      speechSynthesis.removeEventListener('voiceschanged', loadVoices);
+    };
+  }, [isSupported]);
+
+  // --- Subscribe to singleton playing tracker ---
+  useEffect(() => {
+    return subscribeCurrentlyPlaying((id) => {
+      if (activeIdRef.current && id !== activeIdRef.current) {
+        // Another message started — this one is no longer playing.
+        activeIdRef.current = null;
+        utteranceRef.current = null;
+        setIsSpeaking(false);
+      }
+    });
+  }, []);
+
+  // Cleanup on unmount — cancel if this hook's utterance is active.
+  useEffect(() => {
+    return () => {
+      if (activeIdRef.current && _currentlyPlaying === activeIdRef.current) {
+        speechSynthesis.cancel();
+        setCurrentlyPlaying(null);
+      }
+    };
+  }, []);
+
+  // --- Resolve the preferred voice ---
+  const resolveVoice = useCallback(
+    (availableVoices: SpeechSynthesisVoice[]): SpeechSynthesisVoice | null => {
+      if (availableVoices.length === 0) return null;
+
+      const preferredUri = getTtsVoiceUri();
+      if (preferredUri) {
+        const match = availableVoices.find((v) => v.voiceURI === preferredUri);
+        if (match) return match;
+      }
+
+      // Fallback: first voice matching navigator.language
+      const lang = navigator.language ?? 'en-US';
+      const langMatch = availableVoices.find((v) => v.lang.startsWith(lang.split('-')[0]));
+      return langMatch ?? availableVoices[0];
+    },
+    []
+  );
+
+  const speak = useCallback(
+    (text: string, messageId: string) => {
+      if (!isSupported) return;
+
+      // If this same message is already playing, treat as a toggle → stop.
+      if (activeIdRef.current === messageId) {
+        speechSynthesis.cancel();
+        activeIdRef.current = null;
+        utteranceRef.current = null;
+        setIsSpeaking(false);
+        setCurrentlyPlaying(null);
+        return;
+      }
+
+      // Cancel whatever was playing (could be another message).
+      speechSynthesis.cancel();
+
+      // Strip common RP formatting (* * and {{ }}) for cleaner speech.
+      const clean = text
+        .replace(/\{\{([^}]*)\}\}/g, '$1')
+        .replace(/\*([^*]*)\*/g, '$1')
+        .replace(/_([^_]*)_/g, '$1')
+        .trim();
+
+      if (!clean) return;
+
+      const utterance = new SpeechSynthesisUtterance(clean);
+
+      // Apply user preferences
+      const currentVoices = speechSynthesis.getVoices();
+      const voice = resolveVoice(currentVoices.length > 0 ? currentVoices : voices);
+      if (voice) utterance.voice = voice;
+      utterance.rate = getTtsRate();
+      utterance.pitch = getTtsPitch();
+
+      utterance.onend = () => {
+        if (activeIdRef.current === messageId) {
+          activeIdRef.current = null;
+          utteranceRef.current = null;
+          setIsSpeaking(false);
+          setCurrentlyPlaying(null);
+        }
+      };
+
+      utterance.onerror = (ev) => {
+        // 'canceled' fires from our own cancel() call — not an error.
+        if (ev.error === 'canceled') return;
+        if (activeIdRef.current === messageId) {
+          activeIdRef.current = null;
+          utteranceRef.current = null;
+          setIsSpeaking(false);
+          setCurrentlyPlaying(null);
+        }
+      };
+
+      activeIdRef.current = messageId;
+      utteranceRef.current = utterance;
+      setIsSpeaking(true);
+      setCurrentlyPlaying(messageId);
+      speechSynthesis.speak(utterance);
+    },
+    [isSupported, voices, resolveVoice]
+  );
+
+  const stop = useCallback(() => {
+    if (activeIdRef.current) {
+      speechSynthesis.cancel();
+      activeIdRef.current = null;
+      utteranceRef.current = null;
+      setIsSpeaking(false);
+      setCurrentlyPlaying(null);
+    }
+  }, []);
+
+  return { isSupported, voices, isSpeaking, speak, stop };
+}
+
+// ---------------------------------------------------------------------------
+// Standalone helpers for auto-read (used by ChatView, not per-message)
+// ---------------------------------------------------------------------------
+
+/**
+ * Speak text immediately using current TTS preferences.
+ * Cancels any existing utterance first.
+ */
+export function speakText(text: string): void {
+  if (typeof window === 'undefined' || !('speechSynthesis' in window)) return;
+
+  speechSynthesis.cancel();
+
+  const clean = text
+    .replace(/\{\{([^}]*)\}\}/g, '$1')
+    .replace(/\*([^*]*)\*/g, '$1')
+    .replace(/_([^_]*)_/g, '$1')
+    .trim();
+  if (!clean) return;
+
+  const utterance = new SpeechSynthesisUtterance(clean);
+
+  const voices = speechSynthesis.getVoices();
+  const preferredUri = getTtsVoiceUri();
+  if (preferredUri) {
+    const match = voices.find((v) => v.voiceURI === preferredUri);
+    if (match) utterance.voice = match;
+  } else if (voices.length > 0) {
+    const lang = navigator.language ?? 'en-US';
+    const langMatch = voices.find((v) => v.lang.startsWith(lang.split('-')[0]));
+    if (langMatch) utterance.voice = langMatch;
+  }
+
+  utterance.rate = getTtsRate();
+  utterance.pitch = getTtsPitch();
+
+  // Update singleton tracker so per-message buttons know something is playing.
+  setCurrentlyPlaying('__autoread__');
+  utterance.onend = () => setCurrentlyPlaying(null);
+  utterance.onerror = (ev) => {
+    if (ev.error !== 'canceled') setCurrentlyPlaying(null);
+  };
+
+  speechSynthesis.speak(utterance);
+}


### PR DESCRIPTION
Per-message play/stop button on AI bubbles (Volume2/Square icons), singleton tracking so only one message speaks at a time. New useSpeechSynthesis hook wrapping the browser SpeechSynthesis API with feature detection and Chrome async voice loading.

Settings: voice picker dropdown, rate/pitch sliders (0.5-2.0), and auto-read toggle that speaks new AI messages when streaming completes. All preferences persisted to localStorage.