### PR TITLE
Add Phase 7.3: chat display styles

### DIFF
--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -5,6 +5,7 @@ import { MessageActionMenu } from './MessageActionMenu';
 import { SwipeControl } from './SwipeControl';
 import { MarkdownContent } from './MarkdownContent';
 import { useSpeechSynthesis } from '../../hooks/useSpeechSynthesis';
+import type { ChatLayoutMode, AvatarShape } from '../../hooks/displayPreferences';
 
 interface ChatMessageProps {
   /** Unique message id — used as TTS tracking key. */
@@ -20,6 +21,11 @@ interface ChatMessageProps {
   images?: string[];
   /** Phase 7.2: true while this message is actively being streamed. */
   isStreaming?: boolean;
+  /** Phase 7.3: display style settings. */
+  layoutMode?: ChatLayoutMode;
+  avatarShape?: AvatarShape;
+  fontSize?: number;
+  chatMaxWidth?: number;
   // Swipe support (only for AI messages)
   swipes?: string[];
   swipeId?: number;
@@ -114,6 +120,10 @@ export function ChatMessage({
   onSwipeLeft,
   onSwipeRight,
   isStreaming: isStreamingMsg,
+  layoutMode = 'bubbles',
+  avatarShape = 'circle',
+  fontSize,
+  chatMaxWidth = 80,
   onEdit,
   onEditAndRegenerate,
   onDelete,
@@ -191,6 +201,10 @@ export function ChatMessage({
     }
   };
 
+  // Font size style applied to content containers
+  const fontStyle = fontSize && fontSize !== 14 ? { fontSize: `${fontSize}px` } : undefined;
+
+  // ---- System messages: identical in all modes ----
   if (isSystem) {
     return (
       <div className="flex justify-center my-4">
@@ -201,184 +215,276 @@ export function ChatMessage({
     );
   }
 
-  return (
-    <div
-      className={`flex gap-3 px-4 py-3 group ${isUser ? 'flex-row-reverse' : 'flex-row'}`}
-    >
-      <Avatar src={avatar} alt={name} size="md" className="flex-shrink-0" />
+  // ---- Shared UI fragments ----
 
-      <div
-        className={`flex flex-col max-w-[80%] md:max-w-[70%] ${isUser ? 'items-end' : 'items-start'}`}
+  const timeStr = timestamp
+    ? new Date(timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+    : null;
+
+  const actionButtons = !isEditing && (onEdit || onDelete) ? (
+    <div className="relative flex flex-col gap-0.5">
+      <button
+        onClick={() => setShowMenu(!showMenu)}
+        disabled={disabled}
+        className="p-1.5 rounded-lg text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-tertiary)] opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity disabled:opacity-50"
+        aria-label="Message actions"
       >
-        <div className="flex items-center gap-2 mb-1">
-          <span className="text-xs font-medium text-[var(--color-text-secondary)]">
-            {name}
-          </span>
-          {timestamp && (
-            <span className="text-xs text-zinc-500">
-              {new Date(timestamp).toLocaleTimeString([], {
-                hour: '2-digit',
-                minute: '2-digit',
-              })}
-            </span>
-          )}
-        </div>
+        <MoreHorizontal size={16} />
+      </button>
+      <MessageActionMenu
+        isOpen={showMenu}
+        onClose={() => setShowMenu(false)}
+        onEdit={handleStartEdit}
+        onCopy={handleCopy}
+        onDelete={() => onDelete?.()}
+        onRegenerate={onRegenerate}
+        showRegenerate={!isUser && !!onRegenerate}
+        anchorRight={layoutMode === 'bubbles' && isUser}
+      />
+      {showTtsButton && (
+        <button
+          onClick={() => isSpeaking ? stop() : speak(content, messageId)}
+          className={`p-1.5 rounded-lg transition-all ${
+            isSpeaking
+              ? 'text-[var(--color-primary)] bg-[var(--color-primary)]/10 opacity-100'
+              : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-tertiary)] opacity-0 group-hover:opacity-100 focus:opacity-100'
+          }`}
+          aria-label={isSpeaking ? 'Stop speaking' : 'Read aloud'}
+          title={isSpeaking ? 'Stop' : 'Read aloud'}
+        >
+          {isSpeaking ? <Square size={14} /> : <Volume2 size={14} />}
+        </button>
+      )}
+    </div>
+  ) : null;
 
-        <div className="flex items-start gap-2 relative">
-          {/* Action menu button + TTS button */}
-          {!isEditing && (onEdit || onDelete) && (
-            <div className="relative flex flex-col gap-0.5">
-              <button
-                onClick={() => setShowMenu(!showMenu)}
-                disabled={disabled}
-                className="p-1.5 rounded-lg text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-tertiary)] opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity disabled:opacity-50"
-                aria-label="Message actions"
-              >
-                <MoreHorizontal size={16} />
-              </button>
-              <MessageActionMenu
-                isOpen={showMenu}
-                onClose={() => setShowMenu(false)}
-                onEdit={handleStartEdit}
-                onCopy={handleCopy}
-                onDelete={() => onDelete?.()}
-                onRegenerate={onRegenerate}
-                showRegenerate={!isUser && !!onRegenerate}
-                anchorRight={isUser}
-              />
-              {showTtsButton && (
+  const imageGrid = !isEditing && images && images.length > 0 ? (
+    <div
+      className={`grid gap-1 ${content.length > 0 ? 'mb-2' : ''} ${
+        images.length === 1 ? 'grid-cols-1' : 'grid-cols-2'
+      }`}
+    >
+      {images.map((src, idx) => (
+        <a
+          key={idx}
+          href={src}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="block rounded-lg overflow-hidden"
+          aria-label={`View attachment ${idx + 1}`}
+        >
+          <img
+            src={src}
+            alt={`Attachment ${idx + 1}`}
+            className="w-full h-auto max-h-60 object-cover block"
+            loading="lazy"
+          />
+        </a>
+      ))}
+    </div>
+  ) : null;
+
+  const editingUI = isEditing ? (
+    <div className="flex flex-col gap-2">
+      <textarea
+        ref={textareaRef}
+        value={editContent}
+        onChange={(e) => setEditContent(e.target.value)}
+        onKeyDown={handleKeyDown}
+        className={`w-full bg-transparent text-sm resize-none outline-none min-h-[60px] ${
+          isUser && layoutMode === 'bubbles' ? 'text-white' : 'text-[var(--color-text-primary)]'
+        }`}
+        style={fontStyle}
+        placeholder="Enter message..."
+      />
+      <div className="flex justify-end gap-2">
+        <button
+          onClick={handleCancelEdit}
+          className={`p-1.5 rounded-lg transition-colors ${
+            isUser && layoutMode === 'bubbles'
+              ? 'bg-white/20 hover:bg-white/30'
+              : 'bg-[var(--color-bg-secondary)] hover:bg-[var(--color-bg-primary)]'
+          }`}
+          title="Cancel (Esc)"
+        >
+          <X size={14} />
+        </button>
+        {isUser && onEditAndRegenerate ? (
+          <div className="relative">
+            <button
+              onClick={() => setShowEditOptions(!showEditOptions)}
+              className={`p-1.5 rounded-lg transition-colors ${
+                isUser && layoutMode === 'bubbles'
+                  ? 'bg-white/20 hover:bg-white/30'
+                  : 'bg-[var(--color-bg-secondary)] hover:bg-[var(--color-bg-primary)]'
+              }`}
+              title="Save options"
+            >
+              <Check size={14} />
+            </button>
+            {showEditOptions && (
+              <div className="absolute right-0 top-full mt-1 z-20 min-w-[180px] bg-[var(--color-bg-secondary)] border border-[var(--color-border)] rounded-lg shadow-xl overflow-hidden">
                 <button
-                  onClick={() => isSpeaking ? stop() : speak(content, messageId)}
-                  className={`p-1.5 rounded-lg transition-all ${
-                    isSpeaking
-                      ? 'text-[var(--color-primary)] bg-[var(--color-primary)]/10 opacity-100'
-                      : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-tertiary)] opacity-0 group-hover:opacity-100 focus:opacity-100'
-                  }`}
-                  aria-label={isSpeaking ? 'Stop speaking' : 'Read aloud'}
-                  title={isSpeaking ? 'Stop' : 'Read aloud'}
+                  onClick={handleSaveOnly}
+                  className="w-full px-3 py-2 text-xs text-left text-[var(--color-text-primary)] hover:bg-[var(--color-bg-tertiary)] transition-colors"
                 >
-                  {isSpeaking ? <Square size={14} /> : <Volume2 size={14} />}
+                  Save only
                 </button>
-              )}
-            </div>
-          )}
-
-          <div
-            className={`
-              px-4 py-2 rounded-2xl
-              ${isUser
-                ? 'bg-[var(--color-primary)] text-white rounded-br-md'
-                : 'bg-[var(--color-bg-tertiary)] text-[var(--color-text-primary)] rounded-bl-md'}
-              ${isEditing ? 'w-full' : ''}
-            `}
-          >
-            {/* Phase 6.1: image attachments render above the text content.
-                Grid scales column count to keep thumbnails reasonable. */}
-            {!isEditing && images && images.length > 0 && (
-              <div
-                className={`grid gap-1 ${content.length > 0 ? 'mb-2' : ''} ${
-                  images.length === 1 ? 'grid-cols-1' : 'grid-cols-2'
-                }`}
-              >
-                {images.map((src, idx) => (
-                  <a
-                    key={idx}
-                    href={src}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="block rounded-lg overflow-hidden"
-                    aria-label={`View attachment ${idx + 1}`}
-                  >
-                    <img
-                      src={src}
-                      alt={`Attachment ${idx + 1}`}
-                      className="w-full h-auto max-h-60 object-cover block"
-                      loading="lazy"
-                    />
-                  </a>
-                ))}
+                <button
+                  onClick={handleSaveAndRegenerate}
+                  className="w-full px-3 py-2 text-xs text-left text-[var(--color-text-primary)] hover:bg-[var(--color-bg-tertiary)] transition-colors"
+                >
+                  Save &amp; regenerate
+                </button>
               </div>
             )}
-            {isEditing ? (
-              <div className="flex flex-col gap-2">
-                <textarea
-                  ref={textareaRef}
-                  value={editContent}
-                  onChange={(e) => setEditContent(e.target.value)}
-                  onKeyDown={handleKeyDown}
-                  className={`w-full bg-transparent text-sm resize-none outline-none min-h-[60px] ${isUser ? 'text-white' : 'text-[var(--color-text-primary)]'}`}
-                  placeholder="Enter message..."
-                />
-                <div className="flex justify-end gap-2">
-                  <button
-                    onClick={handleCancelEdit}
-                    className={`p-1.5 rounded-lg transition-colors ${isUser ? 'bg-white/20 hover:bg-white/30' : 'bg-[var(--color-bg-secondary)] hover:bg-[var(--color-bg-primary)]'}`}
-                    title="Cancel (Esc)"
-                  >
-                    <X size={14} />
-                  </button>
-                  {isUser && onEditAndRegenerate ? (
-                    <div className="relative">
-                      <button
-                        onClick={() => setShowEditOptions(!showEditOptions)}
-                        className={`p-1.5 rounded-lg transition-colors ${isUser ? 'bg-white/20 hover:bg-white/30' : 'bg-[var(--color-bg-secondary)] hover:bg-[var(--color-bg-primary)]'}`}
-                        title="Save options"
-                      >
-                        <Check size={14} />
-                      </button>
-                      {showEditOptions && (
-                        <div className="absolute right-0 top-full mt-1 z-20 min-w-[180px] bg-[var(--color-bg-secondary)] border border-[var(--color-border)] rounded-lg shadow-xl overflow-hidden">
-                          <button
-                            onClick={handleSaveOnly}
-                            className="w-full px-3 py-2 text-xs text-left text-[var(--color-text-primary)] hover:bg-[var(--color-bg-tertiary)] transition-colors"
-                          >
-                            Save only
-                          </button>
-                          <button
-                            onClick={handleSaveAndRegenerate}
-                            className="w-full px-3 py-2 text-xs text-left text-[var(--color-text-primary)] hover:bg-[var(--color-bg-tertiary)] transition-colors"
-                          >
-                            Save &amp; regenerate
-                          </button>
-                        </div>
-                      )}
-                    </div>
-                  ) : (
-                    <button
-                      onClick={handleSaveOnly}
-                      className={`p-1.5 rounded-lg transition-colors ${isUser ? 'bg-white/20 hover:bg-white/30' : 'bg-[var(--color-bg-secondary)] hover:bg-[var(--color-bg-primary)]'}`}
-                      title="Save (Enter)"
-                    >
-                      <Check size={14} />
-                    </button>
-                  )}
-                </div>
-              </div>
-            ) : content.length > 0 ? (
-              isUser ? (
-                <div className="text-sm whitespace-pre-wrap break-words">
-                  <FormattedContent content={content} isUser={isUser} />
-                </div>
-              ) : (
-                <div className="text-sm break-words">
-                  <MarkdownContent content={content} isUser={false} isStreaming={isStreamingMsg} />
-                </div>
-              )
-            ) : null}
           </div>
-        </div>
-
-        {/* Swipe control for AI messages */}
-        {showSwipeControl && !isEditing && swipes && swipeId !== undefined && onSwipeLeft && onSwipeRight && swipes.length >= 1 && (
-          <SwipeControl
-            swipeId={swipeId}
-            swipesCount={swipes.length}
-            onSwipeLeft={onSwipeLeft}
-            onSwipeRight={onSwipeRight}
-            disabled={disabled}
-          />
+        ) : (
+          <button
+            onClick={handleSaveOnly}
+            className={`p-1.5 rounded-lg transition-colors ${
+              isUser && layoutMode === 'bubbles'
+                ? 'bg-white/20 hover:bg-white/30'
+                : 'bg-[var(--color-bg-secondary)] hover:bg-[var(--color-bg-primary)]'
+            }`}
+            title="Save (Enter)"
+          >
+            <Check size={14} />
+          </button>
         )}
       </div>
+    </div>
+  ) : null;
+
+  const messageContent = !isEditing && content.length > 0 ? (
+    isUser ? (
+      <div className="whitespace-pre-wrap break-words" style={fontStyle}>
+        <FormattedContent content={content} isUser={isUser} />
+      </div>
+    ) : (
+      <div className="break-words" style={fontStyle}>
+        <MarkdownContent content={content} isUser={false} isStreaming={isStreamingMsg} />
+      </div>
+    )
+  ) : null;
+
+  const swipeControl = showSwipeControl && !isEditing && swipes && swipeId !== undefined && onSwipeLeft && onSwipeRight && swipes.length >= 1 ? (
+    <SwipeControl
+      swipeId={swipeId}
+      swipesCount={swipes.length}
+      onSwipeLeft={onSwipeLeft}
+      onSwipeRight={onSwipeRight}
+      disabled={disabled}
+    />
+  ) : null;
+
+  // ==================================================================
+  // Bubbles layout (default — original behavior)
+  // ==================================================================
+  if (layoutMode === 'bubbles') {
+    return (
+      <div className={`flex gap-3 px-4 py-3 group ${isUser ? 'flex-row-reverse' : 'flex-row'}`}>
+        <Avatar src={avatar} alt={name} size="md" shape={avatarShape} className="flex-shrink-0" />
+
+        <div
+          className={`flex flex-col ${isUser ? 'items-end' : 'items-start'}`}
+          style={{ maxWidth: `${chatMaxWidth}%` }}
+        >
+          <div className="flex items-center gap-2 mb-1">
+            <span className="text-xs font-medium text-[var(--color-text-secondary)]">{name}</span>
+            {timeStr && <span className="text-xs text-zinc-500">{timeStr}</span>}
+          </div>
+
+          <div className="flex items-start gap-2 relative">
+            {actionButtons}
+            <div
+              className={`
+                px-4 py-2 rounded-2xl
+                ${isUser
+                  ? 'bg-[var(--color-primary)] text-white rounded-br-md'
+                  : 'bg-[var(--color-bg-tertiary)] text-[var(--color-text-primary)] rounded-bl-md'}
+                ${isEditing ? 'w-full' : ''}
+              `}
+            >
+              {imageGrid}
+              {editingUI}
+              {messageContent}
+            </div>
+          </div>
+
+          {swipeControl}
+        </div>
+      </div>
+    );
+  }
+
+  // ==================================================================
+  // Flat layout — full-width, dividers, no bubble background
+  // ==================================================================
+  if (layoutMode === 'flat') {
+    return (
+      <div
+        className={`px-4 py-3 group border-b border-[var(--color-border)]/20 ${
+          isUser ? 'border-l-2 border-l-[var(--color-primary)]' : ''
+        }`}
+      >
+        {/* Header row: avatar + name + time + actions */}
+        <div className="flex items-center gap-2 mb-1.5">
+          <Avatar src={avatar} alt={name} size="sm" shape={avatarShape} className="flex-shrink-0" />
+          <span className={`text-xs font-semibold ${
+            isUser ? 'text-[var(--color-primary)]' : 'text-[var(--color-text-secondary)]'
+          }`}>
+            {name}
+          </span>
+          {timeStr && <span className="text-xs text-zinc-500">{timeStr}</span>}
+          <div className="ml-auto">{actionButtons}</div>
+        </div>
+
+        {/* Content area */}
+        <div className="text-[var(--color-text-primary)]">
+          {imageGrid}
+          {isEditing ? (
+            <div className="p-2 rounded-lg bg-[var(--color-bg-tertiary)]">
+              {editingUI}
+            </div>
+          ) : messageContent}
+        </div>
+
+        {swipeControl}
+      </div>
+    );
+  }
+
+  // ==================================================================
+  // Document layout — compact, inline names, no avatars
+  // ==================================================================
+  return (
+    <div className="px-4 py-1.5 group">
+      <div className="flex items-start gap-2">
+        <div className="flex-1 min-w-0 text-[var(--color-text-primary)]">
+          {/* Inline name + timestamp */}
+          <span className={`font-bold text-sm ${
+            isUser ? 'text-[var(--color-primary)]' : 'text-[var(--color-text-secondary)]'
+          }`}>
+            {name}
+          </span>
+          {timeStr && <span className="text-xs text-zinc-500 ml-2">{timeStr}</span>}
+
+          {imageGrid && <div className="mt-1">{imageGrid}</div>}
+
+          {isEditing ? (
+            <div className="mt-1 p-2 rounded-lg bg-[var(--color-bg-tertiary)]">
+              {editingUI}
+            </div>
+          ) : messageContent ? (
+            <div className="mt-0.5">{messageContent}</div>
+          ) : null}
+        </div>
+
+        {actionButtons}
+      </div>
+
+      {swipeControl}
     </div>
   );
 }

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -19,6 +19,12 @@ import {
 } from '../../utils/images';
 import { getTtsAutoRead } from '../../hooks/speechLanguage';
 import { speakText } from '../../hooks/useSpeechSynthesis';
+import {
+  getChatLayoutMode,
+  getAvatarShape,
+  getChatFontSize,
+  getChatMaxWidth,
+} from '../../hooks/displayPreferences';
 
 export function ChatView() {
   const { selectedCharacter, isGroupChatMode, groupChatCharacters, exitGroupChat } = useCharacterStore();
@@ -58,6 +64,13 @@ export function ChatView() {
   /** Whether the user is scrolled near the bottom (within 150px). */
   const isNearBottomRef = useRef(true);
   const lastCharacterRef = useRef<string | null>(null);
+
+  // Phase 7.3: display preferences (read from localStorage on mount/render)
+  const chatLayoutMode = getChatLayoutMode();
+  const avatarShapePref = getAvatarShape();
+  const chatFontSize = getChatFontSize();
+  const chatMaxWidth = getChatMaxWidth();
+
   const [failedExpressions, setFailedExpressions] = useState<Set<string>>(new Set());
   const [prefillText, setPrefillText] = useState<string | undefined>(undefined);
   const [prefillNonce, setPrefillNonce] = useState(0);
@@ -465,6 +478,10 @@ export function ChatView() {
                   disabled={isSending}
                   images={message.images}
                   isStreaming={isLastAiMessage && isStreaming}
+                  layoutMode={chatLayoutMode}
+                  avatarShape={avatarShapePref}
+                  fontSize={chatFontSize}
+                  chatMaxWidth={chatMaxWidth}
                   swipes={message.swipes}
                   swipeId={message.swipeId}
                   showSwipeControl={showSwipeControl}

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { ArrowLeft, BookOpen, Check, ChevronRight, Eye, EyeOff, Key, Loader2, Mic, Sliders, Trash2, Volume2 } from 'lucide-react';
+import { ArrowLeft, BookOpen, Check, ChevronRight, Eye, EyeOff, Key, Loader2, MessageSquare, Mic, Sliders, Trash2, Volume2 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useSettingsStore } from '../../stores/settingsStore';
 import { PROVIDERS, type SecretState } from '../../api/client';
@@ -17,6 +17,18 @@ import {
   getTtsAutoRead,
   setTtsAutoRead,
 } from '../../hooks/speechLanguage';
+import {
+  getChatLayoutMode,
+  setChatLayoutMode,
+  getAvatarShape,
+  setAvatarShape,
+  getChatFontSize,
+  setChatFontSize,
+  getChatMaxWidth,
+  setChatMaxWidth,
+  type ChatLayoutMode,
+  type AvatarShape,
+} from '../../hooks/displayPreferences';
 import { useSpeechRecognition } from '../../hooks/useSpeechRecognition';
 import { useSpeechSynthesis } from '../../hooks/useSpeechSynthesis';
 
@@ -43,6 +55,12 @@ export function SettingsPage() {
   const [showApiKey, setShowApiKey] = useState<Record<string, boolean>>({});
   const [speechLang, setSpeechLangState] = useState<string>(() => getSpeechLanguage());
   const { isSupported: isSpeechSupported } = useSpeechRecognition();
+
+  // Phase 7.3: Chat display preferences
+  const [layoutMode, setLayoutModeState] = useState<ChatLayoutMode>(() => getChatLayoutMode());
+  const [avatarShapePref, setAvatarShapeState] = useState<AvatarShape>(() => getAvatarShape());
+  const [fontSizePref, setFontSizeState] = useState<number>(() => getChatFontSize());
+  const [chatWidthPref, setChatWidthState] = useState<number>(() => getChatMaxWidth());
 
   // Phase 6.3: TTS settings state
   const { isSupported: isTtsSupported, voices: ttsVoices } = useSpeechSynthesis();
@@ -319,6 +337,114 @@ export function SettingsPage() {
                 </div>
                 <ChevronRight size={20} className="text-[var(--color-text-secondary)]" />
               </button>
+            </section>
+
+            {/* Chat Display (Phase 7.3) */}
+            <section className="bg-[var(--color-bg-secondary)] rounded-lg p-4">
+              <div className="flex items-center gap-2 mb-3">
+                <MessageSquare size={16} className="text-[var(--color-text-secondary)]" />
+                <h2 className="text-sm font-semibold text-[var(--color-text-primary)]">
+                  Chat Display
+                </h2>
+              </div>
+
+              {/* Layout Mode */}
+              <label className="block text-xs text-[var(--color-text-secondary)] mb-1.5">
+                Layout
+              </label>
+              <div className="grid grid-cols-3 gap-2 mb-4">
+                {([
+                  { value: 'bubbles' as const, label: 'Bubbles', desc: 'Rounded colored bubbles' },
+                  { value: 'flat' as const, label: 'Flat', desc: 'Full-width, dividers' },
+                  { value: 'document' as const, label: 'Document', desc: 'Compact, inline names' },
+                ] as const).map((opt) => (
+                  <button
+                    key={opt.value}
+                    onClick={() => { setLayoutModeState(opt.value); setChatLayoutMode(opt.value); }}
+                    className={`p-2.5 rounded-lg text-center transition-all ${
+                      layoutMode === opt.value
+                        ? 'bg-[var(--color-primary)] text-white'
+                        : 'bg-[var(--color-bg-tertiary)] text-[var(--color-text-secondary)] hover:bg-zinc-700'
+                    }`}
+                  >
+                    <span className="text-xs font-medium block">{opt.label}</span>
+                    <span className={`text-[10px] block mt-0.5 ${
+                      layoutMode === opt.value ? 'text-white/70' : 'text-[var(--color-text-secondary)]'
+                    }`}>
+                      {opt.desc}
+                    </span>
+                  </button>
+                ))}
+              </div>
+
+              {/* Avatar Shape */}
+              <label className="block text-xs text-[var(--color-text-secondary)] mb-1.5">
+                Avatar Shape
+              </label>
+              <div className="grid grid-cols-3 gap-2 mb-4">
+                {([
+                  { value: 'circle' as const, label: 'Circle', cls: 'rounded-full' },
+                  { value: 'square' as const, label: 'Square', cls: 'rounded-none' },
+                  { value: 'rounded-square' as const, label: 'Rounded', cls: 'rounded-md' },
+                ] as const).map((opt) => (
+                  <button
+                    key={opt.value}
+                    onClick={() => { setAvatarShapeState(opt.value); setAvatarShape(opt.value); }}
+                    className={`flex items-center justify-center gap-2 p-2.5 rounded-lg transition-all ${
+                      avatarShapePref === opt.value
+                        ? 'bg-[var(--color-primary)] text-white'
+                        : 'bg-[var(--color-bg-tertiary)] text-[var(--color-text-secondary)] hover:bg-zinc-700'
+                    }`}
+                  >
+                    <span className={`w-4 h-4 ${opt.cls} ${
+                      avatarShapePref === opt.value ? 'bg-white/80' : 'bg-[var(--color-text-secondary)]'
+                    }`} />
+                    <span className="text-xs font-medium">{opt.label}</span>
+                  </button>
+                ))}
+              </div>
+
+              {/* Font Size */}
+              <label className="block text-xs text-[var(--color-text-secondary)] mb-1">
+                Font Size: {fontSizePref}px
+              </label>
+              <input
+                type="range"
+                min={12}
+                max={20}
+                step={1}
+                value={fontSizePref}
+                onChange={(e) => {
+                  const v = Number(e.target.value);
+                  setFontSizeState(v);
+                  setChatFontSize(v);
+                }}
+                className="w-full accent-[var(--color-primary)] mb-1"
+              />
+              <p className="text-[var(--color-text-secondary)] mb-4" style={{ fontSize: `${fontSizePref}px` }}>
+                Sample text Aa
+              </p>
+
+              {/* Chat Width */}
+              <label className="block text-xs text-[var(--color-text-secondary)] mb-1">
+                Message Width: {chatWidthPref}%
+                {layoutMode !== 'bubbles' && (
+                  <span className="ml-1 text-[var(--color-text-secondary)]">(bubbles only)</span>
+                )}
+              </label>
+              <input
+                type="range"
+                min={60}
+                max={100}
+                step={5}
+                value={chatWidthPref}
+                onChange={(e) => {
+                  const v = Number(e.target.value);
+                  setChatWidthState(v);
+                  setChatMaxWidth(v);
+                }}
+                className="w-full accent-[var(--color-primary)]"
+              />
             </section>
 
             {/* Voice Input Language */}

--- a/src/components/ui/Avatar.tsx
+++ b/src/components/ui/Avatar.tsx
@@ -5,10 +5,12 @@ interface AvatarProps {
   src?: string;
   alt?: string;
   size?: 'sm' | 'md' | 'lg' | 'xl';
+  /** Phase 7.3: avatar shape — circle (default), square, or rounded square. */
+  shape?: 'circle' | 'square' | 'rounded-square';
   className?: string;
 }
 
-export function Avatar({ src, alt, size = 'md', className = '' }: AvatarProps) {
+export function Avatar({ src, alt, size = 'md', shape = 'circle', className = '' }: AvatarProps) {
   const [error, setError] = useState(false);
 
   // Reset error state when src changes
@@ -30,10 +32,18 @@ export function Avatar({ src, alt, size = 'md', className = '' }: AvatarProps) {
     xl: 32,
   };
 
+  const shapes = {
+    'circle': 'rounded-full',
+    'square': 'rounded-none',
+    'rounded-square': 'rounded-lg',
+  };
+
+  const shapeClass = shapes[shape];
+
   if (!src || error) {
     return (
       <div
-        className={`${sizes[size]} rounded-full bg-[var(--color-bg-tertiary)] flex items-center justify-center ${className}`}
+        className={`${sizes[size]} ${shapeClass} bg-[var(--color-bg-tertiary)] flex items-center justify-center ${className}`}
       >
         <User size={iconSizes[size]} className="text-[var(--color-text-secondary)]" />
       </div>
@@ -44,7 +54,7 @@ export function Avatar({ src, alt, size = 'md', className = '' }: AvatarProps) {
     <img
       src={src}
       alt={alt || 'Avatar'}
-      className={`${sizes[size]} rounded-full object-cover ${className}`}
+      className={`${sizes[size]} ${shapeClass} object-cover ${className}`}
       onError={() => setError(true)}
     />
   );

--- a/src/hooks/displayPreferences.ts
+++ b/src/hooks/displayPreferences.ts
@@ -1,0 +1,82 @@
+/**
+ * Persistent chat display preferences backed by localStorage.
+ *
+ * Follows the same pattern as speechLanguage.ts — plain getter/setter
+ * functions with `stm:` key prefix, no reactive store needed since the
+ * chat view remounts when navigating back from settings.
+ */
+
+export type ChatLayoutMode = 'bubbles' | 'flat' | 'document';
+export type AvatarShape = 'circle' | 'square' | 'rounded-square';
+
+const LAYOUT_MODE_KEY = 'stm:chat-layout-mode';
+const AVATAR_SHAPE_KEY = 'stm:avatar-shape';
+const FONT_SIZE_KEY = 'stm:chat-font-size';
+const CHAT_WIDTH_KEY = 'stm:chat-max-width';
+
+const VALID_LAYOUTS: ChatLayoutMode[] = ['bubbles', 'flat', 'document'];
+const VALID_SHAPES: AvatarShape[] = ['circle', 'square', 'rounded-square'];
+
+// ---- Layout Mode ----------------------------------------------------
+
+export function getChatLayoutMode(): ChatLayoutMode {
+  try {
+    const v = localStorage.getItem(LAYOUT_MODE_KEY);
+    if (v && VALID_LAYOUTS.includes(v as ChatLayoutMode)) return v as ChatLayoutMode;
+  } catch { /* ignore */ }
+  return 'bubbles';
+}
+
+export function setChatLayoutMode(mode: ChatLayoutMode): void {
+  try { localStorage.setItem(LAYOUT_MODE_KEY, mode); } catch { /* ignore */ }
+}
+
+// ---- Avatar Shape ---------------------------------------------------
+
+export function getAvatarShape(): AvatarShape {
+  try {
+    const v = localStorage.getItem(AVATAR_SHAPE_KEY);
+    if (v && VALID_SHAPES.includes(v as AvatarShape)) return v as AvatarShape;
+  } catch { /* ignore */ }
+  return 'circle';
+}
+
+export function setAvatarShape(shape: AvatarShape): void {
+  try { localStorage.setItem(AVATAR_SHAPE_KEY, shape); } catch { /* ignore */ }
+}
+
+// ---- Font Size (px) -------------------------------------------------
+
+export function getChatFontSize(): number {
+  try {
+    const v = localStorage.getItem(FONT_SIZE_KEY);
+    if (v) {
+      const n = Number(v);
+      if (n >= 12 && n <= 20) return n;
+    }
+  } catch { /* ignore */ }
+  return 14;
+}
+
+export function setChatFontSize(px: number): void {
+  const clamped = Math.max(12, Math.min(20, Math.round(px)));
+  try { localStorage.setItem(FONT_SIZE_KEY, String(clamped)); } catch { /* ignore */ }
+}
+
+// ---- Chat Max Width (%) ---------------------------------------------
+
+export function getChatMaxWidth(): number {
+  try {
+    const v = localStorage.getItem(CHAT_WIDTH_KEY);
+    if (v) {
+      const n = Number(v);
+      if (n >= 60 && n <= 100) return n;
+    }
+  } catch { /* ignore */ }
+  return 80;
+}
+
+export function setChatMaxWidth(pct: number): void {
+  const clamped = Math.max(60, Math.min(100, Math.round(pct)));
+  try { localStorage.setItem(CHAT_WIDTH_KEY, String(clamped)); } catch { /* ignore */ }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -256,3 +256,10 @@ body {
   0%, 100% { opacity: 1; }
   50% { opacity: 0; }
 }
+
+/* ===================================================================
+   Phase 7.3 — Chat Display Styles
+   Layout modes (bubbles/flat/document), avatar shapes, font size, and
+   chat width are all driven by inline Tailwind classes + inline styles
+   in ChatMessage.tsx.  No additional CSS needed here.
+   =================================================================== */


### PR DESCRIPTION
Three layout modes (bubbles/flat/document), configurable avatar shapes (circle/square/rounded), font size slider (12-20px), and message width control (60-100%). Settings persist in localStorage and are configurable from a new Chat Display section in the settings page.