### PR TITLE
Add Phase 7.4: theming with light/dark mode and accent presets

### DIFF
--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { ArrowLeft, BookOpen, Check, ChevronRight, Eye, EyeOff, Key, Loader2, MessageSquare, Mic, Sliders, Trash2, Volume2 } from 'lucide-react';
+import { ArrowLeft, BookOpen, Check, ChevronRight, Eye, EyeOff, Key, Loader2, MessageSquare, Mic, Palette, Sliders, Trash2, Volume2 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useSettingsStore } from '../../stores/settingsStore';
 import { PROVIDERS, type SecretState } from '../../api/client';
@@ -29,6 +29,17 @@ import {
   type ChatLayoutMode,
   type AvatarShape,
 } from '../../hooks/displayPreferences';
+import {
+  getThemeMode,
+  setThemeMode,
+  getThemePreset,
+  setThemePreset,
+  applyTheme,
+  THEME_PRESETS,
+  PRESET_SWATCHES,
+  type ThemeMode,
+  type ThemePreset,
+} from '../../hooks/themePreferences';
 import { useSpeechRecognition } from '../../hooks/useSpeechRecognition';
 import { useSpeechSynthesis } from '../../hooks/useSpeechSynthesis';
 
@@ -55,6 +66,10 @@ export function SettingsPage() {
   const [showApiKey, setShowApiKey] = useState<Record<string, boolean>>({});
   const [speechLang, setSpeechLangState] = useState<string>(() => getSpeechLanguage());
   const { isSupported: isSpeechSupported } = useSpeechRecognition();
+
+  // Phase 7.4: Theme preferences
+  const [themeMode, setThemeModeState] = useState<ThemeMode>(() => getThemeMode());
+  const [themePresetVal, setThemePresetState] = useState<ThemePreset>(() => getThemePreset());
 
   // Phase 7.3: Chat display preferences
   const [layoutMode, setLayoutModeState] = useState<ChatLayoutMode>(() => getChatLayoutMode());
@@ -337,6 +352,69 @@ export function SettingsPage() {
                 </div>
                 <ChevronRight size={20} className="text-[var(--color-text-secondary)]" />
               </button>
+            </section>
+
+            {/* Appearance (Phase 7.4) */}
+            <section className="bg-[var(--color-bg-secondary)] rounded-lg p-4">
+              <div className="flex items-center gap-2 mb-3">
+                <Palette size={16} className="text-[var(--color-text-secondary)]" />
+                <h2 className="text-sm font-semibold text-[var(--color-text-primary)]">
+                  Appearance
+                </h2>
+              </div>
+
+              {/* Theme Mode */}
+              <label className="block text-xs text-[var(--color-text-secondary)] mb-1.5">
+                Theme
+              </label>
+              <div className="grid grid-cols-3 gap-2 mb-4">
+                {([
+                  { value: 'light' as const, label: 'Light' },
+                  { value: 'dark' as const, label: 'Dark' },
+                  { value: 'auto' as const, label: 'Auto' },
+                ] as const).map((opt) => (
+                  <button
+                    key={opt.value}
+                    onClick={() => {
+                      setThemeModeState(opt.value);
+                      setThemeMode(opt.value);
+                      applyTheme();
+                    }}
+                    className={`p-2.5 rounded-lg text-center text-xs font-medium transition-all ${
+                      themeMode === opt.value
+                        ? 'bg-[var(--color-primary)] text-white'
+                        : 'bg-[var(--color-bg-tertiary)] text-[var(--color-text-secondary)] hover:bg-zinc-700'
+                    }`}
+                  >
+                    {opt.label}
+                  </button>
+                ))}
+              </div>
+
+              {/* Accent Color */}
+              <label className="block text-xs text-[var(--color-text-secondary)] mb-1.5">
+                Accent Color
+              </label>
+              <div className="flex gap-3">
+                {THEME_PRESETS.map((preset) => (
+                  <button
+                    key={preset}
+                    onClick={() => {
+                      setThemePresetState(preset);
+                      setThemePreset(preset);
+                      applyTheme();
+                    }}
+                    className={`w-8 h-8 rounded-full transition-all ${
+                      themePresetVal === preset
+                        ? 'ring-2 ring-offset-2 ring-offset-[var(--color-bg-secondary)] ring-[var(--color-primary)] scale-110'
+                        : 'hover:scale-110'
+                    }`}
+                    style={{ backgroundColor: PRESET_SWATCHES[preset] }}
+                    title={preset.charAt(0).toUpperCase() + preset.slice(1)}
+                    aria-label={`${preset} theme`}
+                  />
+                ))}
+              </div>
             </section>
 
             {/* Chat Display (Phase 7.3) */}

--- a/src/hooks/themePreferences.ts
+++ b/src/hooks/themePreferences.ts
@@ -1,0 +1,179 @@
+/**
+ * Theme system — light/dark/auto mode with accent color presets.
+ *
+ * Theme = mode (light | dark | auto) + preset (purple | blue | green | red | amber).
+ * Each combination maps to 8 CSS variable values applied to <html>.
+ *
+ * `applyTheme()` must be called synchronously before React renders
+ * (in main.tsx) to avoid a flash of wrong colors.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ThemeMode = 'light' | 'dark' | 'auto';
+export type ThemePreset = 'purple' | 'blue' | 'green' | 'red' | 'amber';
+
+interface ThemeColors {
+  primary: string;
+  primaryHover: string;
+  bgPrimary: string;
+  bgSecondary: string;
+  bgTertiary: string;
+  textPrimary: string;
+  textSecondary: string;
+  border: string;
+}
+
+// ---------------------------------------------------------------------------
+// Preset definitions
+// ---------------------------------------------------------------------------
+
+const DARK_THEMES: Record<ThemePreset, ThemeColors> = {
+  purple: {
+    primary: '#8b5cf6', primaryHover: '#7c3aed',
+    bgPrimary: '#0f0f0f', bgSecondary: '#1a1a1a', bgTertiary: '#262626',
+    textPrimary: '#ffffff', textSecondary: '#a1a1aa', border: '#3f3f46',
+  },
+  blue: {
+    primary: '#3b82f6', primaryHover: '#2563eb',
+    bgPrimary: '#0f0f0f', bgSecondary: '#1a1a1a', bgTertiary: '#262626',
+    textPrimary: '#ffffff', textSecondary: '#a1a1aa', border: '#3f3f46',
+  },
+  green: {
+    primary: '#22c55e', primaryHover: '#16a34a',
+    bgPrimary: '#0f0f0f', bgSecondary: '#1a1a1a', bgTertiary: '#262626',
+    textPrimary: '#ffffff', textSecondary: '#a1a1aa', border: '#3f3f46',
+  },
+  red: {
+    primary: '#ef4444', primaryHover: '#dc2626',
+    bgPrimary: '#0f0f0f', bgSecondary: '#1a1a1a', bgTertiary: '#262626',
+    textPrimary: '#ffffff', textSecondary: '#a1a1aa', border: '#3f3f46',
+  },
+  amber: {
+    primary: '#f59e0b', primaryHover: '#d97706',
+    bgPrimary: '#0f0f0f', bgSecondary: '#1a1a1a', bgTertiary: '#262626',
+    textPrimary: '#ffffff', textSecondary: '#a1a1aa', border: '#3f3f46',
+  },
+};
+
+const LIGHT_THEMES: Record<ThemePreset, ThemeColors> = {
+  purple: {
+    primary: '#7c3aed', primaryHover: '#6d28d9',
+    bgPrimary: '#ffffff', bgSecondary: '#f4f4f5', bgTertiary: '#e4e4e7',
+    textPrimary: '#18181b', textSecondary: '#71717a', border: '#d4d4d8',
+  },
+  blue: {
+    primary: '#2563eb', primaryHover: '#1d4ed8',
+    bgPrimary: '#ffffff', bgSecondary: '#f4f4f5', bgTertiary: '#e4e4e7',
+    textPrimary: '#18181b', textSecondary: '#71717a', border: '#d4d4d8',
+  },
+  green: {
+    primary: '#16a34a', primaryHover: '#15803d',
+    bgPrimary: '#ffffff', bgSecondary: '#f4f4f5', bgTertiary: '#e4e4e7',
+    textPrimary: '#18181b', textSecondary: '#71717a', border: '#d4d4d8',
+  },
+  red: {
+    primary: '#dc2626', primaryHover: '#b91c1c',
+    bgPrimary: '#ffffff', bgSecondary: '#f4f4f5', bgTertiary: '#e4e4e7',
+    textPrimary: '#18181b', textSecondary: '#71717a', border: '#d4d4d8',
+  },
+  amber: {
+    primary: '#d97706', primaryHover: '#b45309',
+    bgPrimary: '#ffffff', bgSecondary: '#f4f4f5', bgTertiary: '#e4e4e7',
+    textPrimary: '#18181b', textSecondary: '#71717a', border: '#d4d4d8',
+  },
+};
+
+/** Accent swatch colors shown in the settings picker (always the dark variant). */
+export const PRESET_SWATCHES: Record<ThemePreset, string> = {
+  purple: '#8b5cf6',
+  blue: '#3b82f6',
+  green: '#22c55e',
+  red: '#ef4444',
+  amber: '#f59e0b',
+};
+
+export const THEME_PRESETS: ThemePreset[] = ['purple', 'blue', 'green', 'red', 'amber'];
+
+// ---------------------------------------------------------------------------
+// localStorage persistence
+// ---------------------------------------------------------------------------
+
+const MODE_KEY = 'stm:theme-mode';
+const PRESET_KEY = 'stm:theme-preset';
+
+const VALID_MODES: ThemeMode[] = ['light', 'dark', 'auto'];
+const VALID_PRESETS: ThemePreset[] = THEME_PRESETS;
+
+export function getThemeMode(): ThemeMode {
+  try {
+    const v = localStorage.getItem(MODE_KEY);
+    if (v && VALID_MODES.includes(v as ThemeMode)) return v as ThemeMode;
+  } catch { /* ignore */ }
+  return 'dark';
+}
+
+export function setThemeMode(mode: ThemeMode): void {
+  try { localStorage.setItem(MODE_KEY, mode); } catch { /* ignore */ }
+}
+
+export function getThemePreset(): ThemePreset {
+  try {
+    const v = localStorage.getItem(PRESET_KEY);
+    if (v && VALID_PRESETS.includes(v as ThemePreset)) return v as ThemePreset;
+  } catch { /* ignore */ }
+  return 'purple';
+}
+
+export function setThemePreset(preset: ThemePreset): void {
+  try { localStorage.setItem(PRESET_KEY, preset); } catch { /* ignore */ }
+}
+
+// ---------------------------------------------------------------------------
+// Theme application
+// ---------------------------------------------------------------------------
+
+/** Resolve 'auto' to an actual mode based on OS preference. */
+export function resolveMode(mode: ThemeMode): 'light' | 'dark' {
+  if (mode !== 'auto') return mode;
+  try {
+    return window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+  } catch {
+    return 'dark';
+  }
+}
+
+/**
+ * Read saved preferences, resolve the active mode, and set all 8 CSS
+ * variables on `<html>`. Also updates `<meta name="theme-color">` and
+ * the `color-scheme` CSS property for native form controls.
+ *
+ * Call this synchronously before `createRoot()` in main.tsx and again
+ * whenever the user changes theme settings.
+ */
+export function applyTheme(): void {
+  const mode = getThemeMode();
+  const preset = getThemePreset();
+  const resolved = resolveMode(mode);
+
+  const colors = resolved === 'light' ? LIGHT_THEMES[preset] : DARK_THEMES[preset];
+  const root = document.documentElement;
+
+  root.style.setProperty('--color-primary', colors.primary);
+  root.style.setProperty('--color-primary-hover', colors.primaryHover);
+  root.style.setProperty('--color-bg-primary', colors.bgPrimary);
+  root.style.setProperty('--color-bg-secondary', colors.bgSecondary);
+  root.style.setProperty('--color-bg-tertiary', colors.bgTertiary);
+  root.style.setProperty('--color-text-primary', colors.textPrimary);
+  root.style.setProperty('--color-text-secondary', colors.textSecondary);
+  root.style.setProperty('--color-border', colors.border);
+
+  // Native form controls and scrollbars respect color-scheme
+  root.style.colorScheme = resolved;
+
+  // Update mobile status bar color
+  const meta = document.querySelector('meta[name="theme-color"]');
+  if (meta) meta.setAttribute('content', colors.bgPrimary);
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,9 @@
 @import "tailwindcss";
 
-/* Custom CSS variables for theming */
+/* CSS custom properties for theming.
+   These fallback values match the default dark-purple theme.
+   At runtime, applyTheme() (called from main.tsx before first render)
+   overwrites them on <html> based on the user's saved preference. */
 :root {
   --color-primary: #8b5cf6;
   --color-primary-hover: #7c3aed;
@@ -10,6 +13,7 @@
   --color-text-primary: #ffffff;
   --color-text-secondary: #a1a1aa;
   --color-border: #3f3f46;
+  color-scheme: dark;
 }
 
 /* Base styles */

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,10 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App';
+import { applyTheme } from './hooks/themePreferences';
+
+// Apply theme before first render to avoid flash of wrong colors.
+applyTheme();
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>


### PR DESCRIPTION
Light/dark/auto mode toggle with 5 accent color presets (purple, blue, green, red, amber). Theme applied via CSS variables on <html> before first render to prevent flash. Settings UI with mode toggle and color swatch picker. Persisted in localStorage.