### PR TITLE
Add Phase 8.1: Author's Note with configurable depth injection

### DIFF
--- a/src/components/chat/AuthorNote.tsx
+++ b/src/components/chat/AuthorNote.tsx
@@ -1,0 +1,126 @@
+import { useState, useCallback } from 'react';
+import { ChevronDown, ChevronUp, BookOpen } from 'lucide-react';
+import { useChatStore, type AuthorNote as AuthorNoteType } from '../../stores/chatStore';
+
+interface AuthorNoteProps {
+  fileName: string;
+}
+
+const ROLE_OPTIONS: Array<{ value: AuthorNoteType['role']; label: string }> = [
+  { value: 'system', label: 'System' },
+  { value: 'user', label: 'User' },
+  { value: 'assistant', label: 'Assistant' },
+];
+
+const MAX_LENGTH = 2000;
+const DEFAULT_NOTE: AuthorNoteType = { content: '', depth: 4, role: 'system' };
+
+export function AuthorNote({ fileName }: AuthorNoteProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const note = useChatStore(
+    (s) => s.authorNotes[fileName] ?? DEFAULT_NOTE
+  );
+  const setAuthorNote = useChatStore((s) => s.setAuthorNote);
+
+  const handleContentChange = useCallback(
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      const value = e.target.value.slice(0, MAX_LENGTH);
+      setAuthorNote(fileName, { content: value });
+    },
+    [fileName, setAuthorNote]
+  );
+
+  const handleDepthChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const val = parseInt(e.target.value, 10);
+      if (isFinite(val) && val >= 0) {
+        setAuthorNote(fileName, { depth: val });
+      }
+    },
+    [fileName, setAuthorNote]
+  );
+
+  const handleRoleChange = useCallback(
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
+      const role = e.target.value as AuthorNoteType['role'];
+      setAuthorNote(fileName, { role });
+    },
+    [fileName, setAuthorNote]
+  );
+
+  const charCount = note.content.length;
+  const hasContent = charCount > 0;
+
+  return (
+    <div className="border-t border-[var(--color-border)]">
+      <button
+        type="button"
+        onClick={() => setIsExpanded((v) => !v)}
+        className="w-full flex items-center gap-2 px-4 py-2 text-sm hover:bg-[var(--color-bg-tertiary)] transition-colors"
+        aria-expanded={isExpanded}
+        aria-label="Toggle Author's Note"
+      >
+        <BookOpen size={14} className={hasContent ? 'text-[var(--color-primary)]' : 'text-[var(--color-text-secondary)]'} />
+        <span className={`font-medium ${hasContent ? 'text-[var(--color-primary)]' : 'text-[var(--color-text-secondary)]'}`}>
+          Author's Note
+        </span>
+        {hasContent && (
+          <span className="text-xs text-[var(--color-text-secondary)] ml-1">
+            ({charCount})
+          </span>
+        )}
+        <span className="ml-auto text-[var(--color-text-secondary)]">
+          {isExpanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+        </span>
+      </button>
+
+      {isExpanded && (
+        <div className="px-4 pb-3 space-y-2 bg-[var(--color-bg-secondary)]">
+          <textarea
+            value={note.content}
+            onChange={handleContentChange}
+            placeholder="Write style, tone, or direction instructions here (e.g. &quot;Write in a gothic style, focus on atmosphere and tension&quot;). This text is injected into the AI prompt at the configured depth."
+            className="w-full h-24 px-3 py-2 text-sm rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-primary)] text-[var(--color-text-primary)] placeholder:text-[var(--color-text-secondary)]/50 resize-y focus:outline-none focus:ring-1 focus:ring-[var(--color-primary)]"
+            maxLength={MAX_LENGTH}
+          />
+
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <label className="flex items-center gap-1.5 text-xs text-[var(--color-text-secondary)]">
+                Depth
+                <input
+                  type="number"
+                  min={0}
+                  max={999}
+                  value={note.depth}
+                  onChange={handleDepthChange}
+                  className="w-14 px-1.5 py-1 text-xs rounded border border-[var(--color-border)] bg-[var(--color-bg-primary)] text-[var(--color-text-primary)] focus:outline-none focus:ring-1 focus:ring-[var(--color-primary)] text-center"
+                />
+              </label>
+
+              <label className="flex items-center gap-1.5 text-xs text-[var(--color-text-secondary)]">
+                Role
+                <select
+                  value={note.role}
+                  onChange={handleRoleChange}
+                  className="px-1.5 py-1 text-xs rounded border border-[var(--color-border)] bg-[var(--color-bg-primary)] text-[var(--color-text-primary)] focus:outline-none focus:ring-1 focus:ring-[var(--color-primary)]"
+                >
+                  {ROLE_OPTIONS.map((opt) => (
+                    <option key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </div>
+
+            <span className={`text-xs ${charCount >= MAX_LENGTH ? 'text-red-400' : 'text-[var(--color-text-secondary)]'}`}>
+              {charCount}/{MAX_LENGTH}
+            </span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -6,6 +6,7 @@ import { ChatMessage } from './ChatMessage';
 import { ChatInput } from './ChatInput';
 import { ChatActionBar } from './ChatActionBar';
 import { GroupChatControls } from './GroupChatControls';
+import { AuthorNote } from './AuthorNote';
 import { TypingIndicator } from './TypingIndicator';
 import { useCharacterSprites } from '../../hooks/useCharacterSprites';
 import {
@@ -547,6 +548,9 @@ export function ChatView() {
           </button>
         </div>
       ) : null}
+
+      {/* Phase 8.1: Author's Note — collapsible panel for per-chat instructions */}
+      {currentChatFile && <AuthorNote fileName={currentChatFile} />}
 
       {/* Input Area */}
       <ChatInput

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -90,6 +90,33 @@ export interface GroupChatInfo {
   title?: string;
 }
 
+/** Phase 8.1: per-chat Author's Note — a persistent instruction that gets
+ *  injected into the AI prompt at a configurable depth from the end of the
+ *  conversation history. Stored in localStorage keyed by chat file name. */
+export interface AuthorNote {
+  content: string;
+  depth: number;
+  role: 'system' | 'user' | 'assistant';
+}
+
+const AUTHOR_NOTES_KEY = 'sillytavern_author_notes';
+
+function loadAuthorNotesFromStorage(): Record<string, AuthorNote> {
+  try {
+    const stored = localStorage.getItem(AUTHOR_NOTES_KEY);
+    if (!stored) return {};
+    const parsed = JSON.parse(stored);
+    if (!parsed || typeof parsed !== 'object') return {};
+    return parsed;
+  } catch {
+    return {};
+  }
+}
+
+function saveAuthorNotesToStorage(notes: Record<string, AuthorNote>) {
+  localStorage.setItem(AUTHOR_NOTES_KEY, JSON.stringify(notes));
+}
+
 const GROUP_CHATS_KEY = 'sillytavern_group_chats';
 
 /**
@@ -334,6 +361,11 @@ interface ChatState {
   setGroupTitle: (fileName: string, title: string) => void;
   addGroupChatMember: (fileName: string, character: CharacterInfo) => void;
   removeGroupChatMember: (fileName: string, avatar: string) => void;
+
+  // Phase 8.1: Author's Note
+  authorNotes: Record<string, AuthorNote>;
+  getAuthorNote: (fileName: string) => AuthorNote | null;
+  setAuthorNote: (fileName: string, note: Partial<AuthorNote>) => void;
 
   // New Phase 1 actions
   stopGeneration: () => void;
@@ -652,6 +684,12 @@ Choose the emotion that best matches how ${character.name} would feel based on t
   const depthPrompt = getDepthPrompt(character);
   const depthPromptContent = depthPrompt ? sub(depthPrompt.prompt) : '';
 
+  // Phase 8.1: Author's Note — per-chat persistent instruction injected at depth
+  const { currentChatFile } = useChatStore.getState();
+  const authorNote = currentChatFile
+    ? useChatStore.getState().getAuthorNote(currentChatFile)
+    : null;
+
   // Persona @ depth
   const personaAtDepth =
     persona && persona.descriptionPosition === 'at_depth' && personaDescription
@@ -687,6 +725,13 @@ Choose the emotion that best matches how ${character.name} would feel based on t
         content: depthPromptContent,
       });
     }
+    // Phase 8.1: Author's Note injection at depth
+    if (authorNote && depthFromEnd === authorNote.depth) {
+      historyWithInsertions.push({
+        role: authorNote.role,
+        content: sub(authorNote.content),
+      });
+    }
     if (personaAtDepth && depthFromEnd === personaAtDepth.depth) {
       historyWithInsertions.push({
         role: personaAtDepth.role,
@@ -717,6 +762,12 @@ Choose the emotion that best matches how ${character.name} would feel based on t
     historyWithInsertions.unshift({
       role: depthPrompt.role,
       content: depthPromptContent,
+    });
+  }
+  if (authorNote && authorNote.depth > recentMessages.length) {
+    historyWithInsertions.unshift({
+      role: authorNote.role,
+      content: sub(authorNote.content),
     });
   }
   if (personaAtDepth && personaAtDepth.depth > recentMessages.length) {
@@ -837,15 +888,40 @@ IMPORTANT:
 
   context.push({ role: 'system', content: systemPrompt });
 
-  const recentMessages = messages.slice(-30);
-  for (const msg of recentMessages) {
-    if (msg.isSystem) continue;
+  // Phase 8.1: Author's Note for group chats
+  const { currentChatFile: groupChatFile } = useChatStore.getState();
+  const groupAuthorNote = groupChatFile
+    ? useChatStore.getState().getAuthorNote(groupChatFile)
+    : null;
+
+  const recentMessages = messages.slice(-30).filter((m) => !m.isSystem);
+  for (let i = 0; i < recentMessages.length; i++) {
+    const msg = recentMessages[i];
+    const depthFromEnd = recentMessages.length - i;
+
+    // Inject author's note at the configured depth
+    if (groupAuthorNote && depthFromEnd === groupAuthorNote.depth) {
+      context.push({
+        role: groupAuthorNote.role,
+        content: groupAuthorNote.content,
+      });
+    }
+
     const contentWithName = msg.isUser
       ? msg.content
       : `[${msg.name}]: ${msg.content}`;
     context.push({
       role: msg.isUser ? 'user' : 'assistant',
       content: contentWithName,
+    });
+  }
+
+  // If depth exceeds history, prepend
+  if (groupAuthorNote && groupAuthorNote.depth > recentMessages.length) {
+    // Insert after the system prompt (index 1)
+    context.splice(1, 0, {
+      role: groupAuthorNote.role,
+      content: groupAuthorNote.content,
     });
   }
 
@@ -1014,6 +1090,11 @@ async function saveChatToBackend(
 ) {
   if (!currentChatFile) return;
 
+  // Phase 8.1: include author's note in chat header metadata
+  const authorNote = currentChatFile
+    ? useChatStore.getState().getAuthorNote(currentChatFile)
+    : null;
+
   const chatData = [
     {
       user_name: 'You',
@@ -1022,6 +1103,13 @@ async function saveChatToBackend(
         : character.name,
       create_date: new Date().toISOString(),
       ...(isGroupChat ? { is_group_chat: true } : {}),
+      ...(authorNote ? {
+        author_note: {
+          content: authorNote.content,
+          depth: authorNote.depth,
+          role: authorNote.role,
+        },
+      } : {}),
     },
     ...messages.map((msg) => ({
       name: msg.name,
@@ -1180,6 +1268,30 @@ export const useChatStore = create<ChatState>((set, get) => ({
   error: null,
   abortController: null,
   currentSpeakerName: null,
+
+  // Phase 8.1: Author's Note
+  authorNotes: loadAuthorNotesFromStorage(),
+
+  getAuthorNote: (fileName: string) => {
+    const note = get().authorNotes[fileName];
+    if (!note || !note.content?.trim()) return null;
+    return note;
+  },
+
+  setAuthorNote: (fileName: string, partial: Partial<AuthorNote>) => {
+    const { authorNotes } = get();
+    const existing = authorNotes[fileName] || { content: '', depth: 4, role: 'system' as const };
+    const updated = {
+      ...authorNotes,
+      [fileName]: {
+        content: partial.content ?? existing.content,
+        depth: partial.depth ?? existing.depth,
+        role: partial.role ?? existing.role,
+      },
+    };
+    saveAuthorNotesToStorage(updated);
+    set({ authorNotes: updated });
+  },
 
   refreshGroupChats: () => {
     set({ groupChats: loadGroupChatsFromStorage() });
@@ -1423,7 +1535,6 @@ export const useChatStore = create<ChatState>((set, get) => ({
   loadGroupChat: async (groupChat: GroupChatInfo) => {
     set({ isLoading: true, error: null, currentChatFile: groupChat.fileName });
     try {
-      // Use the first character's avatar to fetch the chat file
       const avatarUrl = groupChat.characterAvatars[0];
       const rawMessages = await api.getChatMessages(avatarUrl, groupChat.fileName);
       const messages = rawMessages.map(normalizeMessage);


### PR DESCRIPTION
Per-chat persistent text box for style/tone/direction instructions injected into the AI prompt at a configurable depth. Supports both solo and group chats with depth (default 4) and role (system/user/ assistant) controls. Persisted in localStorage and chat JSONL header.