### PR TITLE
Add Phase 8.2: Regex Scripts for message find/replace processing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { MainLayout } from './components/layout/MainLayout';
 import { ChatView } from './components/chat/ChatView';
 import { SettingsPage, GenerationSettingsPage } from './components/settings';
 import { WorldInfoPage } from './components/worldinfo';
+import { RegexScriptPage } from './components/regexscripts';
 
 function App() {
   return (
@@ -15,6 +16,7 @@ function App() {
         <Route path="/settings" element={<SettingsPage />} />
         <Route path="/settings/generation" element={<GenerationSettingsPage />} />
         <Route path="/settings/worldinfo" element={<WorldInfoPage />} />
+        <Route path="/settings/regex" element={<RegexScriptPage />} />
         <Route path="/" element={<MainLayout />}>
           <Route index element={<ChatView />} />
           <Route path="chat/:characterId" element={<ChatView />} />

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -6,6 +6,8 @@ import { SwipeControl } from './SwipeControl';
 import { MarkdownContent } from './MarkdownContent';
 import { useSpeechSynthesis } from '../../hooks/useSpeechSynthesis';
 import type { ChatLayoutMode, AvatarShape } from '../../hooks/displayPreferences';
+import { useRegexScriptStore } from '../../stores/regexScriptStore';
+import { applyRegexScripts, getActiveScripts } from '../../utils/regexScripts';
 
 interface ChatMessageProps {
   /** Unique message id — used as TTS tracking key. */
@@ -19,6 +21,8 @@ interface ChatMessageProps {
   disabled?: boolean;
   /** Phase 6.1: attached image data URLs shown as a grid above content. */
   images?: string[];
+  /** Phase 8.2: raw character avatar string for display-only regex scoping. */
+  characterAvatar?: string;
   /** Phase 7.2: true while this message is actively being streamed. */
   isStreaming?: boolean;
   /** Phase 7.3: display style settings. */
@@ -114,6 +118,7 @@ export function ChatMessage({
   timestamp,
   disabled,
   images,
+  characterAvatar,
   swipes,
   swipeId,
   showSwipeControl,
@@ -134,6 +139,17 @@ export function ChatMessage({
   const [showMenu, setShowMenu] = useState(false);
   const [showEditOptions, setShowEditOptions] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // Phase 8.2: apply display-only regex scripts for rendering
+  const regexScripts = useRegexScriptStore((s) => s.scripts);
+  const displayContent = useMemo(() => {
+    const scripts = getActiveScripts(
+      regexScripts,
+      characterAvatar,
+      isUser ? 'user_input' : 'ai_output'
+    ).filter((s) => s.displayOnly);
+    return scripts.length > 0 ? applyRegexScripts(content, scripts) : content;
+  }, [content, regexScripts, characterAvatar, isUser]);
 
   // Phase 6.3: TTS — only wired for non-user, non-system messages.
   const { isSupported: ttsSupported, isSpeaking, speak, stop } = useSpeechSynthesis();
@@ -363,7 +379,7 @@ export function ChatMessage({
       </div>
     ) : (
       <div className="break-words" style={fontStyle}>
-        <MarkdownContent content={content} isUser={false} isStreaming={isStreamingMsg} />
+        <MarkdownContent content={displayContent} isUser={false} isStreaming={isStreamingMsg} />
       </div>
     )
   ) : null;

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -478,6 +478,7 @@ export function ChatView() {
                   timestamp={message.timestamp}
                   disabled={isSending}
                   images={message.images}
+                  characterAvatar={message.isUser ? selectedCharacter?.avatar : (message.characterAvatar || selectedCharacter?.avatar)}
                   isStreaming={isLastAiMessage && isStreaming}
                   layoutMode={chatLayoutMode}
                   avatarShape={avatarShapePref}

--- a/src/components/regexscripts/RegexScriptEditor.tsx
+++ b/src/components/regexscripts/RegexScriptEditor.tsx
@@ -1,0 +1,230 @@
+import { useState, useMemo } from 'react';
+import { X, Check, AlertCircle } from 'lucide-react';
+import { Modal } from '../ui/Modal';
+import type { RegexScript, RegexScope } from '../../stores/regexScriptStore';
+import { useCharacterStore } from '../../stores/characterStore';
+
+interface RegexScriptEditorProps {
+  script: RegexScript | null;
+  onSave: (data: Partial<RegexScript>) => void;
+  onCancel: () => void;
+}
+
+const SCOPE_OPTIONS: Array<{ value: RegexScope; label: string }> = [
+  { value: 'ai_output', label: 'AI Output' },
+  { value: 'user_input', label: 'User Input' },
+  { value: 'both', label: 'Both' },
+];
+
+export function RegexScriptEditor({ script, onSave, onCancel }: RegexScriptEditorProps) {
+  const [name, setName] = useState(script?.name || '');
+  const [pattern, setPattern] = useState(script?.pattern || '');
+  const [replacement, setReplacement] = useState(script?.replacement ?? '');
+  const [flags, setFlags] = useState(script?.flags || 'g');
+  const [scope, setScope] = useState<RegexScope>(script?.scope || 'ai_output');
+  const [displayOnly, setDisplayOnly] = useState(script?.displayOnly ?? false);
+  const [characterScope, setCharacterScope] = useState<string[]>(script?.characterScope || []);
+  const [order, setOrder] = useState(script?.order ?? 0);
+
+  const characters = useCharacterStore((s) => s.characters);
+
+  const patternValid = useMemo(() => {
+    if (!pattern.trim()) return null; // empty = neutral
+    try {
+      new RegExp(pattern, flags);
+      return true;
+    } catch {
+      return false;
+    }
+  }, [pattern, flags]);
+
+  const toggleFlag = (flag: string) => {
+    setFlags((f) => f.includes(flag) ? f.replace(flag, '') : f + flag);
+  };
+
+  const toggleCharacter = (avatar: string) => {
+    setCharacterScope((prev) =>
+      prev.includes(avatar) ? prev.filter((a) => a !== avatar) : [...prev, avatar]
+    );
+  };
+
+  const handleSave = () => {
+    if (!pattern.trim() || patternValid === false) return;
+    onSave({
+      name: name.trim() || 'Untitled Script',
+      pattern,
+      replacement,
+      flags,
+      scope,
+      displayOnly,
+      characterScope,
+      order,
+    });
+  };
+
+  return (
+    <Modal isOpen onClose={onCancel} title={script ? 'Edit Script' : 'New Script'} size="lg">
+      <div className="space-y-4">
+        {/* Name */}
+        <div>
+          <label className="block text-xs font-medium text-[var(--color-text-secondary)] mb-1">Name</label>
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="My Script"
+            className="w-full px-3 py-2 text-sm rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-primary)] text-[var(--color-text-primary)] focus:outline-none focus:ring-1 focus:ring-[var(--color-primary)]"
+          />
+        </div>
+
+        {/* Pattern */}
+        <div>
+          <label className="block text-xs font-medium text-[var(--color-text-secondary)] mb-1">
+            Pattern (regex)
+            {patternValid === true && <Check size={12} className="inline ml-1 text-green-400" />}
+            {patternValid === false && <AlertCircle size={12} className="inline ml-1 text-red-400" />}
+          </label>
+          <input
+            type="text"
+            value={pattern}
+            onChange={(e) => setPattern(e.target.value)}
+            placeholder="\\*([^*]+)\\*"
+            className={`w-full px-3 py-2 text-sm font-mono rounded-lg border bg-[var(--color-bg-primary)] text-[var(--color-text-primary)] focus:outline-none focus:ring-1 ${
+              patternValid === false
+                ? 'border-red-500 focus:ring-red-500'
+                : 'border-[var(--color-border)] focus:ring-[var(--color-primary)]'
+            }`}
+          />
+          {patternValid === false && (
+            <p className="text-xs text-red-400 mt-1">Invalid regex pattern</p>
+          )}
+        </div>
+
+        {/* Replacement */}
+        <div>
+          <label className="block text-xs font-medium text-[var(--color-text-secondary)] mb-1">
+            Replacement
+          </label>
+          <input
+            type="text"
+            value={replacement}
+            onChange={(e) => setReplacement(e.target.value)}
+            placeholder="$1 (use $1, $2 for capture groups)"
+            className="w-full px-3 py-2 text-sm font-mono rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-primary)] text-[var(--color-text-primary)] focus:outline-none focus:ring-1 focus:ring-[var(--color-primary)]"
+          />
+        </div>
+
+        {/* Flags */}
+        <div>
+          <label className="block text-xs font-medium text-[var(--color-text-secondary)] mb-1">Flags</label>
+          <div className="flex gap-2">
+            {[
+              { flag: 'g', label: 'Global', hint: 'Replace all matches' },
+              { flag: 'i', label: 'Case-insensitive', hint: 'Ignore case' },
+              { flag: 'm', label: 'Multiline', hint: '^ and $ match line boundaries' },
+              { flag: 's', label: 'Dotall', hint: '. matches newlines' },
+            ].map(({ flag, label }) => (
+              <button
+                key={flag}
+                type="button"
+                onClick={() => toggleFlag(flag)}
+                className={`px-2.5 py-1 text-xs font-mono rounded border transition-colors ${
+                  flags.includes(flag)
+                    ? 'bg-[var(--color-primary)]/20 border-[var(--color-primary)] text-[var(--color-primary)]'
+                    : 'border-[var(--color-border)] text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-tertiary)]'
+                }`}
+              >
+                {flag}
+                <span className="ml-1 font-sans">{label}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Scope + Display Only */}
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className="block text-xs font-medium text-[var(--color-text-secondary)] mb-1">Scope</label>
+            <select
+              value={scope}
+              onChange={(e) => setScope(e.target.value as RegexScope)}
+              className="w-full px-3 py-2 text-sm rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-primary)] text-[var(--color-text-primary)] focus:outline-none focus:ring-1 focus:ring-[var(--color-primary)]"
+            >
+              {SCOPE_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>{opt.label}</option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label className="block text-xs font-medium text-[var(--color-text-secondary)] mb-1">Order</label>
+            <input
+              type="number"
+              min={0}
+              value={order}
+              onChange={(e) => setOrder(parseInt(e.target.value, 10) || 0)}
+              className="w-full px-3 py-2 text-sm rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-primary)] text-[var(--color-text-primary)] focus:outline-none focus:ring-1 focus:ring-[var(--color-primary)]"
+            />
+          </div>
+        </div>
+
+        <label className="flex items-center gap-2 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={displayOnly}
+            onChange={(e) => setDisplayOnly(e.target.checked)}
+            className="rounded border-[var(--color-border)]"
+          />
+          <span className="text-sm text-[var(--color-text-primary)]">Display only</span>
+          <span className="text-xs text-[var(--color-text-secondary)]">(visual transform, original text preserved)</span>
+        </label>
+
+        {/* Character Scope */}
+        {characters.length > 0 && (
+          <div>
+            <label className="block text-xs font-medium text-[var(--color-text-secondary)] mb-1">
+              Character Scope
+              <span className="ml-1 font-normal">(none selected = applies to all)</span>
+            </label>
+            <div className="flex flex-wrap gap-1.5 max-h-24 overflow-y-auto">
+              {characters.map((c) => (
+                <button
+                  key={c.avatar}
+                  type="button"
+                  onClick={() => toggleCharacter(c.avatar)}
+                  className={`px-2 py-1 text-xs rounded-full border transition-colors ${
+                    characterScope.includes(c.avatar)
+                      ? 'bg-[var(--color-primary)]/20 border-[var(--color-primary)] text-[var(--color-primary)]'
+                      : 'border-[var(--color-border)] text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-tertiary)]'
+                  }`}
+                >
+                  {c.name}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+        {/* Footer */}
+        <div className="flex justify-end gap-2 pt-4 mt-2 border-t border-[var(--color-border)]">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="flex items-center gap-1.5 px-4 py-2 text-sm rounded-lg border border-[var(--color-border)] text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-tertiary)] transition-colors"
+          >
+            <X size={14} />
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={!pattern.trim() || patternValid === false}
+            className="flex items-center gap-1.5 px-4 py-2 text-sm rounded-lg bg-[var(--color-primary)] text-white hover:opacity-90 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            <Check size={14} />
+            Save
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/regexscripts/RegexScriptPage.tsx
+++ b/src/components/regexscripts/RegexScriptPage.tsx
@@ -1,0 +1,256 @@
+import { useState, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  ArrowLeft,
+  Plus,
+  Download,
+  Upload,
+  ToggleLeft,
+  ToggleRight,
+  Pencil,
+  Trash2,
+  Copy,
+  Replace,
+} from 'lucide-react';
+import { useRegexScriptStore, type RegexScript } from '../../stores/regexScriptStore';
+import { RegexScriptEditor } from './RegexScriptEditor';
+
+const SCOPE_LABELS: Record<string, string> = {
+  ai_output: 'AI Output',
+  user_input: 'User Input',
+  both: 'Both',
+};
+
+export function RegexScriptPage() {
+  const navigate = useNavigate();
+  const scripts = useRegexScriptStore((s) => s.scripts);
+  const {
+    createScript,
+    updateScript,
+    deleteScript,
+    duplicateScript,
+    toggleScript,
+    importScripts,
+    exportScripts,
+  } = useRegexScriptStore();
+
+  const [editingScript, setEditingScript] = useState<RegexScript | null>(null);
+  const [isCreating, setIsCreating] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const sorted = [...scripts].sort((a, b) => a.order - b.order);
+
+  const handleCreate = () => {
+    setEditingScript(null);
+    setIsCreating(true);
+  };
+
+  const handleEdit = (script: RegexScript) => {
+    setEditingScript(script);
+    setIsCreating(true);
+  };
+
+  const handleSave = (data: Partial<RegexScript>) => {
+    if (editingScript) {
+      updateScript(editingScript.id, data);
+    } else {
+      createScript(data);
+    }
+    setIsCreating(false);
+    setEditingScript(null);
+  };
+
+  const handleCancel = () => {
+    setIsCreating(false);
+    setEditingScript(null);
+  };
+
+  const handleExport = () => {
+    const json = exportScripts();
+    const blob = new Blob([json], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'regex_scripts.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleImport = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      const count = importScripts(reader.result as string);
+      if (count === 0) {
+        alert('No valid scripts found in file.');
+      }
+    };
+    reader.readAsText(file);
+    // Reset so same file can be re-imported
+    e.target.value = '';
+  };
+
+  return (
+    <div className="h-full flex flex-col bg-[var(--color-bg-primary)]">
+      {/* Header */}
+      <div className="flex items-center gap-3 px-4 py-3 border-b border-[var(--color-border)]">
+        <button
+          onClick={() => navigate('/settings')}
+          className="p-1.5 rounded-lg hover:bg-[var(--color-bg-tertiary)] text-[var(--color-text-secondary)]"
+          aria-label="Back"
+        >
+          <ArrowLeft size={20} />
+        </button>
+        <h1 className="text-lg font-semibold text-[var(--color-text-primary)] flex-1">
+          Regex Scripts
+        </h1>
+        <div className="flex items-center gap-1">
+          <button
+            onClick={handleImport}
+            className="p-1.5 rounded-lg hover:bg-[var(--color-bg-tertiary)] text-[var(--color-text-secondary)]"
+            title="Import"
+          >
+            <Upload size={18} />
+          </button>
+          <button
+            onClick={handleExport}
+            className="p-1.5 rounded-lg hover:bg-[var(--color-bg-tertiary)] text-[var(--color-text-secondary)]"
+            title="Export"
+            disabled={scripts.length === 0}
+          >
+            <Download size={18} />
+          </button>
+          <button
+            onClick={handleCreate}
+            className="p-1.5 rounded-lg bg-[var(--color-primary)] text-white hover:opacity-90"
+            title="New Script"
+          >
+            <Plus size={18} />
+          </button>
+        </div>
+      </div>
+
+      {/* Hidden file input for import */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".json"
+        onChange={handleFileChange}
+        className="hidden"
+      />
+
+      {/* Script List */}
+      <div className="flex-1 overflow-y-auto p-4 space-y-2">
+        {sorted.length === 0 ? (
+          <div className="flex flex-col items-center justify-center text-center py-16">
+            <Replace size={48} className="text-[var(--color-text-secondary)] mb-4" />
+            <h3 className="text-lg font-medium text-[var(--color-text-primary)] mb-2">
+              No Regex Scripts
+            </h3>
+            <p className="text-sm text-[var(--color-text-secondary)] max-w-sm mb-4">
+              Create find/replace patterns to automatically transform AI output or user input.
+            </p>
+            <button
+              onClick={handleCreate}
+              className="flex items-center gap-2 px-4 py-2 text-sm rounded-lg bg-[var(--color-primary)] text-white hover:opacity-90"
+            >
+              <Plus size={16} />
+              Create Script
+            </button>
+          </div>
+        ) : (
+          sorted.map((script) => (
+            <div
+              key={script.id}
+              className={`p-3 rounded-lg border transition-colors ${
+                script.enabled
+                  ? 'bg-[var(--color-bg-secondary)] border-[var(--color-border)]'
+                  : 'bg-[var(--color-bg-secondary)]/40 border-[var(--color-border)]/40 opacity-60'
+              }`}
+            >
+              <div className="flex items-start justify-between gap-2">
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 mb-1">
+                    <h3 className="text-sm font-medium text-[var(--color-text-primary)] truncate">
+                      {script.name}
+                    </h3>
+                    <span className="text-[10px] px-1.5 py-0.5 rounded font-medium bg-[var(--color-primary)]/15 text-[var(--color-primary)]">
+                      {SCOPE_LABELS[script.scope]}
+                    </span>
+                    {script.displayOnly && (
+                      <span className="text-[10px] px-1.5 py-0.5 rounded font-medium bg-yellow-500/15 text-yellow-400">
+                        Display
+                      </span>
+                    )}
+                  </div>
+                  <p className="text-xs font-mono text-[var(--color-text-secondary)] truncate">
+                    /{script.pattern}/{script.flags}
+                  </p>
+                  {script.replacement && (
+                    <p className="text-xs text-[var(--color-text-secondary)] truncate mt-0.5">
+                      <span className="opacity-60">Replace:</span> {script.replacement}
+                    </p>
+                  )}
+                  {script.characterScope.length > 0 && (
+                    <p className="text-[10px] text-[var(--color-text-secondary)] mt-0.5 truncate">
+                      Scoped to {script.characterScope.length} character(s)
+                    </p>
+                  )}
+                </div>
+
+                <div className="flex items-center gap-0.5 flex-shrink-0">
+                  <button
+                    onClick={() => toggleScript(script.id)}
+                    className="p-1.5 rounded-lg hover:bg-[var(--color-bg-tertiary)] transition-colors"
+                    title={script.enabled ? 'Disable' : 'Enable'}
+                  >
+                    {script.enabled ? (
+                      <ToggleRight size={18} className="text-[var(--color-primary)]" />
+                    ) : (
+                      <ToggleLeft size={18} className="text-[var(--color-text-secondary)]" />
+                    )}
+                  </button>
+                  <button
+                    onClick={() => handleEdit(script)}
+                    className="p-1.5 rounded-lg hover:bg-[var(--color-bg-tertiary)] text-[var(--color-text-secondary)]"
+                    title="Edit"
+                  >
+                    <Pencil size={14} />
+                  </button>
+                  <button
+                    onClick={() => duplicateScript(script.id)}
+                    className="p-1.5 rounded-lg hover:bg-[var(--color-bg-tertiary)] text-[var(--color-text-secondary)]"
+                    title="Duplicate"
+                  >
+                    <Copy size={14} />
+                  </button>
+                  <button
+                    onClick={() => deleteScript(script.id)}
+                    className="p-1.5 rounded-lg hover:bg-[var(--color-bg-tertiary)] text-red-400"
+                    title="Delete"
+                  >
+                    <Trash2 size={14} />
+                  </button>
+                </div>
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+
+      {/* Editor modal */}
+      {isCreating && (
+        <RegexScriptEditor
+          script={editingScript}
+          onSave={handleSave}
+          onCancel={handleCancel}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/regexscripts/index.ts
+++ b/src/components/regexscripts/index.ts
@@ -1,0 +1,1 @@
+export { RegexScriptPage } from './RegexScriptPage';

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { ArrowLeft, BookOpen, Check, ChevronRight, Eye, EyeOff, Key, Loader2, MessageSquare, Mic, Palette, Sliders, Trash2, Volume2 } from 'lucide-react';
+import { ArrowLeft, BookOpen, Check, ChevronRight, Eye, EyeOff, Key, Loader2, MessageSquare, Mic, Palette, Replace, Sliders, Trash2, Volume2 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useSettingsStore } from '../../stores/settingsStore';
 import { PROVIDERS, type SecretState } from '../../api/client';
@@ -348,6 +348,27 @@ export function SettingsPage() {
                   </h3>
                   <p className="text-xs text-[var(--color-text-secondary)]">
                     Lorebooks with keyword-triggered context injection
+                  </p>
+                </div>
+                <ChevronRight size={20} className="text-[var(--color-text-secondary)]" />
+              </button>
+            </section>
+
+            {/* Regex Scripts Link (Phase 8.2) */}
+            <section className="bg-[var(--color-bg-secondary)] rounded-lg overflow-hidden">
+              <button
+                onClick={() => navigate('/settings/regex')}
+                className="w-full flex items-center gap-3 p-4 hover:bg-[var(--color-bg-tertiary)] transition-colors text-left"
+              >
+                <div className="w-10 h-10 rounded-lg bg-[var(--color-primary)]/20 flex items-center justify-center">
+                  <Replace size={20} className="text-[var(--color-primary)]" />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <h3 className="text-sm font-semibold text-[var(--color-text-primary)]">
+                    Regex Scripts
+                  </h3>
+                  <p className="text-xs text-[var(--color-text-secondary)]">
+                    Find/replace patterns for message processing
                   </p>
                 </div>
                 <ChevronRight size={20} className="text-[var(--color-text-secondary)]" />

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -25,6 +25,8 @@ import {
   trimHistoryToBudget,
 } from '../utils/tokenizer';
 import { getInstructTemplate, formatInstructPrompt } from '../utils/instructTemplates';
+import { useRegexScriptStore } from './regexScriptStore';
+import { applyRegexScripts, getActiveScripts } from '../utils/regexScripts';
 
 export interface ChatMessage {
   id: string;
@@ -1002,7 +1004,7 @@ async function generateGroupTurn(
   }
 
   const emotion = parseEmotion(responseText);
-  const cleanedContent = stripEmotionTag(responseText);
+  const cleanedContent = applyAiOutputRegex(stripEmotionTag(responseText), character.avatar);
 
   set((state) => ({
     messages: state.messages.map((msg) =>
@@ -1187,6 +1189,26 @@ function imagesFromLastUserMessage(
     return resolveImagesForSend(m.images);
   }
   return undefined;
+}
+
+/** Phase 8.2: apply permanent (non-display-only) regex scripts to AI output text. */
+function applyAiOutputRegex(text: string, characterAvatar?: string): string {
+  const scripts = getActiveScripts(
+    useRegexScriptStore.getState().scripts,
+    characterAvatar,
+    'ai_output'
+  ).filter((s) => !s.displayOnly);
+  return scripts.length > 0 ? applyRegexScripts(text, scripts) : text;
+}
+
+/** Phase 8.2: apply permanent (non-display-only) regex scripts to user input text. */
+function applyUserInputRegex(text: string, characterAvatar?: string): string {
+  const scripts = getActiveScripts(
+    useRegexScriptStore.getState().scripts,
+    characterAvatar,
+    'user_input'
+  ).filter((s) => !s.displayOnly);
+  return scripts.length > 0 ? applyRegexScripts(text, scripts) : text;
 }
 
 /** Reset streaming flags in a `finally` block only when the local controller
@@ -1752,7 +1774,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
       }
 
       const emotion = parseEmotion(responseText);
-      const cleanedContent = stripEmotionTag(responseText);
+      const cleanedContent = applyAiOutputRegex(stripEmotionTag(responseText), character.avatar);
 
       set((state) => ({
         messages: state.messages.map((m) => {
@@ -1835,7 +1857,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
 
       // Strip any new emotion tags from the continuation
       const fullText = existingContent + newTokens;
-      const cleanedContent = stripEmotionTag(fullText);
+      const cleanedContent = applyAiOutputRegex(stripEmotionTag(fullText), character.avatar);
 
       set((state) => ({
         messages: state.messages.map((m) => {
@@ -1928,11 +1950,14 @@ export const useChatStore = create<ChatState>((set, get) => ({
       attachedImages = undefined;
     }
 
+    // Phase 8.2: apply permanent regex scripts to user input
+    const processedContent = applyUserInputRegex(content, character.avatar);
+
     addMessage({
       name: 'You',
       isUser: true,
       isSystem: false,
-      content,
+      content: processedContent,
       timestamp: Date.now(),
       images: attachedImages,
     });
@@ -1986,7 +2011,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
         }
 
         const emotion = parseEmotion(responseText);
-        const cleanedContent = stripEmotionTag(responseText);
+        const cleanedContent = applyAiOutputRegex(stripEmotionTag(responseText), character.avatar);
 
         set((state) => ({
           messages: state.messages.map((msg) =>
@@ -2029,11 +2054,14 @@ export const useChatStore = create<ChatState>((set, get) => ({
       attachedImages = undefined;
     }
 
+    // Phase 8.2: apply permanent regex scripts to user input (group)
+    const processedGroupContent = applyUserInputRegex(content);
+
     addMessage({
       name: 'You',
       isUser: true,
       isSystem: false,
-      content,
+      content: processedGroupContent,
       timestamp: Date.now(),
       images: attachedImages,
     });

--- a/src/stores/regexScriptStore.ts
+++ b/src/stores/regexScriptStore.ts
@@ -1,0 +1,194 @@
+import { create } from 'zustand';
+
+/** Phase 8.2: Regex Scripts — find/replace patterns applied to AI output,
+ *  user input, or both. Scripts can be display-only (render transform only)
+ *  or permanent (modifies stored text). Per-character scoping supported. */
+export interface RegexScript {
+  id: string;
+  name: string;
+  /** Raw regex pattern string (not wrapped in slashes). */
+  pattern: string;
+  /** Replacement text. Supports $1, $2 capture group references. */
+  replacement: string;
+  /** Standard JS regex flags (g, i, m, s). */
+  flags: string;
+  enabled: boolean;
+  scope: RegexScope;
+  /** true = transform rendered text only, original stored unchanged. */
+  displayOnly: boolean;
+  /** Character avatars this script applies to. Empty = global (all). */
+  characterScope: string[];
+  /** Execution order — lower values run first. */
+  order: number;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export type RegexScope = 'ai_output' | 'user_input' | 'both';
+
+const STORAGE_KEY = 'sillytavern_regex_scripts';
+
+function generateId(): string {
+  return `rs_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function loadFromStorage(): RegexScript[] {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (!stored) return [];
+    const parsed = JSON.parse(stored);
+    if (!Array.isArray(parsed)) return [];
+    return parsed;
+  } catch {
+    return [];
+  }
+}
+
+function saveToStorage(scripts: RegexScript[]) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(scripts));
+  } catch {
+    console.error('[RegexScripts] Failed to save to localStorage');
+  }
+}
+
+interface RegexScriptState {
+  scripts: RegexScript[];
+
+  createScript: (partial?: Partial<RegexScript>) => string;
+  updateScript: (id: string, partial: Partial<RegexScript>) => void;
+  deleteScript: (id: string) => void;
+  duplicateScript: (id: string) => string | null;
+  toggleScript: (id: string) => void;
+
+  importScripts: (json: string) => number;
+  exportScripts: () => string;
+}
+
+export const useRegexScriptStore = create<RegexScriptState>((set, get) => ({
+  scripts: loadFromStorage(),
+
+  createScript: (partial) => {
+    const now = Date.now();
+    const { scripts } = get();
+    const maxOrder = scripts.reduce((max, s) => Math.max(max, s.order), -1);
+    const script: RegexScript = {
+      id: generateId(),
+      name: partial?.name || 'New Script',
+      pattern: partial?.pattern || '',
+      replacement: partial?.replacement ?? '',
+      flags: partial?.flags || 'g',
+      enabled: partial?.enabled ?? true,
+      scope: partial?.scope || 'ai_output',
+      displayOnly: partial?.displayOnly ?? false,
+      characterScope: partial?.characterScope || [],
+      order: partial?.order ?? maxOrder + 1,
+      createdAt: now,
+      updatedAt: now,
+    };
+    const updated = [...scripts, script];
+    saveToStorage(updated);
+    set({ scripts: updated });
+    return script.id;
+  },
+
+  updateScript: (id, partial) => {
+    const { scripts } = get();
+    const updated = scripts.map((s) =>
+      s.id === id ? { ...s, ...partial, updatedAt: Date.now() } : s
+    );
+    saveToStorage(updated);
+    set({ scripts: updated });
+  },
+
+  deleteScript: (id) => {
+    const { scripts } = get();
+    const updated = scripts.filter((s) => s.id !== id);
+    saveToStorage(updated);
+    set({ scripts: updated });
+  },
+
+  duplicateScript: (id) => {
+    const { scripts } = get();
+    const source = scripts.find((s) => s.id === id);
+    if (!source) return null;
+    const now = Date.now();
+    const maxOrder = scripts.reduce((max, s) => Math.max(max, s.order), -1);
+    const copy: RegexScript = {
+      ...source,
+      id: generateId(),
+      name: `${source.name} (copy)`,
+      order: maxOrder + 1,
+      createdAt: now,
+      updatedAt: now,
+    };
+    const updated = [...scripts, copy];
+    saveToStorage(updated);
+    set({ scripts: updated });
+    return copy.id;
+  },
+
+  toggleScript: (id) => {
+    const { scripts } = get();
+    const updated = scripts.map((s) =>
+      s.id === id ? { ...s, enabled: !s.enabled, updatedAt: Date.now() } : s
+    );
+    saveToStorage(updated);
+    set({ scripts: updated });
+  },
+
+  importScripts: (json: string) => {
+    try {
+      const parsed = JSON.parse(json);
+      const arr: unknown[] = Array.isArray(parsed)
+        ? parsed
+        : Array.isArray(parsed?.scripts)
+          ? parsed.scripts
+          : [];
+      if (arr.length === 0) return 0;
+
+      const { scripts } = get();
+      let maxOrder = scripts.reduce((max, s) => Math.max(max, s.order), -1);
+      const now = Date.now();
+      const imported: RegexScript[] = [];
+
+      for (const raw of arr) {
+        if (!raw || typeof raw !== 'object') continue;
+        const r = raw as Record<string, unknown>;
+        if (typeof r.pattern !== 'string' || !r.pattern.trim()) continue;
+
+        imported.push({
+          id: generateId(),
+          name: typeof r.name === 'string' ? r.name : 'Imported Script',
+          pattern: r.pattern as string,
+          replacement: typeof r.replacement === 'string' ? r.replacement : '',
+          flags: typeof r.flags === 'string' ? r.flags : 'g',
+          enabled: typeof r.enabled === 'boolean' ? r.enabled : true,
+          scope: (['ai_output', 'user_input', 'both'].includes(r.scope as string)
+            ? r.scope as RegexScope
+            : 'ai_output'),
+          displayOnly: typeof r.displayOnly === 'boolean' ? r.displayOnly : false,
+          characterScope: Array.isArray(r.characterScope)
+            ? (r.characterScope as unknown[]).filter((x): x is string => typeof x === 'string')
+            : [],
+          order: ++maxOrder,
+          createdAt: now,
+          updatedAt: now,
+        });
+      }
+
+      if (imported.length === 0) return 0;
+      const updated = [...scripts, ...imported];
+      saveToStorage(updated);
+      set({ scripts: updated });
+      return imported.length;
+    } catch {
+      return 0;
+    }
+  },
+
+  exportScripts: () => {
+    const { scripts } = get();
+    return JSON.stringify({ scripts }, null, 2);
+  },
+}));

--- a/src/utils/regexScripts.ts
+++ b/src/utils/regexScripts.ts
@@ -1,0 +1,50 @@
+import type { RegexScript } from '../stores/regexScriptStore';
+
+/** Compile a RegexScript's pattern + flags into a RegExp.
+ *  Returns null if the pattern is invalid. */
+function compileRegex(script: RegexScript): RegExp | null {
+  try {
+    return new RegExp(script.pattern, script.flags);
+  } catch {
+    return null;
+  }
+}
+
+/** Apply an ordered list of regex scripts to text sequentially.
+ *  Invalid patterns are silently skipped. */
+export function applyRegexScripts(text: string, scripts: RegexScript[]): string {
+  let result = text;
+  for (const script of scripts) {
+    const re = compileRegex(script);
+    if (!re) continue;
+    try {
+      result = result.replace(re, script.replacement);
+    } catch {
+      // skip on replacement error (e.g. bad group reference)
+    }
+  }
+  return result;
+}
+
+/** Get enabled scripts matching the given scope and character, sorted by order.
+ *  @param characterAvatar — current character's avatar; undefined for system/user-only contexts
+ *  @param scope — which pipeline stage is requesting scripts */
+export function getActiveScripts(
+  scripts: RegexScript[],
+  characterAvatar: string | undefined,
+  scope: 'ai_output' | 'user_input'
+): RegexScript[] {
+  return scripts
+    .filter((s) => {
+      if (!s.enabled) return false;
+      if (!s.pattern.trim()) return false;
+      // Scope match: 'both' matches either side
+      if (s.scope !== 'both' && s.scope !== scope) return false;
+      // Character scope: empty = global
+      if (s.characterScope.length > 0 && characterAvatar) {
+        if (!s.characterScope.includes(characterAvatar)) return false;
+      }
+      return true;
+    })
+    .sort((a, b) => a.order - b.order);
+}


### PR DESCRIPTION
Regex scripts allow find/replace patterns on AI output, user input, or both. Scripts can be permanent (modifies stored text) or display- only (visual transform, original preserved). Supports per-character scoping, configurable execution order, regex flags, capture groups, and JSON import/export. Settings UI at /settings/regex.