### PR TITLE
Fix TypeScript build errors for production deployment

### DIFF
--- a/src/components/chat/MarkdownContent.tsx
+++ b/src/components/chat/MarkdownContent.tsx
@@ -132,7 +132,7 @@ DOMPurify.addHook('afterSanitizeAttributes', (node) => {
   }
 });
 
-const SANITIZE_CONFIG: DOMPurify.Config = {
+const SANITIZE_CONFIG = {
   ALLOWED_TAGS: [
     'p', 'br', 'strong', 'b', 'em', 'i', 'del', 's',
     'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
@@ -171,7 +171,7 @@ function renderMarkdown(text: string, streaming?: boolean): { html: string; isBl
   const raw = isBlock
     ? (marked.parse(prepared) as string)
     : (marked.parseInline(prepared) as string);
-  return { html: DOMPurify.sanitize(raw, SANITIZE_CONFIG), isBlock };
+  return { html: DOMPurify.sanitize(raw, SANITIZE_CONFIG) as string, isBlock };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -20,7 +20,6 @@ import { dataUrlToPart, supportsVision } from '../utils/images';
 import { processMacros, type MacroContext } from '../utils/macros';
 import {
   estimateConversationTokens,
-  estimateMessageTokens,
   profileForProvider,
   trimHistoryToBudget,
 } from '../utils/tokenizer';


### PR DESCRIPTION
## Summary
- Remove `DOMPurify.Config` type annotation (namespace not exported in newer `dompurify` versions)
- Cast `DOMPurify.sanitize()` return to `string` (returns `TrustedHTML` in newer types)
- Remove unused `estimateMessageTokens` import from `chatStore.ts`

## Test plan
- [ ] `npm run build` completes without errors
- [ ] Verify the deployed site loads and markdown rendering works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)