### PR TITLE
Add Docker deployment for one-command setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+dist
+.git
+.github
+.claude
+.vscode
+*.md
+.env*
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+# ---------- Stage 1: Build ----------
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+# ---------- Stage 2: Serve ----------
+FROM nginx:alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+services:
+  frontend:
+    build: .
+    ports:
+      - "80:80"
+    depends_on:
+      sillytavern:
+        condition: service_started
+    restart: unless-stopped
+
+  sillytavern:
+    image: ghcr.io/sillytavern/sillytavern:latest
+    environment:
+      - ST_PORT=8000
+    volumes:
+      - st-config:/home/node/app/config
+      - st-data:/home/node/app/data
+    restart: unless-stopped
+
+volumes:
+  st-config:
+  st-data:

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,49 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Serve static frontend — fall back to index.html for SPA routing
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Proxy all API paths to the SillyTavern backend
+    location /api/ {
+        proxy_pass http://sillytavern:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # SSE / streaming support for message generation
+        proxy_set_header Connection '';
+        proxy_buffering off;
+        proxy_cache off;
+        chunked_transfer_encoding on;
+    }
+
+    location /csrf-token {
+        proxy_pass http://sillytavern:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    location /thumbnail {
+        proxy_pass http://sillytavern:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    location /characters {
+        proxy_pass http://sillytavern:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    # Allow uploads up to 20 MB (avatars, sprites, attachments)
+    client_max_body_size 20M;
+}


### PR DESCRIPTION
## Summary
- Add `Dockerfile` with multi-stage build (Node build → Nginx serve)
- Add `docker-compose.yml` orchestrating the frontend + SillyTavern backend
- Add `nginx.conf` with reverse proxy config (API proxying, SSE streaming support, SPA routing)
- Add `.dockerignore` to keep images small

## Usage
```bash
git clone https://github.com/sammygallo/sillytavern-mobile.git
cd sillytavern-mobile
docker compose up -d
# → Site live at http://localhost
```

SillyTavern data persists across restarts via named Docker volumes (`st-config`, `st-data`).

## Test plan
- [ ] `docker compose up -d` starts both services
- [ ] Frontend loads at `http://localhost`
- [ ] API calls proxy correctly to the SillyTavern backend
- [ ] Streaming responses (SSE) work for message generation
- [ ] Character avatar uploads work (up to 20 MB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)