### PR TITLE
Fix logout data leakage and unguarded JSON.parse

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -38,7 +38,11 @@ export async function apiRequest<T>(
   const text = await response.text();
   if (!text) return {} as T;
 
-  return JSON.parse(text);
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new Error(`Invalid JSON response from ${endpoint}`);
+  }
 }
 
 export interface UserInfo {

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -1,5 +1,8 @@
 import { create } from 'zustand';
 import { api, type UserInfo } from '../api/client';
+import { useCharacterStore } from './characterStore';
+import { useChatStore } from './chatStore';
+import { useSettingsStore } from './settingsStore';
 
 interface AuthState {
   isAuthenticated: boolean;
@@ -104,6 +107,36 @@ export const useAuthStore = create<AuthState>((set) => ({
       await api.logout();
     } finally {
       set({ isAuthenticated: false, currentUser: null });
+
+      // Clear all stores to prevent data leakage between users
+      useCharacterStore.setState({
+        characters: [],
+        selectedCharacter: null,
+        isGroupChatMode: false,
+        groupChatCharacters: [],
+      });
+      useChatStore.setState({
+        messages: [],
+        chatFiles: [],
+        groupChats: [],
+        currentChatFile: null,
+        isStreaming: false,
+        isSending: false,
+        error: null,
+        abortController: null,
+        currentSpeakerName: null,
+      });
+      useSettingsStore.setState({
+        secrets: {},
+        activeProvider: 'openai',
+        activeModel: 'gpt-4o',
+        error: null,
+        successMessage: null,
+      });
+
+      // Clear persisted localStorage data
+      localStorage.removeItem('sillytavern_group_chats');
+      localStorage.removeItem('sillytavern_author_notes');
     }
   },
 


### PR DESCRIPTION
## Summary
- **Logout cleanup**: Clear all Zustand stores (character, chat, settings) and remove `localStorage` entries (`sillytavern_group_chats`, `sillytavern_author_notes`) on logout to prevent data leakage between users on shared devices
- **JSON.parse guard**: Wrap `JSON.parse` in `apiRequest()` with try-catch so malformed backend responses throw a descriptive error instead of crashing the app

## Test plan
- [ ] Log in, open a chat, then log out — verify chat messages, character selection, and settings are cleared
- [ ] Log in as a different user after logout — verify no stale data from previous session
- [ ] Verify `localStorage` no longer contains `sillytavern_group_chats` or `sillytavern_author_notes` after logout
- [ ] Simulate a malformed JSON backend response — verify a descriptive error is thrown instead of an unhandled exception

🤖 Generated with [Claude Code](https://claude.com/claude-code)