### PR TITLE
Add frontend role model and route guards (Multiuser Phase 2)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { LoginPage } from './components/auth/LoginPage';
 import { RegisterPage } from './components/auth/RegisterPage';
+import { RequireRole } from './components/auth/RequireRole';
 import { MainLayout } from './components/layout/MainLayout';
 import { ChatView } from './components/chat/ChatView';
 import { SettingsPage, GenerationSettingsPage } from './components/settings';
@@ -13,10 +14,10 @@ function App() {
       <Routes>
         <Route path="/login" element={<LoginPage />} />
         <Route path="/register" element={<RegisterPage />} />
-        <Route path="/settings" element={<SettingsPage />} />
-        <Route path="/settings/generation" element={<GenerationSettingsPage />} />
-        <Route path="/settings/worldinfo" element={<WorldInfoPage />} />
-        <Route path="/settings/regex" element={<RegexScriptPage />} />
+        <Route path="/settings" element={<RequireRole minRole="admin"><SettingsPage /></RequireRole>} />
+        <Route path="/settings/generation" element={<RequireRole minRole="admin"><GenerationSettingsPage /></RequireRole>} />
+        <Route path="/settings/worldinfo" element={<RequireRole minRole="admin"><WorldInfoPage /></RequireRole>} />
+        <Route path="/settings/regex" element={<RequireRole minRole="admin"><RegexScriptPage /></RequireRole>} />
         <Route path="/" element={<MainLayout />}>
           <Route index element={<ChatView />} />
           <Route path="chat/:characterId" element={<ChatView />} />

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -172,9 +172,14 @@ export const api = {
     await apiRequest('/api/users/logout', { method: 'POST' });
   },
 
-  async getCurrentUser(): Promise<{ handle: string; name: string } | null> {
+  async getCurrentUser(): Promise<{ handle: string; name: string; role: import('../types').UserRole } | null> {
     try {
-      return await apiRequest('/api/users/me');
+      const user = await apiRequest<{ handle: string; name: string; admin: boolean; role?: string }>('/api/users/me');
+      // Derive role: backend may return role directly (Phase 1 backend),
+      // or fall back to admin boolean for older servers.
+      const role = (user.role as import('../types').UserRole) ||
+        (user.admin ? 'admin' : 'end_user');
+      return { handle: user.handle, name: user.name, role };
     } catch {
       return null;
     }

--- a/src/components/auth/RequireRole.tsx
+++ b/src/components/auth/RequireRole.tsx
@@ -1,0 +1,29 @@
+import { Navigate } from 'react-router-dom';
+import { useAuthStore } from '../../stores/authStore';
+import { hasMinRole } from '../../utils/permissions';
+import type { UserRole } from '../../types';
+
+interface RequireRoleProps {
+  minRole: UserRole;
+  children: React.ReactNode;
+  /** Where to redirect when the user lacks permission. Defaults to "/" */
+  redirectTo?: string;
+}
+
+/**
+ * Route guard that renders children only when the current user's role
+ * meets or exceeds `minRole`. Otherwise redirects.
+ */
+export function RequireRole({ minRole, children, redirectTo = '/' }: RequireRoleProps) {
+  const { isAuthenticated, currentUser } = useAuthStore();
+
+  if (!isAuthenticated || !currentUser) {
+    return <Navigate to="/login" replace />;
+  }
+
+  if (!hasMinRole(currentUser.role, minRole)) {
+    return <Navigate to={redirectTo} replace />;
+  }
+
+  return <>{children}</>;
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -3,6 +3,7 @@ import { Menu, Settings, LogOut, Pencil, History } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useAuthStore } from '../../stores/authStore';
 import { useCharacterStore } from '../../stores/characterStore';
+import { can } from '../../utils/permissions';
 import { Avatar, Button } from '../ui';
 import { CharacterEdit } from '../character/CharacterEdit';
 import { ChatHistoryPanel } from '../chat/ChatHistoryPanel';
@@ -17,6 +18,9 @@ export function Header({ onMenuClick }: HeaderProps) {
   const navigate = useNavigate();
   const { currentUser, logout } = useAuthStore();
   const { selectedCharacter, isGroupChatMode, fetchCharacters } = useCharacterStore();
+  const userRole = currentUser?.role;
+  const canEdit = can(userRole, 'character:edit');
+  const canViewSettings = can(userRole, 'settings:view');
   const [showEditModal, setShowEditModal] = useState(false);
   const [showHistoryPanel, setShowHistoryPanel] = useState(false);
   const [convertToPersonaData, setConvertToPersonaData] = useState<
@@ -61,15 +65,17 @@ export function Header({ onMenuClick }: HeaderProps) {
                 {selectedCharacter.name}
               </h1>
             </div>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="p-2"
-              aria-label="Edit character"
-              onClick={() => setShowEditModal(true)}
-            >
-              <Pencil size={18} />
-            </Button>
+            {canEdit && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="p-2"
+                aria-label="Edit character"
+                onClick={() => setShowEditModal(true)}
+              >
+                <Pencil size={18} />
+              </Button>
+            )}
           </>
         ) : (
           <h1 className="text-sm font-semibold text-[var(--color-text-primary)]">
@@ -92,15 +98,17 @@ export function Header({ onMenuClick }: HeaderProps) {
           </Button>
         )}
         <PersonaSelector />
-        <Button
-          variant="ghost"
-          size="sm"
-          className="p-2"
-          aria-label="Settings"
-          onClick={() => navigate('/settings')}
-        >
-          <Settings size={20} />
-        </Button>
+        {canViewSettings && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="p-2"
+            aria-label="Settings"
+            onClick={() => navigate('/settings')}
+          >
+            <Settings size={20} />
+          </Button>
+        )}
         <Button
           variant="ghost"
           size="sm"

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -16,6 +16,8 @@ import {
 } from 'lucide-react';
 import { useCharacterStore } from '../../stores/characterStore';
 import { useChatStore, type GroupChatInfo } from '../../stores/chatStore';
+import { useAuthStore } from '../../stores/authStore';
+import { can } from '../../utils/permissions';
 import { Avatar, Button, Input } from '../ui';
 import { CharacterCreation } from '../character/CharacterCreation';
 import { CharacterImport } from '../character/CharacterImport';
@@ -28,6 +30,9 @@ interface SidebarProps {
 }
 
 export function Sidebar({ isOpen, onClose }: SidebarProps) {
+  const { currentUser } = useAuthStore();
+  const userRole = currentUser?.role;
+  const canCreateCharacters = can(userRole, 'character:create');
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [showImportModal, setShowImportModal] = useState(false);
   const [showCharacterList, setShowCharacterList] = useState(false);
@@ -583,7 +588,7 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
                   <Users size={18} className="mr-2" />
                   Start Group Chat ({groupChatCharacters.length}/2+)
                 </Button>
-              ) : (
+              ) : canCreateCharacters ? (
                 <div className="flex gap-2">
                   <Button
                     variant="secondary"
@@ -602,7 +607,7 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
                     New
                   </Button>
                 </div>
-              )}
+              ) : null}
             </div>
           </>
         )}

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -3,11 +3,12 @@ import { api, type UserInfo } from '../api/client';
 import { useCharacterStore } from './characterStore';
 import { useChatStore } from './chatStore';
 import { useSettingsStore } from './settingsStore';
+import type { UserRole } from '../types';
 
 interface AuthState {
   isAuthenticated: boolean;
   isLoading: boolean;
-  currentUser: { handle: string; name: string } | null;
+  currentUser: { handle: string; name: string; role: UserRole } | null;
   availableUsers: UserInfo[];
   error: string | null;
   canSelfRegister: boolean;
@@ -35,7 +36,11 @@ export const useAuthStore = create<AuthState>((set) => ({
     try {
       const user = await api.getCurrentUser();
       if (user) {
-        set({ isAuthenticated: true, currentUser: user, isLoading: false });
+        set({
+          isAuthenticated: true,
+          currentUser: { handle: user.handle, name: user.name, role: user.role },
+          isLoading: false,
+        });
       } else {
         set({ isAuthenticated: false, currentUser: null, isLoading: false });
       }
@@ -70,7 +75,7 @@ export const useAuthStore = create<AuthState>((set) => ({
       const loginResult = await api.login(result.handle, password);
       set({
         isAuthenticated: true,
-        currentUser: { handle: loginResult.handle, name },
+        currentUser: { handle: loginResult.handle, name, role: 'end_user' },
         isLoading: false,
       });
       return true;
@@ -89,7 +94,7 @@ export const useAuthStore = create<AuthState>((set) => ({
       const result = await api.login(handle, password);
       set({
         isAuthenticated: true,
-        currentUser: { handle: result.handle, name: result.handle },
+        currentUser: { handle: result.handle, name: result.handle, role: 'end_user' },
         isLoading: false,
       });
       return true;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,8 +1,11 @@
 // User types
+export type UserRole = 'owner' | 'admin' | 'contributor' | 'end_user';
+
 export interface User {
   handle: string;
   name: string;
   admin: boolean;
+  role: UserRole;
   avatar?: string;
 }
 

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -1,0 +1,47 @@
+import type { UserRole } from '../types';
+
+/**
+ * Role hierarchy (higher index = more privilege):
+ *   end_user < contributor < admin < owner
+ */
+const ROLE_LEVEL: Record<UserRole, number> = {
+  end_user: 0,
+  contributor: 1,
+  admin: 2,
+  owner: 3,
+};
+
+/** Actions that can be checked with `can()`. */
+export type Action =
+  | 'chat'                  // send/receive messages
+  | 'character:view'        // browse character list
+  | 'character:create'      // create / import characters
+  | 'character:edit'        // edit existing characters
+  | 'character:delete'      // delete characters
+  | 'settings:view'         // access settings page
+  | 'settings:api_keys'     // manage API keys / secrets
+  | 'admin:panel';          // access admin panel / user management
+
+/** Minimum role required for each action. */
+const ACTION_MIN_ROLE: Record<Action, UserRole> = {
+  'chat':              'end_user',
+  'character:view':    'end_user',
+  'character:create':  'contributor',
+  'character:edit':    'contributor',
+  'character:delete':  'contributor',
+  'settings:view':     'admin',
+  'settings:api_keys': 'admin',
+  'admin:panel':       'admin',
+};
+
+/** Check whether `role` is allowed to perform `action`. */
+export function can(role: UserRole | undefined, action: Action): boolean {
+  if (!role) return false;
+  return ROLE_LEVEL[role] >= ROLE_LEVEL[ACTION_MIN_ROLE[action]];
+}
+
+/** Check if role meets a minimum role threshold. */
+export function hasMinRole(role: UserRole | undefined, minRole: UserRole): boolean {
+  if (!role) return false;
+  return ROLE_LEVEL[role] >= ROLE_LEVEL[minRole];
+}


### PR DESCRIPTION
## Summary
- Adds `UserRole` type (`owner | admin | contributor | end_user`) and role-aware permission system (`can()` helper + `hasMinRole()`)
- `RequireRole` route guard component wraps `/settings/*` routes, redirecting unauthorized users
- Hides character create/edit/import buttons for `end_user`, hides settings gear for roles below `admin`
- `authStore` and API client now fetch and store the user's role from `/api/users/me`, with graceful fallback for pre-Phase-1 backends

## Test plan
- [ ] Log in as `owner`/`admin` — verify settings gear, character edit pencil, and import/new buttons are all visible
- [ ] Log in as `contributor` — verify settings gear is hidden, character create/edit/import buttons are visible
- [ ] Log in as `end_user` — verify settings gear, edit pencil, and import/new buttons are all hidden
- [ ] Navigate directly to `/settings` as `end_user` — verify redirect to `/`
- [ ] Verify TypeScript compiles cleanly (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)