### PR TITLE
Fix Docker: ST whitelist blocks seed script, configurable port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   frontend:
     build: .
     ports:
-      - "80:80"
+      - "${PORT:-8080}:80"
     environment:
       # Set these to auto-create an owner account on first boot:
       - OWNER_HANDLE=${OWNER_HANDLE:-}
@@ -21,6 +21,7 @@ services:
     volumes:
       - st-config:/home/node/app/config
       - st-data:/home/node/app/data
+      - ./docker/st-config.yaml:/home/node/app/config/config.yaml:ro
     restart: unless-stopped
 
 volumes:

--- a/docker/st-config.yaml
+++ b/docker/st-config.yaml
@@ -1,0 +1,5 @@
+# SillyTavern base config for Docker deployment
+# Whitelist disabled so the frontend container can reach the API on first boot
+whitelistMode: false
+whitelist:
+  - 127.0.0.1


### PR DESCRIPTION
## Summary
- Mounts `docker/st-config.yaml` into the SillyTavern container to disable whitelist mode, fixing the `Blocked connection from 172.19.0.3` error that prevented the owner seed script from calling the ST API
- Host port is now configurable via `PORT` env var (defaults to `8080` to avoid conflicts with anything already running on 80)

## Usage
```bash
# Default (port 8080)
docker compose up --build

# Custom port
PORT=80 docker compose up --build
```

## Test plan
- [ ] `docker compose up` — seed script connects to ST API without being blocked
- [ ] Owner account created successfully on first boot with `OWNER_HANDLE`/`OWNER_PASSWORD` set
- [ ] `PORT=80 docker compose up` works when port 80 is free

🤖 Generated with [Claude Code](https://claude.com/claude-code)