### PR TITLE
Multiuser system Phase 1 & 2 + full feature build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,4 @@ RUN npm run build
 FROM nginx:alpine
 COPY --from=build /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
-COPY docker/seed-owner.sh /docker-entrypoint.d/50-seed-owner.sh
-RUN chmod +x /docker-entrypoint.d/50-seed-owner.sh
 EXPOSE 80

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,12 +2,7 @@ services:
   frontend:
     build: .
     ports:
-      - "${PORT:-8080}:80"
-    environment:
-      # Set these to auto-create an owner account on first boot:
-      - OWNER_HANDLE=${OWNER_HANDLE:-}
-      - OWNER_PASSWORD=${OWNER_PASSWORD:-}
-      - OWNER_NAME=${OWNER_NAME:-}
+      - "${PORT:-80}:80"
     depends_on:
       sillytavern:
         condition: service_started
@@ -21,8 +16,25 @@ services:
     volumes:
       - st-config:/home/node/app/config
       - st-data:/home/node/app/data
-      - ./docker/st-config.yaml:/home/node/app/config/config.yaml:ro
     restart: unless-stopped
+
+  seed-owner:
+    image: alpine:latest
+    # Share ST's network namespace so seed calls localhost — always whitelisted
+    network_mode: "service:sillytavern"
+    volumes:
+      - ./docker/seed-owner.sh:/seed-owner.sh:ro
+      - st-config:/config
+    environment:
+      - OWNER_HANDLE=${OWNER_HANDLE:-}
+      - OWNER_PASSWORD=${OWNER_PASSWORD:-}
+      - OWNER_NAME=${OWNER_NAME:-}
+      - ST_PORT=8000
+    entrypoint: ["/bin/sh", "/seed-owner.sh"]
+    depends_on:
+      sillytavern:
+        condition: service_started
+    restart: "no"
 
 volumes:
   st-config:

--- a/docker/seed-owner.sh
+++ b/docker/seed-owner.sh
@@ -1,64 +1,91 @@
 #!/bin/sh
 # Seed an owner account on first boot via the SillyTavern API.
-# Requires OWNER_HANDLE and OWNER_PASSWORD env vars.
-# Runs once then touches a sentinel file to skip on subsequent boots.
+# Runs as a sidecar sharing ST's network namespace — calls localhost:8000
+# so it is always within ST's whitelist.
+#
+# Required env vars: OWNER_HANDLE, OWNER_PASSWORD
+# Optional env var:  OWNER_NAME (defaults to OWNER_HANDLE)
+#
+# Sentinel file in the st-config volume prevents re-seeding on restart.
 
 set -e
 
-SENTINEL="/usr/share/nginx/html/.owner-seeded"
-ST_HOST="${ST_BACKEND:-http://sillytavern:8000}"
+SENTINEL="/config/.owner-seeded"
+ST="http://localhost:${ST_PORT:-8000}"
 
 # Skip if already seeded or env vars not set
-if [ -f "$SENTINEL" ] || [ -z "$OWNER_HANDLE" ] || [ -z "$OWNER_PASSWORD" ]; then
-  exec "$@"
+if [ -f "$SENTINEL" ]; then
+  echo "[seed-owner] Already seeded, skipping"
+  exit 0
 fi
 
-echo "[seed-owner] Waiting for SillyTavern backend..."
-for i in $(seq 1 30); do
-  if wget -qO /dev/null "$ST_HOST/api/ping" 2>/dev/null; then
+if [ -z "$OWNER_HANDLE" ] || [ -z "$OWNER_PASSWORD" ]; then
+  echo "[seed-owner] OWNER_HANDLE/OWNER_PASSWORD not set, skipping"
+  exit 0
+fi
+
+echo "[seed-owner] Waiting for SillyTavern to be ready..."
+for i in $(seq 1 60); do
+  if wget -qO /dev/null "$ST/csrf-token" 2>/dev/null; then
     break
+  fi
+  if [ "$i" -eq 60 ]; then
+    echo "[seed-owner] Timed out waiting for SillyTavern"
+    exit 1
   fi
   sleep 2
 done
 
-# Grab a CSRF token
-CSRF=$(wget -qO- "$ST_HOST/csrf-token" 2>/dev/null | sed 's/.*"token":"\([^"]*\)".*/\1/')
+# Grab CSRF token
+CSRF=$(wget -qO- "$ST/csrf-token" | sed 's/.*"token":"\([^"]*\)".*/\1/')
 if [ -z "$CSRF" ]; then
-  echo "[seed-owner] Warning: could not get CSRF token, skipping seed"
-  exec "$@"
+  echo "[seed-owner] Could not get CSRF token"
+  exit 1
 fi
 
 # Login as default-user (auto-created admin, no password)
-LOGIN=$(wget -qO- --header="Content-Type: application/json" \
+LOGIN=$(wget -qO- \
+  --header="Content-Type: application/json" \
   --header="X-CSRF-Token: $CSRF" \
   --post-data='{"handle":"default-user","password":""}' \
-  "$ST_HOST/api/users/login" 2>/dev/null) || true
+  --save-cookies=/tmp/st-cookies.txt \
+  --keep-session-cookies \
+  "$ST/api/users/login" 2>/dev/null) || true
 
-if echo "$LOGIN" | grep -q '"handle"'; then
-  # Fetch fresh CSRF after login (session cookie is in wget's cookie jar — use curl if available)
-  # For simplicity, reuse the same token; SillyTavern usually accepts it within the same session window.
-
-  OWNER_NAME="${OWNER_NAME:-$OWNER_HANDLE}"
-
-  # Create the owner account
-  CREATE=$(wget -qO- --header="Content-Type: application/json" \
-    --header="X-CSRF-Token: $CSRF" \
-    --header="Cookie: $(wget -qO /dev/null --save-cookies /dev/stderr "$ST_HOST/csrf-token" 2>&1 | grep -o 'session=[^;]*' || true)" \
-    --post-data="{\"handle\":\"$OWNER_HANDLE\",\"name\":\"$OWNER_NAME\",\"password\":\"$OWNER_PASSWORD\",\"admin\":true,\"role\":\"owner\"}" \
-    "$ST_HOST/api/users/create" 2>/dev/null) || true
-
-  if echo "$CREATE" | grep -q '"handle"'; then
-    echo "[seed-owner] Owner account '$OWNER_HANDLE' created successfully"
-    touch "$SENTINEL"
-  else
-    echo "[seed-owner] Warning: could not create owner account: $CREATE"
-  fi
-
-  # Logout default-user
-  wget -qO /dev/null --header="X-CSRF-Token: $CSRF" \
-    --post-data='{}' "$ST_HOST/api/users/logout" 2>/dev/null || true
-else
-  echo "[seed-owner] Warning: could not login as default-user, skipping seed"
+if ! echo "$LOGIN" | grep -q '"handle"'; then
+  echo "[seed-owner] Could not log in as default-user: $LOGIN"
+  exit 1
 fi
 
-exec "$@"
+# Refresh CSRF token after login
+CSRF=$(wget -qO- \
+  --load-cookies=/tmp/st-cookies.txt \
+  "$ST/csrf-token" | sed 's/.*"token":"\([^"]*\)".*/\1/')
+
+OWNER_NAME="${OWNER_NAME:-$OWNER_HANDLE}"
+
+# Create the owner account
+CREATE=$(wget -qO- \
+  --header="Content-Type: application/json" \
+  --header="X-CSRF-Token: $CSRF" \
+  --post-data="{\"handle\":\"$OWNER_HANDLE\",\"name\":\"$OWNER_NAME\",\"password\":\"$OWNER_PASSWORD\",\"admin\":true,\"role\":\"owner\"}" \
+  --load-cookies=/tmp/st-cookies.txt \
+  "$ST/api/users/create" 2>/dev/null) || true
+
+if echo "$CREATE" | grep -q '"handle"'; then
+  echo "[seed-owner] Owner account '$OWNER_HANDLE' created"
+  touch "$SENTINEL"
+else
+  echo "[seed-owner] Failed to create owner account: $CREATE"
+  exit 1
+fi
+
+# Logout default-user
+wget -qO /dev/null \
+  --header="Content-Type: application/json" \
+  --header="X-CSRF-Token: $CSRF" \
+  --post-data='{}' \
+  --load-cookies=/tmp/st-cookies.txt \
+  "$ST/api/users/logout" 2>/dev/null || true
+
+echo "[seed-owner] Done"

--- a/docker/st-config.yaml
+++ b/docker/st-config.yaml
@@ -1,5 +1,0 @@
-# SillyTavern base config for Docker deployment
-# Whitelist disabled so the frontend container can reach the API on first boot
-whitelistMode: false
-whitelist:
-  - 127.0.0.1


### PR DESCRIPTION
## Summary

This branch contains the complete feature build for sillytavern-mobile, including the multiuser role system and Docker deployment.

### Multiuser system (Phases 1 & 2)
- **Role model**: four-tier hierarchy — `owner > admin > contributor > end_user`
- **`/api/users/me`** now returns `role`; client falls back to `admin` boolean for older servers
- **`can(role, action)`** permission helper + `hasMinRole()` in `src/utils/permissions.ts`
- **`<RequireRole>`** route guard — wraps all `/settings/*` routes, redirects on insufficient role
- **UI gating**: character edit/create/import hidden for `end_user`; settings gear hidden below `admin`
- **First registrant gets `owner` role** via the default-user bootstrap flow
- **Docker `seed-owner` sidecar**: dedicated Alpine container sharing ST's network namespace (hits `localhost`, bypasses whitelist) — seeds owner account from `OWNER_HANDLE`/`OWNER_PASSWORD` env vars on first boot

### Full feature build (Phases 1–8)
- **Phase 1**: swipes, action bar, message menu, chat history
- **Phase 2**: character & persona depth features
- **Phase 3**: prompt engineering & generation control
- **Phase 4**: World Info / lorebooks (basic + advanced + character-embedded)
- **Phase 5**: group chat (activation strategies, controls, polish)
- **Phase 6**: attachments, voice input, text-to-speech
- **Phase 7**: markdown rendering, streaming indicators, chat display styles, theming
- **Phase 8**: Author's Note, Regex Scripts
- **Docker deployment**: one-command setup via `docker compose up`

## Usage
```bash
# Basic
docker compose up --build

# With owner account pre-seeded
OWNER_HANDLE=sammy OWNER_PASSWORD=secret docker compose up --build
```

## Test plan
- [ ] `end_user` cannot see settings gear, character edit, or create/import buttons
- [ ] `contributor` can create/edit characters but cannot access settings
- [ ] `admin`/`owner` has full access
- [ ] Direct navigation to `/settings` as `end_user` redirects to `/`
- [ ] Docker: seed creates owner account; restart skips seed (sentinel file)
- [ ] Docker: missing `OWNER_HANDLE`/`OWNER_PASSWORD` → silent skip, UI registration still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)