### PR TITLE
Fix Docker: ST whitelist + security restart loop

### DIFF
--- a/docker/st-init.sh
+++ b/docker/st-init.sh
@@ -14,6 +14,9 @@ if [ ! -f "$CONFIG" ]; then
 whitelistMode: false
 enableUserAccounts: true
 listen: true
+# Allows ST to start without whitelist/basic-auth when user accounts
+# are the sole authentication mechanism (avoids exit-code-1 security check).
+securityOverride: true
 EOF
 fi
 


### PR DESCRIPTION
## Problems fixed

**1. ST whitelist blocks all proxied traffic**
ST's IP whitelist checks the direct connection IP (`172.19.0.3` — the nginx container) and ignores `X-Forwarded-For`, so every user request returns 403 before they can even reach the login page.

**2. ST restart loop (exit code 1)**
ST 1.13.5 refuses to start when whitelist is disabled and an admin user (`default-user`) has no password — even with `enableUserAccounts: true`. It exits 1 and Docker restarts it in a loop.

## Fix

`docker/st-init.sh` runs as ST's entrypoint on first boot and writes a minimal `config.yaml` (only if one doesn't exist), then hands off to `node server.js` so ST can freely modify the file:

```yaml
whitelistMode: false       # allow nginx proxy traffic through
enableUserAccounts: true   # use account auth instead of whitelist
listen: true               # bind to all interfaces
securityOverride: true     # suppress exit-1 security check
```

## Test plan
- [ ] Fresh deploy (`docker compose down -v && docker compose up --build`) — ST starts cleanly, no restart loop
- [ ] `/csrf-token` returns 200, login page loads
- [ ] Login and registration work end-to-end
- [ ] Subsequent restarts — init script skips (config.yaml exists), ST starts normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)