### PR TITLE
Fix Create Account button missing on empty user list

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -157,8 +157,10 @@ export const api = {
     const response = await apiRequest<UserInfo[] | undefined>('/api/users/list', {
       method: 'POST',
     });
-    // Returns array directly, or empty array if 204 (discreet login)
-    return response || [];
+    // Returns array directly, or empty array if 204 (discreet login).
+    // Must use Array.isArray — a 204 causes apiRequest to return {} which
+    // is truthy, so `response || []` would incorrectly return {} instead of [].
+    return Array.isArray(response) ? response : [];
   },
 
   async login(handle: string, password?: string): Promise<{ handle: string }> {

--- a/src/components/auth/LoginPage.tsx
+++ b/src/components/auth/LoginPage.tsx
@@ -85,14 +85,14 @@ export function LoginPage() {
               <p className="text-[var(--color-text-secondary)] mb-4">
                 No users found. Create your first account to get started.
               </p>
-              {canSelfRegister && (
-                <Link to="/register">
-                  <Button size="lg">
-                    <UserPlus size={20} className="mr-2" />
-                    Create Account
-                  </Button>
-                </Link>
-              )}
+              {/* Always show register when no users are visible — without it
+                  there's no way to access the app at all. */}
+              <Link to="/register">
+                <Button size="lg">
+                  <UserPlus size={20} className="mr-2" />
+                  Create Account
+                </Button>
+              </Link>
             </div>
           ) : (
             <>


### PR DESCRIPTION
## Problem

On a fresh deploy with no registered users, the login page showed "No users found" but no Create Account button — leaving no way to access the app.

**Root cause:** `getUsers()` used `response || []` to handle ST's 204 response (discreet login mode). But `apiRequest` returns `{}` for empty/204 responses, which is truthy, so the `|| []` fallback never fired. `checkCanRegister` received a non-array, saw `users.length === undefined`, and returned `canRegister: false` — hiding the button.

## Fix
- `getUsers()`: use `Array.isArray(response)` instead of `response || []`
- `LoginPage`: unconditionally show Create Account in the empty state — if no users are visible there's literally no other way to access the app

## Test plan
- [ ] Fresh deploy: "No users found" state shows Create Account button
- [ ] Register flow creates first user with `owner` role
- [ ] Login works after registration

🤖 Generated with [Claude Code](https://claude.com/claude-code)