### PR TITLE
Remove canSelfRegister gate from RegisterPage

### DIFF
--- a/src/components/auth/RegisterPage.tsx
+++ b/src/components/auth/RegisterPage.tsx
@@ -10,9 +10,7 @@ export function RegisterPage() {
     isLoading,
     error,
     isAuthenticated,
-    canSelfRegister,
     register,
-    checkRegistration,
     clearError,
   } = useAuthStore();
 
@@ -27,10 +25,6 @@ export function RegisterPage() {
       navigate('/');
     }
   }, [isAuthenticated, navigate]);
-
-  useEffect(() => {
-    checkRegistration();
-  }, [checkRegistration]);
 
   const validateForm = (): boolean => {
     setLocalError(null);
@@ -95,23 +89,9 @@ export function RegisterPage() {
 
         {/* Registration Form */}
         <div className="bg-[var(--color-bg-secondary)] rounded-xl p-6 shadow-xl">
-          {!canSelfRegister ? (
-            <div className="text-center py-8">
-              <Lock size={48} className="mx-auto text-[var(--color-text-secondary)] mb-4" />
-              <h3 className="text-lg font-medium text-[var(--color-text-primary)] mb-2">
-                Registration Restricted
-              </h3>
-              <p className="text-[var(--color-text-secondary)] mb-4">
-                New user registration requires admin approval. Please contact an administrator.
-              </p>
-              <Link
-                to="/login"
-                className="text-[var(--color-primary)] hover:underline"
-              >
-                Back to Login
-              </Link>
-            </div>
-          ) : (
+          {/* The backend enforces registration permissions — don't gate here.
+              If registration is disallowed, the API call will return an error. */}
+          {true ? (
             <form onSubmit={handleSubmit} className="space-y-4">
               {/* Username */}
               <div className="flex items-center gap-3 p-3 bg-[var(--color-bg-tertiary)] rounded-lg">


### PR DESCRIPTION
## Problem

RegisterPage blocked the entire registration form when `canSelfRegister` was false — which happens any time the `/api/users/list` check fails (whitelist issues, network errors, etc.). This left users with no way to create an account even on a fresh install.

## Fix

Remove the frontend gate entirely. The backend already enforces registration policy — if registration is disallowed the `/api/users/create` call returns an error. The frontend shouldn't duplicate this with a check that can fail for unrelated reasons.

## Test plan
- [ ] `/register` always shows the form
- [ ] Submitting registers successfully on a fresh install
- [ ] Backend errors (e.g. handle taken) still surface as form errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)