### PR TITLE
Fix RegisterPage: always show form, fix TS syntax error

### DIFF
--- a/src/components/auth/RegisterPage.tsx
+++ b/src/components/auth/RegisterPage.tsx
@@ -89,10 +89,7 @@ export function RegisterPage() {
 
         {/* Registration Form */}
         <div className="bg-[var(--color-bg-secondary)] rounded-xl p-6 shadow-xl">
-          {/* The backend enforces registration permissions — don't gate here.
-              If registration is disallowed, the API call will return an error. */}
-          {true ? (
-            <form onSubmit={handleSubmit} className="space-y-4">
+          <form onSubmit={handleSubmit} className="space-y-4">
               {/* Username */}
               <div className="flex items-center gap-3 p-3 bg-[var(--color-bg-tertiary)] rounded-lg">
                 <AtSign size={20} className="text-[var(--color-text-secondary)] flex-shrink-0" />
@@ -177,7 +174,6 @@ export function RegisterPage() {
                 </Link>
               </p>
             </form>
-          )}
         </div>
 
         {/* Footer */}


### PR DESCRIPTION
## Changes

- **Remove `canSelfRegister` gate** from RegisterPage — the form was blocked whenever the API check failed (whitelist issues, network errors), leaving no way to register on a fresh install. The backend already enforces registration policy; frontend doesn't need a second gate.
- **Fix TS syntax error** — leftover `{true ? ... )}` wrapper from the refactor caused a build failure (`error TS1005: ':' expected`).

## Test plan
- [ ] Build succeeds
- [ ] `/register` always shows the form
- [ ] Registration works on a fresh install
- [ ] Backend errors (handle taken, etc.) still surface as form errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)