### PR TITLE
Fix ST whitelist: share nginx network namespace

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,14 +3,15 @@ services:
     build: .
     ports:
       - "${PORT:-80}:80"
-    depends_on:
-      sillytavern:
-        condition: service_started
     restart: unless-stopped
 
   sillytavern:
     image: ghcr.io/sillytavern/sillytavern:latest
     entrypoint: ["/bin/sh", "/st-init.sh"]
+    # Share frontend's network namespace: nginx connects to localhost:8000,
+    # so ST always sees 127.0.0.1 — permanently whitelisted, no tricks needed.
+    # Docker Compose infers the startup dependency automatically.
+    network_mode: "service:frontend"
     environment:
       - ST_PORT=8000
     volumes:
@@ -21,8 +22,8 @@ services:
 
   seed-owner:
     image: alpine:latest
-    # Share ST's network namespace so seed calls localhost — always whitelisted
-    network_mode: "service:sillytavern"
+    # frontend's namespace = ST's namespace (ST uses service:frontend)
+    network_mode: "service:frontend"
     volumes:
       - ./docker/seed-owner.sh:/seed-owner.sh:ro
       - st-config:/config

--- a/docker/st-init.sh
+++ b/docker/st-init.sh
@@ -12,12 +12,10 @@ if [ ! -f "$CONFIG" ]; then
 # SillyTavern will add remaining defaults on startup.
 
 # whitelistMode: true satisfies ST's startup security check.
-# enableForwardedWhitelist: true makes ST use X-Forwarded-For for
-# whitelist checks instead of the direct connection IP. nginx always
-# sets X-Forwarded-For: 127.0.0.1 so all proxied traffic is allowed.
-# Port 8000 is not exposed externally so this cannot be spoofed.
+# ST runs in the frontend container's network namespace, so nginx
+# connects to localhost:8000 — ST always sees 127.0.0.1, which is
+# whitelisted. Port 8000 is never exposed externally.
 whitelistMode: true
-enableForwardedWhitelist: true
 enableUserAccounts: true
 listen: true
 whitelist:

--- a/nginx.conf
+++ b/nginx.conf
@@ -10,16 +10,14 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
-    # Proxy all API paths to the SillyTavern backend.
-    # X-Forwarded-For is set to 127.0.0.1 so ST's whitelist check
-    # (enableForwardedWhitelist: true) always sees a trusted localhost IP.
-    # Safe because ST port 8000 is not exposed externally.
+    # ST runs in the same network namespace, so proxy to localhost.
+    # ST's whitelist always allows 127.0.0.1 — no IP games needed.
     location /api/ {
-        proxy_pass http://sillytavern:8000;
+        proxy_pass http://127.0.0.1:8000;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For 127.0.0.1;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
 
         # SSE / streaming support for message generation
@@ -30,21 +28,21 @@ server {
     }
 
     location /csrf-token {
-        proxy_pass http://sillytavern:8000;
+        proxy_pass http://127.0.0.1:8000;
         proxy_set_header Host $host;
-        proxy_set_header X-Forwarded-For 127.0.0.1;
+        proxy_set_header X-Real-IP $remote_addr;
     }
 
     location /thumbnail {
-        proxy_pass http://sillytavern:8000;
+        proxy_pass http://127.0.0.1:8000;
         proxy_set_header Host $host;
-        proxy_set_header X-Forwarded-For 127.0.0.1;
+        proxy_set_header X-Real-IP $remote_addr;
     }
 
     location /characters {
-        proxy_pass http://sillytavern:8000;
+        proxy_pass http://127.0.0.1:8000;
         proxy_set_header Host $host;
-        proxy_set_header X-Forwarded-For 127.0.0.1;
+        proxy_set_header X-Real-IP $remote_addr;
     }
 
     # Allow uploads up to 20 MB (avatars, sprites, attachments)


### PR DESCRIPTION
## Summary

- Puts SillyTavern in the frontend container's **network namespace** (`network_mode: "service:frontend"`) so nginx proxies to `localhost:8000` — ST always sees `127.0.0.1`, which is permanently whitelisted
- Drops the previous `enableForwardedWhitelist` + spoofed `X-Forwarded-For: 127.0.0.1` approach (unreliable, hackish)
- `seed-owner` sidecar also updated to use `service:frontend` namespace (same effect as before, just cleaner path)
- `st-init.sh` config simplified: removed `enableForwardedWhitelist` since it's no longer needed

## Why this works

ST's whitelist checks the **direct connection IP**. With both nginx and ST in the same network namespace, nginx connects to `127.0.0.1:8000` — so every proxied request arrives from localhost, which is always on the whitelist. No DNS timing issues, no header manipulation.

## Test plan

- [ ] `docker compose up --build` — no ST restart loops
- [ ] `/register` creates first account successfully
- [ ] `/login` lists users and authenticates
- [ ] API calls (characters, chats) work through nginx proxy
- [ ] `OWNER_HANDLE` / `OWNER_PASSWORD` env vars seed owner account on first boot

🤖 Generated with [Claude Code](https://claude.com/claude-code)