### PR TITLE
Strip enableForwardedWhitelist from config on every boot

### DIFF
--- a/docker/st-init.sh
+++ b/docker/st-init.sh
@@ -23,4 +23,10 @@ whitelist:
 EOF
 fi
 
+# Ensure enableForwardedWhitelist is absent — if a previous deployment wrote
+# it, ST would check the X-Forwarded-For IP (the real client) against the
+# whitelist instead of the direct connection IP (127.0.0.1), blocking everyone.
+# With the shared network namespace, ST always sees 127.0.0.1 directly.
+sed -i '/^enableForwardedWhitelist:/d' "$CONFIG"
+
 exec node /home/node/app/server.js "$@"


### PR DESCRIPTION
## Summary

- `st-init.sh` now strips `enableForwardedWhitelist` from `config.yaml` unconditionally on every container start
- Fixes deployments where a stale `st-config` volume (from a previous iteration) had `enableForwardedWhitelist: true` written — causing ST to whitelist-check the real client IP via `X-Forwarded-For` instead of the direct connection IP (`127.0.0.1`), blocking all traffic

## Root cause

The network namespace fix (`network_mode: "service:frontend"`) works correctly — ST sees `127.0.0.1` as the direct connection IP. But if the `st-config` Docker volume was created by an older deployment that wrote `enableForwardedWhitelist: true`, ST ignores the direct IP and checks `X-Forwarded-For` (the real client, e.g. `136.47.146.35`) instead — which isn't whitelisted.

## Test plan

- [ ] Deploy with an existing `st-config` volume that has `enableForwardedWhitelist: true` — ST should no longer block connections
- [ ] Fresh deploy — registration and login work normally
- [ ] Immediate hotfix: `docker compose exec sillytavern sh -c "sed -i '/enableForwardedWhitelist/d' /home/node/app/config/config.yaml" && docker compose restart sillytavern`

🤖 Generated with [Claude Code](https://claude.com/claude-code)