### PR TITLE
Pin X-Forwarded-For to 127.0.0.1 for all ST proxy locations

### DIFF
--- a/docker/st-init.sh
+++ b/docker/st-init.sh
@@ -27,6 +27,6 @@ fi
 # it, ST would check the X-Forwarded-For IP (the real client) against the
 # whitelist instead of the direct connection IP (127.0.0.1), blocking everyone.
 # With the shared network namespace, ST always sees 127.0.0.1 directly.
-sed -i '/^enableForwardedWhitelist:/d' "$CONFIG"
+sed -i '/enableForwardedWhitelist/d' "$CONFIG"
 
 exec node /home/node/app/server.js "$@"

--- a/nginx.conf
+++ b/nginx.conf
@@ -11,13 +11,16 @@ server {
     }
 
     # ST runs in the same network namespace, so proxy to localhost.
-    # ST's whitelist always allows 127.0.0.1 — no IP games needed.
+    # X-Forwarded-For is pinned to 127.0.0.1 so ST's whitelist check
+    # always sees a whitelisted IP regardless of enableForwardedWhitelist.
+    # Safe: ST port 8000 is never exposed externally, so this cannot be spoofed.
+    # X-Real-IP carries the actual client IP for application-level use.
     location /api/ {
         proxy_pass http://127.0.0.1:8000;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-For 127.0.0.1;
         proxy_set_header X-Forwarded-Proto $scheme;
 
         # SSE / streaming support for message generation
@@ -31,18 +34,21 @@ server {
         proxy_pass http://127.0.0.1:8000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For 127.0.0.1;
     }
 
     location /thumbnail {
         proxy_pass http://127.0.0.1:8000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For 127.0.0.1;
     }
 
     location /characters {
         proxy_pass http://127.0.0.1:8000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For 127.0.0.1;
     }
 
     # Allow uploads up to 20 MB (avatars, sprites, attachments)


### PR DESCRIPTION
## Summary

- All ST proxy locations in nginx now send `X-Forwarded-For: 127.0.0.1` explicitly
- `X-Real-IP: $remote_addr` still carries the actual client IP for application use
- Broadened `sed` pattern in `st-init.sh` to strip `enableForwardedWhitelist` in any format it might appear in a stale config volume

## Root cause (definitive diagnosis)

With `enableForwardedWhitelist: true` still present in the stale `st-config` volume, ST ignores the direct TCP connection IP and checks `X-Forwarded-For` instead. Two failure modes:

| Location | X-Forwarded-For sent | Result |
|---|---|---|
| `/api/` | Real client IP (`136.47.x.x`) | Blocked — not whitelisted |
| `/csrf-token`, `/thumbnail`, `/characters` | Not set (no header) | Blocked — `undefined` fails `whitelist.includes()` |

Both are fixed by pinning `X-Forwarded-For: 127.0.0.1` across all ST proxy locations. ST's port 8000 is never externally exposed, so this value cannot be spoofed by clients.

## Test plan

- [ ] Deploy with existing stale `st-config` volume (has `enableForwardedWhitelist: true`) — no blocked connections
- [ ] `/csrf-token` returns 200 (not 403)
- [ ] Registration and login work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)