### PR TITLE
Fix enableForwardedWhitelist: set to false, not delete

### DIFF
--- a/docker/st-init.sh
+++ b/docker/st-init.sh
@@ -16,6 +16,7 @@ if [ ! -f "$CONFIG" ]; then
 # connects to localhost:8000 — ST always sees 127.0.0.1, which is
 # whitelisted. Port 8000 is never exposed externally.
 whitelistMode: true
+enableForwardedWhitelist: false
 enableUserAccounts: true
 listen: true
 whitelist:
@@ -23,10 +24,15 @@ whitelist:
 EOF
 fi
 
-# Ensure enableForwardedWhitelist is absent — if a previous deployment wrote
-# it, ST would check the X-Forwarded-For IP (the real client) against the
-# whitelist instead of the direct connection IP (127.0.0.1), blocking everyone.
-# With the shared network namespace, ST always sees 127.0.0.1 directly.
-sed -i '/enableForwardedWhitelist/d' "$CONFIG"
+# Explicitly set enableForwardedWhitelist: false.
+# If the key is absent, ST re-adds it on startup with its own default of true,
+# which would cause it to check X-Forwarded-For against the whitelist.
+# Setting it to false here (BEFORE ST starts) ensures ST reads the explicit
+# value and does not replace it with the default.
+if grep -q 'enableForwardedWhitelist' "$CONFIG"; then
+  sed -i 's/enableForwardedWhitelist:.*/enableForwardedWhitelist: false/' "$CONFIG"
+else
+  echo 'enableForwardedWhitelist: false' >> "$CONFIG"
+fi
 
 exec node /home/node/app/server.js "$@"


### PR DESCRIPTION
## Problem

Deleting `enableForwardedWhitelist` from `config.yaml` doesn't work — ST treats the key's absence as "use my default", and its default is `true`. So every time ST starts it re-adds `enableForwardedWhitelist: true`, undoing our fix.

Confirmed via `docker compose exec sillytavern cat /home/node/app/config/config.yaml`:
```
enableForwardedWhitelist: true   ← re-added by ST after our sed deleted it
```

## Fix

- Write `enableForwardedWhitelist: false` explicitly in the fresh-config block
- Change the sed command from deleting the line to replacing it: `s/enableForwardedWhitelist:.*/enableForwardedWhitelist: false/`
- If the key is somehow absent, append it as `false`

ST reads the explicit `false` on startup and preserves it (doesn't replace a present value with its default).

## Test plan

- [ ] After deploy, `docker compose exec sillytavern grep enableForwardedWhitelist /home/node/app/config/config.yaml` → `enableForwardedWhitelist: false`
- [ ] No blocked connections in ST log

🤖 Generated with [Claude Code](https://claude.com/claude-code)