### PR TITLE
Fix stale CSRF token causing login failure after logout

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -11,6 +11,11 @@ async function getCsrfToken(): Promise<string> {
   return csrfToken!;
 }
 
+/** Call after logout so the next request fetches a fresh token from the new session. */
+export function clearCsrfToken(): void {
+  csrfToken = null;
+}
+
 export async function apiRequest<T>(
   endpoint: string,
   options: RequestInit = {}

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { api, type UserInfo } from '../api/client';
+import { api, clearCsrfToken, type UserInfo } from '../api/client';
 import { useCharacterStore } from './characterStore';
 import { useChatStore } from './chatStore';
 import { useSettingsStore } from './settingsStore';
@@ -91,10 +91,14 @@ export const useAuthStore = create<AuthState>((set) => ({
   login: async (handle: string, password?: string) => {
     set({ isLoading: true, error: null });
     try {
-      const result = await api.login(handle, password);
+      await api.login(handle, password);
+      // Fetch real user data so role and display name are correct.
+      const user = await api.getCurrentUser();
       set({
         isAuthenticated: true,
-        currentUser: { handle: result.handle, name: result.handle, role: 'end_user' },
+        currentUser: user
+          ? { handle: user.handle, name: user.name, role: user.role }
+          : { handle, name: handle, role: 'end_user' },
         isLoading: false,
       });
       return true;
@@ -111,6 +115,10 @@ export const useAuthStore = create<AuthState>((set) => ({
     try {
       await api.logout();
     } finally {
+      // Invalidate the cached CSRF token — it's tied to the session that was
+      // just destroyed. Without this, the next login attempt uses the stale
+      // token, ST rejects it, and the login silently fails.
+      clearCsrfToken();
       set({ isAuthenticated: false, currentUser: null });
 
       // Clear all stores to prevent data leakage between users


### PR DESCRIPTION
## Problem

After logging out and clicking a user again, the password field appeared even for passwordless accounts. Empty password failed. Page refresh fixed it.

**Root cause:** The CSRF token is cached as a module-level variable in `client.ts`. ST ties the CSRF token to the Express session. On logout, the session is destroyed — invalidating the token. The cached stale token persists in memory, so the next login attempt sends it, ST rejects it with 403, and `handleUserClick`'s `else` branch shows the password field as a silent fallback.

## Changes

- **`client.ts`**: Export `clearCsrfToken()` to null out the cached token
- **`authStore.ts`**: Call `clearCsrfToken()` in `logout()` so the next request fetches a fresh token from the new session
- **`authStore.ts`**: Fix `login()` to call `getCurrentUser()` after login so `currentUser.role` and `currentUser.name` reflect actual server data instead of hardcoded `'end_user'` / `handle`

## Test plan

- [ ] Log in → log out → click user → logs in directly (no spurious password field)
- [ ] Log in → verify display name and role are correct (not hardcoded `end_user`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)