### PR TITLE
ci: Use pre-built ST image instead of building from source

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,7 @@ services:
     restart: unless-stopped
 
   sillytavern:
-    build:
-      context: https://github.com/sammygallo/SillyTavern.git#feat/role-based-permissions
+    image: ghcr.io/sammygallo/sillytavern:feat-role-based-permissions
     entrypoint: ["/bin/sh", "/st-init.sh"]
     # Share frontend's network namespace: nginx connects to localhost:8000,
     # so ST always sees 127.0.0.1 — permanently whitelisted, no tricks needed.


### PR DESCRIPTION
## Summary

Switches the `sillytavern` service from building from GitHub source to pulling a pre-built image from the fork's GitHub Container Registry.

**Before:**
```yaml
sillytavern:
  build:
    context: https://github.com/sammygallo/SillyTavern.git#feat/role-based-permissions
```

**After:**
```yaml
sillytavern:
  image: ghcr.io/sammygallo/sillytavern:feat-role-based-permissions
```

The image is published automatically by sammygallo/SillyTavern PR #7 (adds a GitHub Actions workflow that builds and pushes to GHCR on every push to `feat/role-based-permissions`).

## Deploy order

1. Merge sammygallo/SillyTavern PR #7 (workflow)
2. Merge sammygallo/SillyTavern PR #6 (invitations) — triggers the first image build, ~5 min on GitHub's runners
3. Merge this PR
4. On the droplet: `docker compose pull && docker compose up -d` (~30 sec)

## Test plan

- [ ] `docker compose pull` fetches `ghcr.io/sammygallo/sillytavern:feat-role-based-permissions` without error
- [ ] `docker compose up -d` starts in under a minute
- [ ] ST is reachable and invitation endpoints respond

🤖 Generated with [Claude Code](https://claude.com/claude-code)