### PR TITLE
feat: Phase 1.1/1.3/1.5/2.1 — swipes, editing, chat file management

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -594,6 +594,49 @@ export const api = {
     const fileName = `${characterName} - ${new Date(timestamp).toISOString().split('T')[0]}@${timestamp}`;
     return fileName;
   },
+
+  async deleteChat(avatarUrl: string, fileName: string): Promise<void> {
+    await apiRequest('/api/chats/delete', {
+      method: 'POST',
+      body: JSON.stringify({ avatar_url: avatarUrl, chatfile: fileName }),
+    });
+  },
+
+  async renameChat(avatarUrl: string, originalFile: string, renamedFile: string): Promise<string> {
+    const result = await apiRequest<{ ok: boolean; sanitizedFileName: string }>('/api/chats/rename', {
+      method: 'POST',
+      body: JSON.stringify({
+        avatar_url: avatarUrl,
+        original_file: originalFile,
+        renamed_file: renamedFile,
+      }),
+    });
+    return result.sanitizedFileName;
+  },
+
+  async importChat(
+    avatarUrl: string,
+    characterName: string,
+    file: File,
+    userName = 'User'
+  ): Promise<string[]> {
+    const formData = new FormData();
+    formData.append('avatar_url', avatarUrl);
+    formData.append('character_name', characterName);
+    formData.append('user_name', userName);
+    formData.append('file_type', file.name.endsWith('.json') ? 'json' : 'jsonl');
+    formData.append('file', file);
+
+    const response = await fetch('/api/chats/import', {
+      method: 'POST',
+      credentials: 'include',
+      body: formData,
+    });
+    if (!response.ok) throw new Error('Import failed');
+    const data = await response.json();
+    if (data.error) throw new Error('Import failed: invalid format');
+    return data.fileNames ?? [];
+  },
 };
 
 interface ChatMessage {

--- a/src/components/chat/ChatHistoryPanel.tsx
+++ b/src/components/chat/ChatHistoryPanel.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect } from 'react';
-import { Plus, Trash2, MessageSquare, Download } from 'lucide-react';
+import { useState, useEffect, useRef } from 'react';
+import { Plus, Trash2, MessageSquare, Download, Upload, Pencil, Check, X } from 'lucide-react';
 import { Modal, ConfirmDialog } from '../ui';
 import { useChatStore } from '../../stores/chatStore';
 import { useCharacterStore } from '../../stores/characterStore';
@@ -11,9 +11,12 @@ interface ChatHistoryPanelProps {
 
 export function ChatHistoryPanel({ isOpen, onClose }: ChatHistoryPanelProps) {
   const { selectedCharacter } = useCharacterStore();
-  const { chatFiles, currentChatFile, fetchChatFiles, loadChat, startNewChat, deleteChat } =
+  const { chatFiles, currentChatFile, fetchChatFiles, loadChat, startNewChat, deleteChat, renameChat, importChat } =
     useChatStore();
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
+  const [renamingFile, setRenamingFile] = useState<string | null>(null);
+  const [renameValue, setRenameValue] = useState('');
+  const importInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (isOpen && selectedCharacter) {
@@ -22,7 +25,7 @@ export function ChatHistoryPanel({ isOpen, onClose }: ChatHistoryPanelProps) {
   }, [isOpen, selectedCharacter, fetchChatFiles]);
 
   const handleLoadChat = async (fileName: string) => {
-    if (!selectedCharacter) return;
+    if (!selectedCharacter || renamingFile) return;
     await loadChat(selectedCharacter.avatar, fileName);
     onClose();
   };
@@ -66,19 +69,57 @@ export function ChatHistoryPanel({ isOpen, onClose }: ChatHistoryPanelProps) {
     }
   };
 
+  const handleStartRename = (fileName: string, e: React.MouseEvent) => {
+    e.stopPropagation();
+    setRenamingFile(fileName);
+    setRenameValue(fileName);
+  };
+
+  const handleConfirmRename = async () => {
+    if (!selectedCharacter || !renamingFile || !renameValue.trim() || renameValue === renamingFile) {
+      setRenamingFile(null);
+      return;
+    }
+    await renameChat(selectedCharacter.avatar, renamingFile, renameValue.trim());
+    setRenamingFile(null);
+  };
+
+  const handleImport = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!selectedCharacter || !e.target.files?.length) return;
+    const file = e.target.files[0];
+    await importChat(selectedCharacter.avatar, selectedCharacter.name, file);
+    e.target.value = '';
+  };
+
   if (!selectedCharacter) return null;
 
   return (
     <>
       <Modal isOpen={isOpen} onClose={onClose} title="Chat History" size="md">
         <div className="flex flex-col gap-2">
-          <button
-            onClick={handleNewChat}
-            className="flex items-center gap-3 px-4 py-3 rounded-lg bg-[var(--color-primary)] text-white hover:opacity-90 transition-opacity"
-          >
-            <Plus size={18} />
-            <span className="font-medium">New Chat</span>
-          </button>
+          <div className="flex gap-2">
+            <button
+              onClick={handleNewChat}
+              className="flex-1 flex items-center gap-3 px-4 py-3 rounded-lg bg-[var(--color-primary)] text-white hover:opacity-90 transition-opacity"
+            >
+              <Plus size={18} />
+              <span className="font-medium">New Chat</span>
+            </button>
+            <button
+              onClick={() => importInputRef.current?.click()}
+              className="flex items-center gap-2 px-3 py-3 rounded-lg border border-[var(--color-border)] text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-tertiary)] transition-colors"
+              title="Import chat (.jsonl or .json)"
+            >
+              <Upload size={18} />
+            </button>
+            <input
+              ref={importInputRef}
+              type="file"
+              accept=".jsonl,.json"
+              className="hidden"
+              onChange={handleImport}
+            />
+          </div>
 
           {chatFiles.length === 0 ? (
             <div className="text-center py-8 text-sm text-[var(--color-text-secondary)]">
@@ -88,6 +129,7 @@ export function ChatHistoryPanel({ isOpen, onClose }: ChatHistoryPanelProps) {
             <div className="flex flex-col gap-1 max-h-[60vh] overflow-y-auto">
               {chatFiles.map((chat) => {
                 const isActive = chat.fileName === currentChatFile;
+                const isRenaming = renamingFile === chat.fileName;
                 return (
                   <div
                     key={chat.fileName}
@@ -98,41 +140,80 @@ export function ChatHistoryPanel({ isOpen, onClose }: ChatHistoryPanelProps) {
                         : 'hover:bg-[var(--color-bg-tertiary)]'}
                     `}
                   >
-                    <button
-                      onClick={() => handleLoadChat(chat.fileName)}
-                      className="flex-1 flex items-center gap-3 min-w-0 text-left"
-                    >
-                      <MessageSquare
-                        size={16}
-                        className="text-[var(--color-text-secondary)] flex-shrink-0"
-                      />
-                      <div className="min-w-0 flex-1">
-                        <div className="text-sm font-medium text-[var(--color-text-primary)] truncate">
-                          {chat.fileName}
-                        </div>
-                        {chat.lastMessage && (
-                          <div className="text-xs text-[var(--color-text-secondary)] truncate">
-                            {chat.lastMessage}
-                          </div>
-                        )}
+                    {isRenaming ? (
+                      <div className="flex-1 flex items-center gap-2 min-w-0">
+                        <MessageSquare size={16} className="text-[var(--color-text-secondary)] flex-shrink-0" />
+                        <input
+                          autoFocus
+                          value={renameValue}
+                          onChange={(e) => setRenameValue(e.target.value)}
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter') handleConfirmRename();
+                            if (e.key === 'Escape') setRenamingFile(null);
+                          }}
+                          className="flex-1 min-w-0 text-sm bg-[var(--color-bg-primary)] border border-[var(--color-primary)] rounded px-2 py-0.5 outline-none"
+                        />
+                        <button
+                          onClick={handleConfirmRename}
+                          className="p-1 rounded text-green-400 hover:bg-green-500/20"
+                          title="Confirm rename"
+                        >
+                          <Check size={14} />
+                        </button>
+                        <button
+                          onClick={() => setRenamingFile(null)}
+                          className="p-1 rounded text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-secondary)]"
+                          title="Cancel"
+                        >
+                          <X size={14} />
+                        </button>
                       </div>
-                    </button>
-                    <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-                      <button
-                        onClick={() => handleExportChat(chat.fileName)}
-                        className="p-1.5 rounded hover:bg-[var(--color-bg-secondary)] text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]"
-                        title="Export as JSONL"
-                      >
-                        <Download size={14} />
-                      </button>
-                      <button
-                        onClick={() => setConfirmDelete(chat.fileName)}
-                        className="p-1.5 rounded hover:bg-red-500/20 text-[var(--color-text-secondary)] hover:text-red-400"
-                        title="Delete chat"
-                      >
-                        <Trash2 size={14} />
-                      </button>
-                    </div>
+                    ) : (
+                      <>
+                        <button
+                          onClick={() => handleLoadChat(chat.fileName)}
+                          className="flex-1 flex items-center gap-3 min-w-0 text-left"
+                        >
+                          <MessageSquare
+                            size={16}
+                            className="text-[var(--color-text-secondary)] flex-shrink-0"
+                          />
+                          <div className="min-w-0 flex-1">
+                            <div className="text-sm font-medium text-[var(--color-text-primary)] truncate">
+                              {chat.fileName}
+                            </div>
+                            {chat.lastMessage && (
+                              <div className="text-xs text-[var(--color-text-secondary)] truncate">
+                                {chat.lastMessage}
+                              </div>
+                            )}
+                          </div>
+                        </button>
+                        <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                          <button
+                            onClick={(e) => handleStartRename(chat.fileName, e)}
+                            className="p-1.5 rounded hover:bg-[var(--color-bg-secondary)] text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]"
+                            title="Rename chat"
+                          >
+                            <Pencil size={14} />
+                          </button>
+                          <button
+                            onClick={() => handleExportChat(chat.fileName)}
+                            className="p-1.5 rounded hover:bg-[var(--color-bg-secondary)] text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]"
+                            title="Export as JSONL"
+                          >
+                            <Download size={14} />
+                          </button>
+                          <button
+                            onClick={() => setConfirmDelete(chat.fileName)}
+                            className="p-1.5 rounded hover:bg-red-500/20 text-[var(--color-text-secondary)] hover:text-red-400"
+                            title="Delete chat"
+                          >
+                            <Trash2 size={14} />
+                          </button>
+                        </div>
+                      </>
+                    )}
                   </div>
                 );
               })}

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -22,6 +22,8 @@ interface ChatInputProps {
    *  the effect. Passing an empty array with a new nonce is a no-op. */
   droppedImages?: string[];
   droppedImagesNonce?: number;
+  /** Called when the user presses ArrowUp in an empty input — edit last message. */
+  onEditLast?: () => void;
 }
 
 /** How long a mic button press must be held before it flips from
@@ -47,6 +49,7 @@ export function ChatInput({
   prefillNonce,
   droppedImages,
   droppedImagesNonce,
+  onEditLast,
 }: ChatInputProps) {
   const [message, setMessage] = useState('');
   const [images, setImages] = useState<string[]>([]);
@@ -289,6 +292,10 @@ export function ChatInput({
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       handleSubmit(e);
+    }
+    if (e.key === 'ArrowUp' && !message.trim() && onEditLast) {
+      e.preventDefault();
+      onEditLast();
     }
   };
 

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -34,6 +34,7 @@ interface ChatMessageProps {
   swipes?: string[];
   swipeId?: number;
   showSwipeControl?: boolean;
+  canGenerateSwipe?: boolean;
   onSwipeLeft?: () => void;
   onSwipeRight?: () => void;
   // Actions
@@ -41,6 +42,8 @@ interface ChatMessageProps {
   onEditAndRegenerate?: (newContent: string) => void;
   onDelete?: () => void;
   onRegenerate?: () => void;
+  /** Increment this to programmatically trigger edit mode (e.g. up-arrow shortcut). */
+  triggerEditNonce?: number;
 }
 
 interface TextSegment {
@@ -122,6 +125,7 @@ export function ChatMessage({
   swipes,
   swipeId,
   showSwipeControl,
+  canGenerateSwipe,
   onSwipeLeft,
   onSwipeRight,
   isStreaming: isStreamingMsg,
@@ -133,6 +137,7 @@ export function ChatMessage({
   onEditAndRegenerate,
   onDelete,
   onRegenerate,
+  triggerEditNonce,
 }: ChatMessageProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [editContent, setEditContent] = useState(content);
@@ -161,6 +166,15 @@ export function ChatMessage({
       textareaRef.current.select();
     }
   }, [isEditing]);
+
+  // Programmatic edit trigger (e.g. up-arrow shortcut from ChatInput)
+  useEffect(() => {
+    if (triggerEditNonce && onEdit) {
+      setEditContent(content);
+      setIsEditing(true);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [triggerEditNonce]);
 
   useEffect(() => {
     if (textareaRef.current) {
@@ -391,6 +405,7 @@ export function ChatMessage({
       onSwipeLeft={onSwipeLeft}
       onSwipeRight={onSwipeRight}
       disabled={disabled}
+      canGenerate={canGenerateSwipe}
     />
   ) : null;
 
@@ -420,7 +435,9 @@ export function ChatMessage({
                   ? 'bg-[var(--color-primary)] text-white rounded-br-md'
                   : 'bg-[var(--color-bg-tertiary)] text-[var(--color-text-primary)] rounded-bl-md'}
                 ${isEditing ? 'w-full' : ''}
+                ${!isEditing && onEdit ? 'cursor-text select-text' : ''}
               `}
+              onDoubleClick={!isEditing && onEdit ? handleStartEdit : undefined}
             >
               {imageGrid}
               {editingUI}
@@ -457,7 +474,10 @@ export function ChatMessage({
         </div>
 
         {/* Content area */}
-        <div className="text-[var(--color-text-primary)]">
+        <div
+          className="text-[var(--color-text-primary)]"
+          onDoubleClick={!isEditing && onEdit ? handleStartEdit : undefined}
+        >
           {imageGrid}
           {isEditing ? (
             <div className="p-2 rounded-lg bg-[var(--color-bg-tertiary)]">
@@ -493,7 +513,12 @@ export function ChatMessage({
               {editingUI}
             </div>
           ) : messageContent ? (
-            <div className="mt-0.5">{messageContent}</div>
+            <div
+              className="mt-0.5"
+              onDoubleClick={!isEditing && onEdit ? handleStartEdit : undefined}
+            >
+              {messageContent}
+            </div>
           ) : null}
         </div>
 

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -82,6 +82,7 @@ export function ChatView() {
   // attachment set, re-triggered by the nonce so identical payloads fire.
   const [droppedImages, setDroppedImages] = useState<string[]>([]);
   const [droppedImagesNonce, setDroppedImagesNonce] = useState(0);
+  const [editLastNonce, setEditLastNonce] = useState(0);
   const [isDragOver, setIsDragOver] = useState(false);
   const dragCounter = useRef(0);
 
@@ -97,6 +98,11 @@ export function ChatView() {
   const lastAiMessageId = useMemo(() => {
     const aiMessages = messages.filter((m) => !m.isUser && !m.isSystem);
     return aiMessages.length > 0 ? aiMessages[aiMessages.length - 1].id : null;
+  }, [messages]);
+
+  const lastUserMessageId = useMemo(() => {
+    const userMessages = messages.filter((m) => m.isUser);
+    return userMessages.length > 0 ? userMessages[userMessages.length - 1].id : null;
   }, [messages]);
 
   const hasAiMessage = useMemo(
@@ -463,8 +469,12 @@ export function ChatView() {
                     : undefined;
 
               const isLastAiMessage = message.id === lastAiMessageId;
+              const isAiMessage = !message.isUser && !message.isSystem;
+              // Show swipe controls on the last AI message always, and on any AI
+              // message that already has multiple swipes (e.g. alternate greetings).
               const showSwipeControl =
-                !isGroupChatMode && isLastAiMessage && !message.isUser && !message.isSystem;
+                !isGroupChatMode && isAiMessage &&
+                (isLastAiMessage || message.swipes.length > 1);
 
               return (
                 <ChatMessage
@@ -487,6 +497,7 @@ export function ChatView() {
                   swipes={message.swipes}
                   swipeId={message.swipeId}
                   showSwipeControl={showSwipeControl}
+                  canGenerateSwipe={isLastAiMessage}
                   onSwipeLeft={() => handleSwipeLeft(message.id)}
                   onSwipeRight={() => handleSwipeRight(message.id)}
                   onEdit={(newContent) => editMessage(message.id, newContent)}
@@ -505,6 +516,7 @@ export function ChatView() {
                   onRegenerate={
                     isLastAiMessage && !isGroupChatMode ? handleRegenerate : undefined
                   }
+                  triggerEditNonce={message.id === lastUserMessageId ? editLastNonce : undefined}
                 />
               );
             })}
@@ -562,6 +574,7 @@ export function ChatView() {
         prefillNonce={prefillNonce}
         droppedImages={droppedImages}
         droppedImagesNonce={droppedImagesNonce}
+        onEditLast={lastUserMessageId && !isSending ? () => setEditLastNonce((n) => n + 1) : undefined}
       />
 
       {/* Manual-strategy hint: auto-pick is disabled, so user has to force-talk. */}

--- a/src/components/chat/SwipeControl.tsx
+++ b/src/components/chat/SwipeControl.tsx
@@ -6,6 +6,8 @@ interface SwipeControlProps {
   onSwipeLeft: () => void;
   onSwipeRight: () => void;
   disabled?: boolean;
+  /** When false, the right button is disabled at the last swipe (no generation). */
+  canGenerate?: boolean;
 }
 
 export function SwipeControl({
@@ -14,8 +16,11 @@ export function SwipeControl({
   onSwipeLeft,
   onSwipeRight,
   disabled,
+  canGenerate = true,
 }: SwipeControlProps) {
   const canSwipeLeft = swipeId > 0 && !disabled;
+  const atLastSwipe = swipeId === swipesCount - 1;
+  const canSwipeRight = !disabled && (!atLastSwipe || canGenerate);
   const current = swipeId + 1;
 
   return (
@@ -33,10 +38,10 @@ export function SwipeControl({
       </span>
       <button
         onClick={onSwipeRight}
-        disabled={disabled}
+        disabled={!canSwipeRight}
         className="p-1 rounded hover:bg-[var(--color-bg-tertiary)] disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
-        aria-label={swipeId === swipesCount - 1 ? 'Generate new response' : 'Next response'}
-        title={swipeId === swipesCount - 1 ? 'Generate new response' : 'Next response'}
+        aria-label={atLastSwipe ? 'Generate new response' : 'Next response'}
+        title={atLastSwipe ? 'Generate new response' : 'Next response'}
       >
         <ChevronRight size={16} />
       </button>

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -378,6 +378,8 @@ interface ChatState {
   continueMessage: (character: CharacterInfo, availableEmotions?: string[]) => Promise<void>;
   impersonate: (character: CharacterInfo, availableEmotions?: string[]) => Promise<string>;
   deleteChat: (avatarUrl: string, fileName: string) => Promise<void>;
+  renameChat: (avatarUrl: string, fileName: string, newName: string) => Promise<void>;
+  importChat: (avatarUrl: string, characterName: string, file: File) => Promise<void>;
 }
 
 let messageIdCounter = 0;
@@ -1705,6 +1707,12 @@ export const useChatStore = create<ChatState>((set, get) => ({
         return { ...msg, swipeId: newSwipeId, content: msg.swipes[newSwipeId] };
       }),
     }));
+    // Persist swipe position
+    const { currentChatFile } = get();
+    const character = useCharacterStore.getState().selectedCharacter;
+    if (character) {
+      saveChatToBackend(get().messages, character, currentChatFile);
+    }
   },
 
   // ---- Swipe Right (next swipe, or generate new if at end) ----
@@ -1722,6 +1730,9 @@ export const useChatStore = create<ChatState>((set, get) => ({
           return { ...m, swipeId: newSwipeId, content: m.swipes[newSwipeId] };
         }),
       }));
+      // Persist swipe position
+      const { currentChatFile } = get();
+      saveChatToBackend(get().messages, character, currentChatFile);
       return;
     }
 
@@ -1918,13 +1929,36 @@ export const useChatStore = create<ChatState>((set, get) => ({
   // ---- Delete Chat File ----
   deleteChat: async (avatarUrl: string, fileName: string) => {
     try {
-      // Save an empty chat to effectively delete it
-      await api.saveChat(avatarUrl, fileName, []);
-      // Refresh chat list
+      await api.deleteChat(avatarUrl, fileName);
       const { fetchChatFiles } = get();
       await fetchChatFiles(avatarUrl);
     } catch (error) {
       set({ error: error instanceof Error ? error.message : 'Failed to delete chat' });
+    }
+  },
+
+  // ---- Rename Chat File ----
+  renameChat: async (avatarUrl: string, fileName: string, newName: string) => {
+    try {
+      const sanitized = await api.renameChat(avatarUrl, fileName, newName);
+      const { currentChatFile, fetchChatFiles } = get();
+      if (currentChatFile === fileName) {
+        set({ currentChatFile: sanitized });
+      }
+      await fetchChatFiles(avatarUrl);
+    } catch (error) {
+      set({ error: error instanceof Error ? error.message : 'Failed to rename chat' });
+    }
+  },
+
+  // ---- Import Chat File ----
+  importChat: async (avatarUrl: string, characterName: string, file: File) => {
+    try {
+      await api.importChat(avatarUrl, characterName, file);
+      const { fetchChatFiles } = get();
+      await fetchChatFiles(avatarUrl);
+    } catch (error) {
+      set({ error: error instanceof Error ? error.message : 'Failed to import chat' });
     }
   },
 


### PR DESCRIPTION
## Summary

- **Phase 1.1 (swipe gap fix):** Swipe controls now appear on *any* AI message with multiple swipes (not just the last), so alternate greeting navigation stays accessible mid-conversation. Added `canGenerate` prop to `SwipeControl` — non-last messages are navigation-only (no spurious regeneration).
- **Phase 1.3 (editing UX):** Double-click/double-tap any message bubble to enter inline edit mode directly. ArrowUp on an empty `ChatInput` triggers edit on the last user message (Discord-style shortcut), wired via `triggerEditNonce`.
- **Phase 1.5 (chat file management):** Proper `/api/chats/delete` replaces the empty-save hack. Added `renameChat` and `importChat` to the API client and store. `ChatHistoryPanel` gains an Upload button (`.jsonl`/`.json`), inline rename (pencil → input → ✓/✗), with rename/export/delete icons per row.
- **Phase 2.1 (greeting swipe persistence):** `swipeLeft` and the navigate-to-existing branch of `swipeRight` now call `saveChatToBackend` so the selected greeting survives page refresh.

## Test plan

- [ ] Open a character with alternate greetings — swipe `◁ ▷` visible on first message even after sending subsequent messages
- [ ] Right button disabled at last swipe on non-last messages; enabled on last AI message for generation
- [ ] Double-click a message bubble → enters inline edit mode
- [ ] Focus empty ChatInput, press ArrowUp → last user message enters edit mode
- [ ] Chat History → Upload button accepts `.jsonl` and imports successfully
- [ ] Hover a chat row → pencil icon → click → rename inline; Enter confirms, Escape cancels
- [ ] Delete chat uses real delete (file removed, not just emptied)
- [ ] Navigate greeting swipes, refresh page → stays on selected greeting

🤖 Generated with [Claude Code](https://claude.com/claude-code)