### PR TITLE
feat: Phase 2.3 — character tags & organization

### DIFF
--- a/src/components/character/CharacterCreation.tsx
+++ b/src/components/character/CharacterCreation.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useCharacterStore } from '../../stores/characterStore';
-import { Modal, Button, Input, TextArea, ImageUpload, ExpressionUpload } from '../ui';
+import { Modal, Button, Input, TextArea, ImageUpload, ExpressionUpload, TagInput } from '../ui';
 import { AlternateGreetingsEditor } from './AlternateGreetingsEditor';
 import { spritesApi } from '../../api/client';
 
@@ -17,17 +17,27 @@ interface CharacterCreationProps {
     exampleMessages: string;
     creatorNotes: string;
     creator: string;
-    tags: string;
+    tags: string[];
   }>;
 }
 
 export function CharacterCreation({ isOpen, onClose, onCreated, initialData }: CharacterCreationProps) {
-  const { createCharacter, isCreating, error, clearError } = useCharacterStore();
+  const { createCharacter, isCreating, error, clearError, getAllTags } = useCharacterStore();
 
   const [avatarFile, setAvatarFile] = useState<File | null>(null);
   const [expressionFiles, setExpressionFiles] = useState<Map<string, File>>(new Map());
   const [isUploadingExpressions, setIsUploadingExpressions] = useState(false);
-  const [formData, setFormData] = useState({
+  const [formData, setFormData] = useState<{
+    name: string;
+    description: string;
+    personality: string;
+    firstMessage: string;
+    scenario: string;
+    exampleMessages: string;
+    creatorNotes: string;
+    creator: string;
+    tags: string[];
+  }>({
     name: initialData?.name || '',
     description: initialData?.description || '',
     personality: initialData?.personality || '',
@@ -36,7 +46,7 @@ export function CharacterCreation({ isOpen, onClose, onCreated, initialData }: C
     exampleMessages: initialData?.exampleMessages || '',
     creatorNotes: initialData?.creatorNotes || '',
     creator: initialData?.creator || '',
-    tags: initialData?.tags || '',
+    tags: initialData?.tags || [],
   });
 
   // Phase 2: Advanced character fields
@@ -73,7 +83,7 @@ export function CharacterCreation({ isOpen, onClose, onCreated, initialData }: C
         mes_example: formData.exampleMessages.trim(),
         creator_notes: formData.creatorNotes.trim(),
         creator: formData.creator.trim(),
-        tags: formData.tags.trim(),
+        tags: formData.tags.join(', '),
         // Advanced fields
         alternate_greetings: alternateGreetings.filter((g) => g.trim()),
         system_prompt: systemPromptOverride.trim() || undefined,
@@ -123,7 +133,7 @@ export function CharacterCreation({ isOpen, onClose, onCreated, initialData }: C
         exampleMessages: '',
         creatorNotes: '',
         creator: '',
-        tags: '',
+        tags: [],
       });
       setAlternateGreetings([]);
       setCharacterVersion('');
@@ -330,11 +340,11 @@ export function CharacterCreation({ isOpen, onClose, onCreated, initialData }: C
             />
 
             {/* Tags */}
-            <Input
+            <TagInput
               label="Tags"
-              placeholder="Comma-separated tags (e.g., fantasy, friendly, assistant)"
               value={formData.tags}
-              onChange={handleChange('tags')}
+              onChange={(tags) => setFormData((prev) => ({ ...prev, tags }))}
+              suggestions={getAllTags()}
             />
           </div>
         </details>

--- a/src/components/character/CharacterEdit.tsx
+++ b/src/components/character/CharacterEdit.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { Download, FileImage, FileJson, Copy, UserCircle } from 'lucide-react';
 import { useCharacterStore } from '../../stores/characterStore';
 import { spritesApi, type CharacterInfo } from '../../api/client';
-import { Modal, Button, Input, TextArea, ImageUpload, ExpressionUpload } from '../ui';
+import { Modal, Button, Input, TextArea, ImageUpload, ExpressionUpload, TagInput } from '../ui';
 import { AlternateGreetingsEditor } from './AlternateGreetingsEditor';
 import { CharacterLorebookSection } from './CharacterLorebookSection';
 
@@ -35,13 +35,24 @@ export function CharacterEdit({
     exportCharacterAsJSON,
     getLinkedBookIds,
     setLinkedBookIds,
+    getAllTags,
   } = useCharacterStore();
   const [showExportMenu, setShowExportMenu] = useState(false);
 
   const [avatarFile, setAvatarFile] = useState<File | null>(null);
   const [expressionFiles, setExpressionFiles] = useState<Map<string, File>>(new Map());
   const [isUploadingExpressions, setIsUploadingExpressions] = useState(false);
-  const [formData, setFormData] = useState({
+  const [formData, setFormData] = useState<{
+    name: string;
+    description: string;
+    personality: string;
+    firstMessage: string;
+    scenario: string;
+    exampleMessages: string;
+    creatorNotes: string;
+    creator: string;
+    tags: string[];
+  }>({
     name: '',
     description: '',
     personality: '',
@@ -50,7 +61,7 @@ export function CharacterEdit({
     exampleMessages: '',
     creatorNotes: '',
     creator: '',
-    tags: '',
+    tags: [],
   });
 
   // Phase 2: Advanced character fields
@@ -81,7 +92,7 @@ export function CharacterEdit({
         exampleMessages: character.mes_example || character.data?.mes_example || '',
         creatorNotes: character.creator_notes || character.data?.creator_notes || '',
         creator: character.creator || character.data?.creator || '',
-        tags: (character.tags || character.data?.tags || []).join(', '),
+        tags: character.tags || character.data?.tags || [],
       });
 
       // Populate advanced fields
@@ -148,7 +159,7 @@ export function CharacterEdit({
         mes_example: formData.exampleMessages.trim(),
         creator_notes: formData.creatorNotes.trim(),
         creator: formData.creator.trim(),
-        tags: formData.tags.trim(),
+        tags: formData.tags.join(', '),
         chat: character.create_date, // Preserve existing
         create_date: character.create_date, // Preserve existing
         // Advanced fields
@@ -486,11 +497,11 @@ export function CharacterEdit({
             />
 
             {/* Tags */}
-            <Input
+            <TagInput
               label="Tags"
-              placeholder="Comma-separated tags (e.g., fantasy, friendly, assistant)"
               value={formData.tags}
-              onChange={handleChange('tags')}
+              onChange={(tags) => setFormData((prev) => ({ ...prev, tags }))}
+              suggestions={getAllTags()}
             />
           </div>
         </details>

--- a/src/components/character/CharacterImport.tsx
+++ b/src/components/character/CharacterImport.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef } from 'react';
 import { Upload, FileImage, FileJson, X, BookOpen } from 'lucide-react';
 import { useCharacterStore } from '../../stores/characterStore';
-import { Modal, Button, Input, TextArea, ImageUpload } from '../ui';
+import { Modal, Button, Input, TextArea, ImageUpload, TagInput } from '../ui';
 import type { CharacterInfo } from '../../api/client';
 import type { CharacterBookV2 } from '../../utils/characterCard';
 
@@ -20,6 +20,7 @@ export function CharacterImport({ isOpen, onClose, onImported }: CharacterImport
     isCreating,
     error,
     clearError,
+    getAllTags,
   } = useCharacterStore();
 
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -27,7 +28,17 @@ export function CharacterImport({ isOpen, onClose, onImported }: CharacterImport
   const [avatarFile, setAvatarFile] = useState<File | null>(null);
   const [avatarPreview, setAvatarPreview] = useState<string | null>(null);
   const [importedBook, setImportedBook] = useState<CharacterBookV2 | null>(null);
-  const [formData, setFormData] = useState({
+  const [formData, setFormData] = useState<{
+    name: string;
+    description: string;
+    personality: string;
+    firstMessage: string;
+    scenario: string;
+    exampleMessages: string;
+    creatorNotes: string;
+    creator: string;
+    tags: string[];
+  }>({
     name: '',
     description: '',
     personality: '',
@@ -36,7 +47,7 @@ export function CharacterImport({ isOpen, onClose, onImported }: CharacterImport
     exampleMessages: '',
     creatorNotes: '',
     creator: '',
-    tags: '',
+    tags: [],
   });
 
   const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -66,7 +77,7 @@ export function CharacterImport({ isOpen, onClose, onImported }: CharacterImport
         exampleMessages: result.data.mes_example || '',
         creatorNotes: result.data.data?.creator_notes || '',
         creator: result.data.data?.creator || '',
-        tags: result.data.tags?.join(', ') || '',
+        tags: result.data.tags || result.data.data?.tags || [],
       });
     }
 
@@ -110,7 +121,7 @@ export function CharacterImport({ isOpen, onClose, onImported }: CharacterImport
         mes_example: formData.exampleMessages.trim(),
         creator_notes: formData.creatorNotes.trim(),
         creator: formData.creator.trim(),
-        tags: formData.tags.trim(),
+        tags: formData.tags.join(', '),
       },
       avatarFile || undefined
     );
@@ -148,7 +159,7 @@ export function CharacterImport({ isOpen, onClose, onImported }: CharacterImport
       exampleMessages: '',
       creatorNotes: '',
       creator: '',
-      tags: '',
+      tags: [],
     });
     clearError();
     onClose();
@@ -195,7 +206,7 @@ export function CharacterImport({ isOpen, onClose, onImported }: CharacterImport
         exampleMessages: result.data.mes_example || '',
         creatorNotes: result.data.data?.creator_notes || '',
         creator: result.data.data?.creator || '',
-        tags: result.data.tags?.join(', ') || '',
+        tags: result.data.tags || result.data.data?.tags || [],
       });
     }
   };
@@ -389,11 +400,11 @@ export function CharacterImport({ isOpen, onClose, onImported }: CharacterImport
               />
 
               {/* Tags */}
-              <Input
+              <TagInput
                 label="Tags"
-                placeholder="Comma-separated tags (e.g., fantasy, friendly, assistant)"
                 value={formData.tags}
-                onChange={handleChange('tags')}
+                onChange={(tags) => setFormData((prev) => ({ ...prev, tags }))}
+                suggestions={getAllTags()}
               />
             </div>
           </details>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -493,6 +493,27 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
                                   {character.description}
                                 </p>
                               )}
+                              {(() => {
+                                const tags = character.tags || character.data?.tags || [];
+                                if (tags.length === 0) return null;
+                                return (
+                                  <div className="flex flex-wrap gap-1 mt-0.5">
+                                    {tags.slice(0, 3).map((tag) => (
+                                      <span
+                                        key={tag}
+                                        className="text-[10px] px-1.5 py-0 leading-4 bg-[var(--color-bg-primary)] text-[var(--color-text-secondary)] rounded-full border border-[var(--color-border)]"
+                                      >
+                                        {tag}
+                                      </span>
+                                    ))}
+                                    {tags.length > 3 && (
+                                      <span className="text-[10px] text-[var(--color-text-secondary)] leading-4">
+                                        +{tags.length - 3}
+                                      </span>
+                                    )}
+                                  </div>
+                                );
+                              })()}
                             </div>
                           </button>
                           {!isGroupSelectMode && (

--- a/src/components/ui/TagInput.tsx
+++ b/src/components/ui/TagInput.tsx
@@ -1,0 +1,138 @@
+import { useState, useRef, useCallback, useId } from 'react';
+import { X } from 'lucide-react';
+
+interface TagInputProps {
+  value: string[];
+  onChange: (tags: string[]) => void;
+  suggestions?: string[];
+  label?: string;
+  placeholder?: string;
+}
+
+export function TagInput({
+  value,
+  onChange,
+  suggestions = [],
+  label,
+  placeholder = 'Add tag...',
+}: TagInputProps) {
+  const [inputText, setInputText] = useState('');
+  const [showSuggestions, setShowSuggestions] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const id = useId();
+
+  const addTag = useCallback(
+    (tag: string) => {
+      const trimmed = tag.trim().toLowerCase();
+      if (!trimmed || value.includes(trimmed)) return;
+      onChange([...value, trimmed]);
+      setInputText('');
+    },
+    [value, onChange]
+  );
+
+  const removeTag = useCallback(
+    (tag: string) => {
+      onChange(value.filter((t) => t !== tag));
+    },
+    [value, onChange]
+  );
+
+  const filteredSuggestions =
+    inputText.trim()
+      ? suggestions.filter(
+          (s) => s.toLowerCase().includes(inputText.toLowerCase()) && !value.includes(s)
+        )
+      : [];
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' || e.key === ',') {
+      e.preventDefault();
+      if (inputText.trim()) {
+        addTag(inputText);
+        setShowSuggestions(false);
+      }
+    } else if (e.key === 'Backspace' && !inputText && value.length > 0) {
+      removeTag(value[value.length - 1]);
+    } else if (e.key === 'Escape') {
+      setShowSuggestions(false);
+    }
+  };
+
+  return (
+    <div className="w-full">
+      {label && (
+        <label
+          htmlFor={id}
+          className="block text-sm font-medium text-[var(--color-text-secondary)] mb-1.5"
+        >
+          {label}
+        </label>
+      )}
+      <div className="relative">
+        <div
+          className="min-h-[42px] px-2 py-1.5 bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] rounded-lg flex flex-wrap gap-1.5 items-center cursor-text focus-within:ring-2 focus-within:ring-[var(--color-primary)] focus-within:border-transparent"
+          onClick={() => inputRef.current?.focus()}
+        >
+          {value.map((tag) => (
+            <span
+              key={tag}
+              className="flex items-center gap-1 px-2 py-0.5 bg-[var(--color-primary)]/20 text-[var(--color-primary)] text-xs rounded-full select-none"
+            >
+              {tag}
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  removeTag(tag);
+                }}
+                className="opacity-60 hover:opacity-100 transition-opacity"
+                aria-label={`Remove tag ${tag}`}
+              >
+                <X size={10} />
+              </button>
+            </span>
+          ))}
+          <input
+            ref={inputRef}
+            id={id}
+            type="text"
+            value={inputText}
+            onChange={(e) => {
+              setInputText(e.target.value);
+              setShowSuggestions(true);
+            }}
+            onKeyDown={handleKeyDown}
+            onFocus={() => setShowSuggestions(true)}
+            onBlur={() => setTimeout(() => setShowSuggestions(false), 150)}
+            placeholder={value.length === 0 ? placeholder : ''}
+            className="flex-1 min-w-[80px] bg-transparent outline-none text-sm text-[var(--color-text-primary)] placeholder-zinc-500"
+          />
+        </div>
+
+        {/* Suggestions dropdown */}
+        {showSuggestions && filteredSuggestions.length > 0 && (
+          <div className="absolute top-full left-0 right-0 mt-1 z-50 bg-[var(--color-bg-secondary)] border border-[var(--color-border)] rounded-lg shadow-lg overflow-hidden">
+            {filteredSuggestions.slice(0, 8).map((suggestion) => (
+              <button
+                key={suggestion}
+                type="button"
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  addTag(suggestion);
+                  setShowSuggestions(false);
+                }}
+                className="w-full text-left px-3 py-2 text-sm text-[var(--color-text-primary)] hover:bg-[var(--color-bg-tertiary)] transition-colors"
+              >
+                {suggestion}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+      <p className="mt-1 text-xs text-[var(--color-text-secondary)]">
+        Press Enter or comma to add · Backspace to remove last
+      </p>
+    </div>
+  );
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -6,3 +6,4 @@ export { TextArea } from './TextArea';
 export { ImageUpload } from './ImageUpload';
 export { ExpressionUpload } from './ExpressionUpload';
 export { ConfirmDialog } from './ConfirmDialog';
+export { TagInput } from './TagInput';


### PR DESCRIPTION
## Summary
- **TagInput component** (`src/components/ui/TagInput.tsx`): pill editor with autocomplete from existing character tags — Enter or comma adds a tag, Backspace removes the last one, suggestions dropdown filters as you type
- **CharacterEdit / CharacterCreation / CharacterImport**: all three tag fields upgraded from a plain comma-separated text input to TagInput; tags stored as `string[]` internally and joined on submit (same API wire format)
- **Sidebar character list**: each character row now shows up to 3 tag pills (with `+N` overflow) beneath the description

Filter/search/sort logic (store `getFilteredCharacters`, sidebar tag chip panel, favorites toggle, sort dropdown) was already fully wired from a prior session — no changes needed there.

## Test plan
- [ ] Open character list sidebar — characters with tags show pill badges on their rows
- [ ] Click Tags button in filter bar — tag chips appear; clicking one filters the list
- [ ] Open CharacterEdit for a tagged character — Tags field shows existing tags as pills; type to get autocomplete suggestions from other characters' tags; Enter/comma adds; × removes
- [ ] Edit tags and save — refreshed list reflects the change
- [ ] CharacterCreation and CharacterImport forms both use the new TagInput

🤖 Generated with [Claude Code](https://claude.com/claude-code)