### PR TITLE
feat: Phase 10.1/10.2 — custom endpoints, quick replies, image gen, translate, user management

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import { ProfilePage } from './components/auth/ProfilePage';
 import { RequireRole } from './components/auth/RequireRole';
 import { MainLayout } from './components/layout/MainLayout';
 import { ChatView } from './components/chat/ChatView';
-import { SettingsPage, GenerationSettingsPage, InvitationManager } from './components/settings';
+import { SettingsPage, GenerationSettingsPage, InvitationManager, UserManagementPage, QuickReplyPage } from './components/settings';
 import { WorldInfoPage } from './components/worldinfo';
 import { RegexScriptPage } from './components/regexscripts';
 import { InviteAcceptPage } from './components/auth/InviteAcceptPage';
@@ -22,6 +22,8 @@ function App() {
         <Route path="/settings/worldinfo" element={<RequireRole minRole="admin"><WorldInfoPage /></RequireRole>} />
         <Route path="/settings/regex" element={<RequireRole minRole="admin"><RegexScriptPage /></RequireRole>} />
         <Route path="/settings/invitations" element={<RequireRole minRole="admin"><InvitationManager /></RequireRole>} />
+        <Route path="/settings/users" element={<RequireRole minRole="admin"><UserManagementPage /></RequireRole>} />
+        <Route path="/settings/quickreplies" element={<RequireRole minRole="end_user"><QuickReplyPage /></RequireRole>} />
         <Route path="/invite/:token" element={<InviteAcceptPage />} />
         <Route path="/" element={<MainLayout />}>
           <Route index element={<ChatView />} />

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -730,6 +730,8 @@ export const PROVIDERS = [
   { id: 'mistralai', name: 'Mistral AI', secretKey: SECRET_KEYS.MISTRAL, models: ['mistral-large-latest', 'mistral-medium-latest', 'mistral-small-latest'] },
   { id: 'groq', name: 'Groq', secretKey: SECRET_KEYS.GROQ, models: ['llama-3.3-70b-versatile', 'llama-3.1-8b-instant', 'mixtral-8x7b-32768'] },
   { id: 'openrouter', name: 'OpenRouter', secretKey: SECRET_KEYS.OPENROUTER, models: ['openai/gpt-4o', 'anthropic/claude-sonnet-4', 'google/gemini-pro-1.5'] },
+  // Custom / local: no secret key required; URL and model are stored directly in oai_settings.
+  { id: 'custom', name: 'Custom / Local', secretKey: '', models: [] as readonly string[] },
 ] as const;
 
 export const settingsApi = {

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -50,6 +50,25 @@ export async function apiRequest<T>(
   }
 }
 
+/** Like apiRequest but returns the raw response body as a string (for plain-text endpoints). */
+export async function apiRequestText(
+  endpoint: string,
+  options: RequestInit = {}
+): Promise<string> {
+  const token = await getCsrfToken();
+  const headers: HeadersInit = {
+    'Content-Type': 'application/json',
+    'X-CSRF-Token': token,
+    ...options.headers,
+  };
+  const response = await fetch(endpoint, { ...options, headers, credentials: 'include' });
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ error: 'Unknown error' }));
+    throw new Error(error.error || error.message || `HTTP ${response.status}`);
+  }
+  return response.text();
+}
+
 export interface UserInfo {
   handle: string;
   name: string;
@@ -647,6 +666,52 @@ interface ChatMessage {
   send_date: number;
   character_avatar?: string; // For group chats
 }
+
+// Admin user management types
+export interface AdminUserInfo {
+  handle: string;
+  name: string;
+  avatar: string;
+  admin: boolean;
+  role: import('../types').UserRole;
+  enabled: boolean;
+  created?: number;
+  password: boolean;
+}
+
+export const adminApi = {
+  async getUsers(): Promise<AdminUserInfo[]> {
+    return apiRequest('/api/users/get', { method: 'POST' });
+  },
+
+  async setRole(handle: string, role: import('../types').UserRole): Promise<void> {
+    await apiRequest('/api/users/set-role', {
+      method: 'POST',
+      body: JSON.stringify({ handle, role }),
+    });
+  },
+
+  async enableUser(handle: string): Promise<void> {
+    await apiRequest('/api/users/enable', {
+      method: 'POST',
+      body: JSON.stringify({ handle }),
+    });
+  },
+
+  async disableUser(handle: string): Promise<void> {
+    await apiRequest('/api/users/disable', {
+      method: 'POST',
+      body: JSON.stringify({ handle }),
+    });
+  },
+
+  async deleteUser(handle: string, purge = false): Promise<void> {
+    await apiRequest('/api/users/delete', {
+      method: 'POST',
+      body: JSON.stringify({ handle, purge }),
+    });
+  },
+};
 
 // Invitation types
 export interface Invitation {

--- a/src/api/imageGenApi.ts
+++ b/src/api/imageGenApi.ts
@@ -1,0 +1,74 @@
+import { apiRequest } from './client';
+
+export type ImageGenBackend = 'pollinations' | 'sdwebui';
+
+export interface ImageGenResult {
+  /** Raw base64 string — no data URI prefix. */
+  base64: string;
+  format: string;
+}
+
+export const imageGenApi = {
+  async pingSdWebui(url: string, auth?: string): Promise<boolean> {
+    try {
+      await apiRequest('/api/sd/ping', {
+        method: 'POST',
+        body: JSON.stringify({ url, auth: auth || undefined }),
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  },
+
+  async generatePollinations(opts: {
+    prompt: string;
+    negativePrompt?: string;
+    model?: string;
+    width?: number;
+    height?: number;
+  }): Promise<ImageGenResult> {
+    const result = await apiRequest<{ image: string }>('/api/sd/pollinations/generate', {
+      method: 'POST',
+      body: JSON.stringify({
+        prompt: opts.prompt,
+        negative_prompt: opts.negativePrompt,
+        model: opts.model ?? 'flux',
+        width: opts.width ?? 1024,
+        height: opts.height ?? 1024,
+        seed: -1,
+      }),
+    });
+    return { base64: result.image, format: 'jpg' };
+  },
+
+  async generateSdWebui(opts: {
+    url: string;
+    auth?: string;
+    prompt: string;
+    negativePrompt?: string;
+    width?: number;
+    height?: number;
+    steps?: number;
+    cfgScale?: number;
+  }): Promise<ImageGenResult> {
+    const result = await apiRequest<{ images: string[] }>('/api/sd/generate', {
+      method: 'POST',
+      body: JSON.stringify({
+        url: opts.url,
+        auth: opts.auth || undefined,
+        prompt: opts.prompt,
+        negative_prompt: opts.negativePrompt ?? '',
+        width: opts.width ?? 512,
+        height: opts.height ?? 512,
+        steps: opts.steps ?? 20,
+        cfg_scale: opts.cfgScale ?? 7,
+        seed: -1,
+      }),
+    });
+    if (!result.images || result.images.length === 0) {
+      throw new Error('No images returned from SD WebUI');
+    }
+    return { base64: result.images[0], format: 'png' };
+  },
+};

--- a/src/api/translateApi.ts
+++ b/src/api/translateApi.ts
@@ -1,0 +1,58 @@
+import { apiRequestText } from './client';
+
+export type TranslateProvider =
+  | 'google'
+  | 'bing'
+  | 'lingva'
+  | 'yandex'
+  | 'deepl'
+  | 'deeplx'
+  | 'libre';
+
+export const TRANSLATE_PROVIDERS: { id: TranslateProvider; name: string; free: boolean }[] = [
+  { id: 'google',  name: 'Google',        free: true  },
+  { id: 'bing',    name: 'Bing',          free: true  },
+  { id: 'lingva',  name: 'Lingva',        free: true  },
+  { id: 'yandex',  name: 'Yandex',        free: true  },
+  { id: 'deepl',   name: 'DeepL',         free: false },
+  { id: 'deeplx',  name: 'DeepLX',        free: false },
+  { id: 'libre',   name: 'LibreTranslate', free: false },
+];
+
+export const TRANSLATE_LANGUAGES = [
+  { code: 'en',    label: 'English' },
+  { code: 'es',    label: 'Spanish' },
+  { code: 'fr',    label: 'French' },
+  { code: 'de',    label: 'German' },
+  { code: 'it',    label: 'Italian' },
+  { code: 'pt',    label: 'Portuguese' },
+  { code: 'ru',    label: 'Russian' },
+  { code: 'ja',    label: 'Japanese' },
+  { code: 'ko',    label: 'Korean' },
+  { code: 'zh-CN', label: 'Chinese (Simplified)' },
+  { code: 'zh-TW', label: 'Chinese (Traditional)' },
+  { code: 'ar',    label: 'Arabic' },
+  { code: 'nl',    label: 'Dutch' },
+  { code: 'pl',    label: 'Polish' },
+  { code: 'sv',    label: 'Swedish' },
+  { code: 'tr',    label: 'Turkish' },
+  { code: 'vi',    label: 'Vietnamese' },
+  { code: 'th',    label: 'Thai' },
+  { code: 'hi',    label: 'Hindi' },
+  { code: 'id',    label: 'Indonesian' },
+];
+
+/** Call the ST /api/translate/<provider> endpoint and return the translated string. */
+export async function translateText(
+  text: string,
+  targetLang: string,
+  provider: TranslateProvider = 'google',
+): Promise<string> {
+  // Yandex expects { chunks: string[], lang } instead of { text, lang }
+  const body =
+    provider === 'yandex'
+      ? JSON.stringify({ chunks: [text], lang: targetLang })
+      : JSON.stringify({ text, lang: targetLang });
+
+  return apiRequestText(`/api/translate/${provider}`, { method: 'POST', body });
+}

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
-import { Send, Mic, Paperclip, Square, X } from 'lucide-react';
+import { Send, Mic, Paperclip, Square, X, Image } from 'lucide-react';
 import { Button } from '../ui';
 import {
   compressImageFiles,
@@ -24,6 +24,8 @@ interface ChatInputProps {
   droppedImagesNonce?: number;
   /** Called when the user presses ArrowUp in an empty input — edit last message. */
   onEditLast?: () => void;
+  /** Phase 7.1: open the image generation modal. */
+  onImageGen?: () => void;
 }
 
 /** How long a mic button press must be held before it flips from
@@ -50,6 +52,7 @@ export function ChatInput({
   droppedImages,
   droppedImagesNonce,
   onEditLast,
+  onImageGen,
 }: ChatInputProps) {
   const [message, setMessage] = useState('');
   const [images, setImages] = useState<string[]>([]);
@@ -440,6 +443,22 @@ export function ChatInput({
         >
           <Paperclip size={20} />
         </Button>
+
+        {/* Image Generation Button */}
+        {onImageGen && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="p-2 flex-shrink-0"
+            aria-label="Generate image"
+            title="Generate image with AI"
+            onClick={onImageGen}
+            disabled={disabled || isListening}
+          >
+            <Image size={20} />
+          </Button>
+        )}
 
         {/* Input Area */}
         <div className="flex-1 flex items-end bg-[var(--color-bg-tertiary)] rounded-2xl px-4 py-2">

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect, useMemo } from 'react';
-import { MoreHorizontal, Check, X, Volume2, Square } from 'lucide-react';
+import { MoreHorizontal, Check, X, Volume2, Square, Globe } from 'lucide-react';
 import { Avatar } from '../ui';
 import { MessageActionMenu } from './MessageActionMenu';
 import { SwipeControl } from './SwipeControl';
@@ -8,6 +8,7 @@ import { useSpeechSynthesis } from '../../hooks/useSpeechSynthesis';
 import type { ChatLayoutMode, AvatarShape } from '../../hooks/displayPreferences';
 import { useRegexScriptStore } from '../../stores/regexScriptStore';
 import { applyRegexScripts, getActiveScripts } from '../../utils/regexScripts';
+import { useTranslateStore } from '../../stores/translateStore';
 
 interface ChatMessageProps {
   /** Unique message id — used as TTS tracking key. */
@@ -160,6 +161,14 @@ export function ChatMessage({
   const { isSupported: ttsSupported, isSpeaking, speak, stop } = useSpeechSynthesis();
   const showTtsButton = ttsSupported && !isUser && !isSystem && content.length > 0;
 
+  // Phase 7.2: Translation
+  const showTranslateButton = !isUser && !isSystem && content.length > 0;
+  const translatedText = useTranslateStore((s) => s.cache.get(messageId));
+  const isTranslating = useTranslateStore((s) => s.pending.has(messageId));
+  const showTranslation = useTranslateStore((s) => s.visible.has(messageId));
+  const targetLang = useTranslateStore((s) => s.targetLang);
+  const toggleTranslation = useTranslateStore((s) => s.toggleTranslation);
+
   useEffect(() => {
     if (isEditing && textareaRef.current) {
       textareaRef.current.focus();
@@ -284,6 +293,37 @@ export function ChatMessage({
         >
           {isSpeaking ? <Square size={14} /> : <Volume2 size={14} />}
         </button>
+      )}
+      {showTranslateButton && (
+        <button
+          onClick={() => toggleTranslation(messageId, content)}
+          className={`p-1.5 rounded-lg transition-all ${
+            showTranslation
+              ? 'text-[var(--color-primary)] bg-[var(--color-primary)]/10 opacity-100'
+              : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-tertiary)] opacity-0 group-hover:opacity-100 focus:opacity-100'
+          }`}
+          aria-label={showTranslation ? 'Hide translation' : 'Translate'}
+          title={showTranslation ? 'Hide translation' : 'Translate'}
+        >
+          <Globe size={14} />
+        </button>
+      )}
+    </div>
+  ) : null;
+
+  const translationPanel = showTranslation && !isEditing ? (
+    <div className="mt-2 pt-2 border-t border-[var(--color-border)]/30">
+      <p className="text-[10px] uppercase tracking-wide text-[var(--color-text-secondary)] mb-0.5 select-none">
+        Translated · {targetLang}
+      </p>
+      {isTranslating ? (
+        <p className="text-sm italic text-[var(--color-text-secondary)] animate-pulse">
+          Translating…
+        </p>
+      ) : (
+        <p className="text-sm italic text-[var(--color-text-secondary)] break-words whitespace-pre-wrap">
+          {translatedText}
+        </p>
       )}
     </div>
   ) : null;
@@ -442,6 +482,7 @@ export function ChatMessage({
               {imageGrid}
               {editingUI}
               {messageContent}
+              {translationPanel}
             </div>
           </div>
 
@@ -485,6 +526,7 @@ export function ChatMessage({
             </div>
           ) : messageContent}
         </div>
+        {translationPanel}
 
         {swipeControl}
       </div>
@@ -520,6 +562,7 @@ export function ChatMessage({
               {messageContent}
             </div>
           ) : null}
+          {translationPanel}
         </div>
 
         {actionButtons}

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useMemo, useState, useCallback } from 'react';
-import { MessageSquare, Users, Settings2, Pencil, Square } from 'lucide-react';
+import { MessageSquare, Users, Settings2, Pencil, Square, Search, ChevronUp, ChevronDown, X } from 'lucide-react';
 import { useCharacterStore } from '../../stores/characterStore';
 import { useChatStore } from '../../stores/chatStore';
 import { ChatMessage } from './ChatMessage';
@@ -8,6 +8,8 @@ import { ChatActionBar } from './ChatActionBar';
 import { GroupChatControls } from './GroupChatControls';
 import { AuthorNote } from './AuthorNote';
 import { TypingIndicator } from './TypingIndicator';
+import { ImageGenModal } from './ImageGenModal';
+import { QuickReplyBar } from './QuickReplyBar';
 import { useCharacterSprites } from '../../hooks/useCharacterSprites';
 import {
   getExpressionThumbnailUrl,
@@ -50,6 +52,7 @@ export function ChatView() {
     continueMessage,
     impersonate,
     stopGeneration,
+    insertImageMessage,
     currentChatFile,
     currentSpeakerName,
     setGroupTitle,
@@ -84,7 +87,18 @@ export function ChatView() {
   const [droppedImagesNonce, setDroppedImagesNonce] = useState(0);
   const [editLastNonce, setEditLastNonce] = useState(0);
   const [isDragOver, setIsDragOver] = useState(false);
+  // Phase 7.1: image generation modal
+  const [isImageGenOpen, setIsImageGenOpen] = useState(false);
   const dragCounter = useRef(0);
+
+  // Phase 9.1: in-chat message search
+  const [isSearchOpen, setIsSearchOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [searchMatchIndex, setSearchMatchIndex] = useState(0);
+  const [highlightedMessageId, setHighlightedMessageId] = useState<string | null>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const messageRefsMap = useRef<Map<string, HTMLDivElement>>(new Map());
+  const highlightTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const { getSpritePath, availableEmotions } = useCharacterSprites(selectedCharacter?.avatar);
 
@@ -109,6 +123,22 @@ export function ChatView() {
     () => messages.some((m) => !m.isUser && !m.isSystem),
     [messages]
   );
+
+  // Phase 9.1: IDs of messages matching the search query (excludes system messages)
+  const searchMatchIds = useMemo(() => {
+    if (!searchQuery.trim()) return [];
+    const q = searchQuery.toLowerCase();
+    return messages
+      .filter((m) => !m.isSystem && m.content.toLowerCase().includes(q))
+      .map((m) => m.id);
+  }, [messages, searchQuery]);
+
+  // Messages to actually render — filtered when search is active
+  const displayedMessages = useMemo(() => {
+    if (!isSearchOpen || !searchQuery.trim()) return messages;
+    const matchSet = new Set(searchMatchIds);
+    return messages.filter((m) => matchSet.has(m.id));
+  }, [isSearchOpen, searchQuery, messages, searchMatchIds]);
 
   const getAvatarUrl = useCallback(
     (avatar: string, emotion?: Emotion | null) => {
@@ -136,6 +166,56 @@ export function ChatView() {
     },
     [getSpritePath, failedExpressions]
   );
+
+  // Phase 9.1: focus the search input when the bar opens
+  useEffect(() => {
+    if (!isSearchOpen) return;
+    const t = setTimeout(() => searchInputRef.current?.focus(), 60);
+    return () => clearTimeout(t);
+  }, [isSearchOpen]);
+
+  // Phase 9.1: auto-navigate to first match when query changes
+  useEffect(() => {
+    setSearchMatchIndex(0);
+    if (searchMatchIds.length > 0) {
+      const messageId = searchMatchIds[0];
+      if (highlightTimerRef.current) clearTimeout(highlightTimerRef.current);
+      setHighlightedMessageId(messageId);
+      highlightTimerRef.current = setTimeout(() => setHighlightedMessageId(null), 1200);
+      // Delay scroll slightly to allow filtered list to render
+      setTimeout(() => {
+        messageRefsMap.current.get(messageId)?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      }, 60);
+    } else {
+      setHighlightedMessageId(null);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchQuery]);
+
+  const navigateToMatch = useCallback(
+    (direction: 1 | -1) => {
+      if (searchMatchIds.length === 0) return;
+      const nextIdx = (searchMatchIndex + direction + searchMatchIds.length) % searchMatchIds.length;
+      setSearchMatchIndex(nextIdx);
+      const messageId = searchMatchIds[nextIdx];
+      messageRefsMap.current.get(messageId)?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      if (highlightTimerRef.current) clearTimeout(highlightTimerRef.current);
+      setHighlightedMessageId(messageId);
+      highlightTimerRef.current = setTimeout(() => setHighlightedMessageId(null), 1200);
+    },
+    [searchMatchIds, searchMatchIndex]
+  );
+
+  const openSearch = useCallback(() => setIsSearchOpen(true), []);
+
+  const closeSearch = useCallback(() => {
+    setIsSearchOpen(false);
+    setSearchQuery('');
+    setSearchMatchIndex(0);
+    setHighlightedMessageId(null);
+    if (highlightTimerRef.current) clearTimeout(highlightTimerRef.current);
+    setTimeout(() => messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' }), 60);
+  }, []);
 
   useEffect(() => {
     if (!selectedCharacter) return;
@@ -170,10 +250,12 @@ export function ChatView() {
 
   // Auto-scroll: always scroll on new user messages or when streaming starts,
   // but during ongoing streaming only scroll if the user hasn't scrolled up.
+  // Suppressed while search is open (navigation controls scroll instead).
   useEffect(() => {
+    if (isSearchOpen) return;
     if (!isNearBottomRef.current && isStreaming) return;
     messagesEndRef.current?.scrollIntoView({ behavior: isStreaming ? 'auto' : 'smooth' });
-  }, [messages, isStreaming]);
+  }, [messages, isStreaming, isSearchOpen]);
 
   // Phase 6.3: Auto-read — speak the last AI message when streaming completes.
   const wasStreamingRef = useRef(false);
@@ -363,6 +445,14 @@ export function ChatView() {
                 </p>
               </div>
               <button
+                onClick={openSearch}
+                className="p-1.5 rounded-full text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-tertiary)] transition-colors"
+                aria-label="Search messages"
+                title="Search messages"
+              >
+                <Search size={18} />
+              </button>
+              <button
                 onClick={() => setShowGroupControls((v) => !v)}
                 className={`p-1.5 rounded-full transition-colors ${
                   showGroupControls
@@ -392,32 +482,118 @@ export function ChatView() {
           )}
         </>
       ) : selectedCharacter ? (
-        <div className="lg:hidden h-[30vh] min-h-[150px] max-h-[250px] relative bg-gradient-to-b from-[var(--color-bg-tertiary)] to-[var(--color-bg-primary)] overflow-hidden">
-          <img
-            key={`${selectedCharacter.avatar}-${latestEmotion ?? 'neutral'}`}
-            src={getFullImageUrl(selectedCharacter.avatar, latestEmotion)}
-            alt={selectedCharacter.name}
-            className="w-full h-full object-cover object-top transition-opacity duration-300"
-            onError={() => {
-              if (latestEmotion) {
-                const expressionKey = `${selectedCharacter.avatar}-${latestEmotion}`;
-                setFailedExpressions((prev) => new Set(prev).add(expressionKey));
-              }
-            }}
-          />
-          <div className="absolute inset-x-0 bottom-0 h-16 bg-gradient-to-t from-[var(--color-bg-primary)] to-transparent" />
-          <div className="absolute bottom-2 left-4 right-4 flex items-center justify-between">
-            <h2 className="text-lg font-semibold text-[var(--color-text-primary)] drop-shadow-lg">
+        <>
+          {/* Mobile: character portrait */}
+          <div className="lg:hidden h-[30vh] min-h-[150px] max-h-[250px] relative bg-gradient-to-b from-[var(--color-bg-tertiary)] to-[var(--color-bg-primary)] overflow-hidden">
+            <img
+              key={`${selectedCharacter.avatar}-${latestEmotion ?? 'neutral'}`}
+              src={getFullImageUrl(selectedCharacter.avatar, latestEmotion)}
+              alt={selectedCharacter.name}
+              className="w-full h-full object-cover object-top transition-opacity duration-300"
+              onError={() => {
+                if (latestEmotion) {
+                  const expressionKey = `${selectedCharacter.avatar}-${latestEmotion}`;
+                  setFailedExpressions((prev) => new Set(prev).add(expressionKey));
+                }
+              }}
+            />
+            <div className="absolute inset-x-0 bottom-0 h-16 bg-gradient-to-t from-[var(--color-bg-primary)] to-transparent" />
+            <div className="absolute bottom-2 left-4 right-4 flex items-center justify-between">
+              <h2 className="text-lg font-semibold text-[var(--color-text-primary)] drop-shadow-lg">
+                {selectedCharacter.name}
+              </h2>
+              <div className="flex items-center gap-2">
+                {latestEmotion && (
+                  <span className="text-xs px-2 py-1 rounded-full bg-black/30 text-white/80 backdrop-blur-sm capitalize">
+                    {latestEmotion}
+                  </span>
+                )}
+                <button
+                  onClick={openSearch}
+                  className="p-1.5 rounded-full bg-black/30 text-white/80 backdrop-blur-sm hover:bg-black/50 transition-colors"
+                  aria-label="Search messages"
+                  title="Search messages"
+                >
+                  <Search size={15} />
+                </button>
+              </div>
+            </div>
+          </div>
+          {/* Desktop: compact header bar */}
+          <div className="hidden lg:flex items-center gap-3 px-4 h-12 border-b border-[var(--color-border)] flex-shrink-0 bg-[var(--color-bg-secondary)]">
+            <h2 className="text-sm font-semibold text-[var(--color-text-primary)] flex-1 truncate">
               {selectedCharacter.name}
             </h2>
-            {latestEmotion && (
-              <span className="text-xs px-2 py-1 rounded-full bg-black/30 text-white/80 backdrop-blur-sm capitalize">
-                {latestEmotion}
-              </span>
-            )}
+            <button
+              onClick={openSearch}
+              className="p-1.5 rounded-md text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-tertiary)] hover:text-[var(--color-text-primary)] transition-colors"
+              aria-label="Search messages"
+              title="Search messages"
+            >
+              <Search size={18} />
+            </button>
           </div>
-        </div>
+        </>
       ) : null}
+
+      {/* Phase 9.1: Search bar — slides in below the header */}
+      <div
+        className={`overflow-hidden transition-[max-height] duration-200 ease-in-out flex-shrink-0 ${
+          isSearchOpen ? 'max-h-14' : 'max-h-0'
+        }`}
+      >
+        <div className="flex items-center gap-1.5 px-3 py-2 bg-[var(--color-bg-secondary)] border-b border-[var(--color-border)]">
+          <Search size={15} className="text-[var(--color-text-secondary)] flex-shrink-0" />
+          <input
+            ref={searchInputRef}
+            type="text"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Escape') closeSearch();
+              else if (e.key === 'Enter' || e.key === 'ArrowDown') {
+                e.preventDefault();
+                navigateToMatch(1);
+              } else if (e.key === 'ArrowUp') {
+                e.preventDefault();
+                navigateToMatch(-1);
+              }
+            }}
+            placeholder="Search messages…"
+            className="flex-1 min-w-0 bg-transparent text-sm text-[var(--color-text-primary)] placeholder:text-[var(--color-text-secondary)] focus:outline-none"
+          />
+          {searchQuery.trim() && (
+            <span className="text-xs text-[var(--color-text-secondary)] whitespace-nowrap flex-shrink-0">
+              {searchMatchIds.length > 0
+                ? `${searchMatchIndex + 1} of ${searchMatchIds.length}`
+                : 'No results'}
+            </span>
+          )}
+          <button
+            onClick={() => navigateToMatch(-1)}
+            disabled={searchMatchIds.length === 0}
+            className="p-1 text-[var(--color-text-secondary)] disabled:opacity-30 hover:text-[var(--color-text-primary)] transition-colors"
+            aria-label="Previous match"
+          >
+            <ChevronUp size={16} />
+          </button>
+          <button
+            onClick={() => navigateToMatch(1)}
+            disabled={searchMatchIds.length === 0}
+            className="p-1 text-[var(--color-text-secondary)] disabled:opacity-30 hover:text-[var(--color-text-primary)] transition-colors"
+            aria-label="Next match"
+          >
+            <ChevronDown size={16} />
+          </button>
+          <button
+            onClick={closeSearch}
+            className="p-1 text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors"
+            aria-label="Close search"
+          >
+            <X size={16} />
+          </button>
+        </div>
+      </div>
 
       {/* Messages Area */}
       <div
@@ -459,7 +635,7 @@ export function ChatView() {
           </div>
         ) : (
           <div className="py-4">
-            {messages.map((message) => {
+            {displayedMessages.map((message) => {
               const messageAvatar = message.isUser
                 ? undefined
                 : isGroupChatMode && message.characterAvatar
@@ -477,47 +653,59 @@ export function ChatView() {
                 (isLastAiMessage || message.swipes.length > 1);
 
               return (
-                <ChatMessage
+                <div
                   key={message.id}
-                  messageId={message.id}
-                  name={message.name}
-                  content={message.content}
-                  isUser={message.isUser}
-                  isSystem={message.isSystem}
-                  avatar={messageAvatar}
-                  timestamp={message.timestamp}
-                  disabled={isSending}
-                  images={message.images}
-                  characterAvatar={message.isUser ? selectedCharacter?.avatar : (message.characterAvatar || selectedCharacter?.avatar)}
-                  isStreaming={isLastAiMessage && isStreaming}
-                  layoutMode={chatLayoutMode}
-                  avatarShape={avatarShapePref}
-                  fontSize={chatFontSize}
-                  chatMaxWidth={chatMaxWidth}
-                  swipes={message.swipes}
-                  swipeId={message.swipeId}
-                  showSwipeControl={showSwipeControl}
-                  canGenerateSwipe={isLastAiMessage}
-                  onSwipeLeft={() => handleSwipeLeft(message.id)}
-                  onSwipeRight={() => handleSwipeRight(message.id)}
-                  onEdit={(newContent) => editMessage(message.id, newContent)}
-                  onEditAndRegenerate={
-                    message.isUser && selectedCharacter && !isGroupChatMode
-                      ? (newContent) =>
-                          editMessageAndRegenerate(
-                            message.id,
-                            newContent,
-                            selectedCharacter,
-                            availableEmotions
-                          )
-                      : undefined
-                  }
-                  onDelete={() => deleteMessage(message.id)}
-                  onRegenerate={
-                    isLastAiMessage && !isGroupChatMode ? handleRegenerate : undefined
-                  }
-                  triggerEditNonce={message.id === lastUserMessageId ? editLastNonce : undefined}
-                />
+                  ref={(el) => {
+                    if (el) messageRefsMap.current.set(message.id, el);
+                    else messageRefsMap.current.delete(message.id);
+                  }}
+                  className={`transition-colors duration-500 ${
+                    message.id === highlightedMessageId
+                      ? 'bg-[var(--color-primary)]/10'
+                      : ''
+                  }`}
+                >
+                  <ChatMessage
+                    messageId={message.id}
+                    name={message.name}
+                    content={message.content}
+                    isUser={message.isUser}
+                    isSystem={message.isSystem}
+                    avatar={messageAvatar}
+                    timestamp={message.timestamp}
+                    disabled={isSending}
+                    images={message.images}
+                    characterAvatar={message.isUser ? selectedCharacter?.avatar : (message.characterAvatar || selectedCharacter?.avatar)}
+                    isStreaming={isLastAiMessage && isStreaming}
+                    layoutMode={chatLayoutMode}
+                    avatarShape={avatarShapePref}
+                    fontSize={chatFontSize}
+                    chatMaxWidth={chatMaxWidth}
+                    swipes={message.swipes}
+                    swipeId={message.swipeId}
+                    showSwipeControl={showSwipeControl}
+                    canGenerateSwipe={isLastAiMessage}
+                    onSwipeLeft={() => handleSwipeLeft(message.id)}
+                    onSwipeRight={() => handleSwipeRight(message.id)}
+                    onEdit={(newContent) => editMessage(message.id, newContent)}
+                    onEditAndRegenerate={
+                      message.isUser && selectedCharacter && !isGroupChatMode
+                        ? (newContent) =>
+                            editMessageAndRegenerate(
+                              message.id,
+                              newContent,
+                              selectedCharacter,
+                              availableEmotions
+                            )
+                        : undefined
+                    }
+                    onDelete={() => deleteMessage(message.id)}
+                    onRegenerate={
+                      isLastAiMessage && !isGroupChatMode ? handleRegenerate : undefined
+                    }
+                    triggerEditNonce={message.id === lastUserMessageId ? editLastNonce : undefined}
+                  />
+                </div>
               );
             })}
 
@@ -565,6 +753,13 @@ export function ChatView() {
       {/* Phase 8.1: Author's Note — collapsible panel for per-chat instructions */}
       {currentChatFile && <AuthorNote fileName={currentChatFile} />}
 
+      {/* Phase 10.2: Quick Reply Bar */}
+      <QuickReplyBar
+        onPrefill={(text) => { setPrefillText(text); setPrefillNonce((n) => n + 1); }}
+        onSend={handleSend}
+        disabled={isSending}
+      />
+
       {/* Input Area */}
       <ChatInput
         onSend={handleSend}
@@ -575,7 +770,26 @@ export function ChatView() {
         droppedImages={droppedImages}
         droppedImagesNonce={droppedImagesNonce}
         onEditLast={lastUserMessageId && !isSending ? () => setEditLastNonce((n) => n + 1) : undefined}
+        onImageGen={!isGroupChatMode && selectedCharacter ? () => setIsImageGenOpen(true) : undefined}
       />
+
+      {/* Phase 7.1: Image generation modal */}
+      {selectedCharacter && (
+        <ImageGenModal
+          isOpen={isImageGenOpen}
+          onClose={() => setIsImageGenOpen(false)}
+          initialPrompt={selectedCharacter.name}
+          onInsert={async (dataUrl, prompt) => {
+            await insertImageMessage(
+              dataUrl,
+              prompt,
+              selectedCharacter.name,
+              selectedCharacter.avatar,
+              selectedCharacter
+            );
+          }}
+        />
+      )}
 
       {/* Manual-strategy hint: auto-pick is disabled, so user has to force-talk. */}
       {isGroupChatMode &&

--- a/src/components/chat/ImageGenModal.tsx
+++ b/src/components/chat/ImageGenModal.tsx
@@ -1,0 +1,373 @@
+import { useState, useRef, useEffect } from 'react';
+import { X, Image, Settings2, ChevronDown, ChevronUp, Loader2, RefreshCw } from 'lucide-react';
+import { useImageGenStore } from '../../stores/imageGenStore';
+import { Button } from '../ui';
+import type { ImageGenBackend } from '../../api/imageGenApi';
+
+interface ImageGenModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  /** Called with the generated image data URL once the user confirms insertion. */
+  onInsert: (dataUrl: string, prompt: string) => void;
+  /** Optional prompt pre-fill (e.g. character name). */
+  initialPrompt?: string;
+}
+
+const POLLINATIONS_MODELS = [
+  'flux',
+  'flux-realism',
+  'flux-cablyai',
+  'flux-anime',
+  'flux-3d',
+  'turbo',
+];
+
+const SIZE_PRESETS = [
+  { label: 'Square 1024×1024', width: 1024, height: 1024 },
+  { label: 'Portrait 768×1024', width: 768, height: 1024 },
+  { label: 'Landscape 1024×768', width: 1024, height: 768 },
+  { label: 'SD Square 512×512', width: 512, height: 512 },
+  { label: 'SD Portrait 512×768', width: 512, height: 768 },
+  { label: 'SD Landscape 768×512', width: 768, height: 512 },
+];
+
+export function ImageGenModal({ isOpen, onClose, onInsert, initialPrompt = '' }: ImageGenModalProps) {
+  const {
+    backend,
+    sdUrl,
+    sdAuth,
+    pollinationsModel,
+    width,
+    height,
+    steps,
+    cfgScale,
+    isGenerating,
+    error,
+    setConfig,
+    generate,
+    clearError,
+  } = useImageGenStore();
+
+  const [prompt, setPrompt] = useState(initialPrompt);
+  const [negativePrompt, setNegativePrompt] = useState('');
+  const [showNeg, setShowNeg] = useState(false);
+  const [showSettings, setShowSettings] = useState(false);
+  const [result, setResult] = useState<string | null>(null);
+  const promptRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      setPrompt(initialPrompt);
+      setResult(null);
+      clearError();
+      // Delay focus so the animation doesn't fight autofocus.
+      const t = setTimeout(() => promptRef.current?.focus(), 60);
+      return () => clearTimeout(t);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  const handleGenerate = async () => {
+    if (!prompt.trim() || isGenerating) return;
+    setResult(null);
+    const dataUrl = await generate(prompt.trim(), negativePrompt.trim() || undefined);
+    if (dataUrl) setResult(dataUrl);
+  };
+
+  const handleInsert = () => {
+    if (!result) return;
+    onInsert(result, prompt.trim());
+    setResult(null);
+    onClose();
+  };
+
+  const handleModalKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') onClose();
+  };
+
+  const handlePromptKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && (e.ctrlKey || e.metaKey) && !result) {
+      e.preventDefault();
+      handleGenerate();
+    }
+  };
+
+  const sizeKey = `${width}x${height}`;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center"
+      onKeyDown={handleModalKeyDown}
+    >
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Panel */}
+      <div className="relative w-full sm:max-w-lg bg-[var(--color-bg-secondary)] rounded-t-2xl sm:rounded-2xl shadow-2xl flex flex-col max-h-[90dvh] overflow-hidden">
+
+        {/* Header */}
+        <div className="flex items-center gap-3 px-4 py-3 border-b border-[var(--color-border)] flex-shrink-0">
+          <Image size={18} className="text-[var(--color-primary)]" />
+          <h2 className="flex-1 text-base font-semibold text-[var(--color-text-primary)]">
+            Generate Image
+          </h2>
+          <button
+            onClick={onClose}
+            className="p-1.5 rounded-lg text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-tertiary)] transition-colors"
+            aria-label="Close"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        {/* Scrollable body */}
+        <div className="flex-1 overflow-y-auto p-4 space-y-3 min-h-0">
+
+          {/* Prompt */}
+          <div>
+            <label className="block text-xs font-medium text-[var(--color-text-secondary)] mb-1">
+              Prompt <span className="text-zinc-500 font-normal">(Ctrl+Enter to generate)</span>
+            </label>
+            <textarea
+              ref={promptRef}
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+              onKeyDown={handlePromptKeyDown}
+              placeholder="Describe the image you want to generate…"
+              rows={3}
+              className="w-full bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] rounded-xl px-3 py-2 text-sm text-[var(--color-text-primary)] placeholder-zinc-500 resize-none focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]/40"
+            />
+          </div>
+
+          {/* Negative prompt toggle */}
+          <button
+            type="button"
+            onClick={() => setShowNeg((v) => !v)}
+            className="flex items-center gap-1 text-xs text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors"
+          >
+            {showNeg ? <ChevronUp size={13} /> : <ChevronDown size={13} />}
+            Negative prompt
+          </button>
+          {showNeg && (
+            <textarea
+              value={negativePrompt}
+              onChange={(e) => setNegativePrompt(e.target.value)}
+              placeholder="Things to exclude from the image…"
+              rows={2}
+              className="w-full bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] rounded-xl px-3 py-2 text-sm text-[var(--color-text-primary)] placeholder-zinc-500 resize-none focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]/40"
+            />
+          )}
+
+          {/* Settings toggle */}
+          <button
+            type="button"
+            onClick={() => setShowSettings((v) => !v)}
+            className="flex items-center gap-1.5 text-xs text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors"
+          >
+            <Settings2 size={13} />
+            {showSettings ? <ChevronUp size={13} /> : <ChevronDown size={13} />}
+            Settings
+          </button>
+
+          {showSettings && (
+            <div className="space-y-3 p-3 bg-[var(--color-bg-tertiary)] rounded-xl border border-[var(--color-border)]">
+
+              {/* Backend */}
+              <div>
+                <label className="block text-xs font-medium text-[var(--color-text-secondary)] mb-1">
+                  Backend
+                </label>
+                <select
+                  value={backend}
+                  onChange={(e) => setConfig({ backend: e.target.value as ImageGenBackend })}
+                  className="w-full bg-[var(--color-bg-secondary)] border border-[var(--color-border)] rounded-lg px-2 py-1.5 text-sm text-[var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]/40"
+                >
+                  <option value="pollinations">Pollinations (free, no setup)</option>
+                  <option value="sdwebui">SD WebUI (local)</option>
+                </select>
+              </div>
+
+              {/* Pollinations model */}
+              {backend === 'pollinations' && (
+                <div>
+                  <label className="block text-xs font-medium text-[var(--color-text-secondary)] mb-1">
+                    Model
+                  </label>
+                  <select
+                    value={pollinationsModel}
+                    onChange={(e) => setConfig({ pollinationsModel: e.target.value })}
+                    className="w-full bg-[var(--color-bg-secondary)] border border-[var(--color-border)] rounded-lg px-2 py-1.5 text-sm text-[var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]/40"
+                  >
+                    {POLLINATIONS_MODELS.map((m) => (
+                      <option key={m} value={m}>{m}</option>
+                    ))}
+                  </select>
+                </div>
+              )}
+
+              {/* SD WebUI fields */}
+              {backend === 'sdwebui' && (
+                <>
+                  <div>
+                    <label className="block text-xs font-medium text-[var(--color-text-secondary)] mb-1">
+                      SD WebUI URL
+                    </label>
+                    <input
+                      type="text"
+                      value={sdUrl}
+                      onChange={(e) => setConfig({ sdUrl: e.target.value })}
+                      placeholder="http://localhost:7860"
+                      className="w-full bg-[var(--color-bg-secondary)] border border-[var(--color-border)] rounded-lg px-2 py-1.5 text-sm text-[var(--color-text-primary)] placeholder-zinc-500 focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]/40"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-xs font-medium text-[var(--color-text-secondary)] mb-1">
+                      Auth <span className="font-normal text-zinc-500">(optional, user:pass)</span>
+                    </label>
+                    <input
+                      type="text"
+                      value={sdAuth}
+                      onChange={(e) => setConfig({ sdAuth: e.target.value })}
+                      placeholder="username:password"
+                      className="w-full bg-[var(--color-bg-secondary)] border border-[var(--color-border)] rounded-lg px-2 py-1.5 text-sm text-[var(--color-text-primary)] placeholder-zinc-500 focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]/40"
+                    />
+                  </div>
+                  <div className="grid grid-cols-2 gap-2">
+                    <div>
+                      <label className="block text-xs font-medium text-[var(--color-text-secondary)] mb-1">
+                        Steps
+                      </label>
+                      <input
+                        type="number"
+                        min={1}
+                        max={150}
+                        value={steps}
+                        onChange={(e) =>
+                          setConfig({ steps: Math.max(1, Math.min(150, parseInt(e.target.value) || 20)) })
+                        }
+                        className="w-full bg-[var(--color-bg-secondary)] border border-[var(--color-border)] rounded-lg px-2 py-1.5 text-sm text-[var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]/40"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-xs font-medium text-[var(--color-text-secondary)] mb-1">
+                        CFG Scale
+                      </label>
+                      <input
+                        type="number"
+                        min={1}
+                        max={30}
+                        step={0.5}
+                        value={cfgScale}
+                        onChange={(e) =>
+                          setConfig({ cfgScale: Math.max(1, Math.min(30, parseFloat(e.target.value) || 7)) })
+                        }
+                        className="w-full bg-[var(--color-bg-secondary)] border border-[var(--color-border)] rounded-lg px-2 py-1.5 text-sm text-[var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]/40"
+                      />
+                    </div>
+                  </div>
+                </>
+              )}
+
+              {/* Size */}
+              <div>
+                <label className="block text-xs font-medium text-[var(--color-text-secondary)] mb-1">
+                  Size
+                </label>
+                <select
+                  value={sizeKey}
+                  onChange={(e) => {
+                    const preset = SIZE_PRESETS.find((p) => `${p.width}x${p.height}` === e.target.value);
+                    if (preset) setConfig({ width: preset.width, height: preset.height });
+                  }}
+                  className="w-full bg-[var(--color-bg-secondary)] border border-[var(--color-border)] rounded-lg px-2 py-1.5 text-sm text-[var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]/40"
+                >
+                  {SIZE_PRESETS.map((p) => {
+                    const key = `${p.width}x${p.height}`;
+                    return (
+                      <option key={key} value={key}>
+                        {p.label}
+                      </option>
+                    );
+                  })}
+                  {!SIZE_PRESETS.find((p) => p.width === width && p.height === height) && (
+                    <option value={sizeKey}>Custom {width}×{height}</option>
+                  )}
+                </select>
+              </div>
+            </div>
+          )}
+
+          {/* Error */}
+          {error && (
+            <div className="p-3 rounded-lg bg-red-500/10 border border-red-500/30">
+              <p className="text-xs text-red-400">{error}</p>
+            </div>
+          )}
+
+          {/* Result preview */}
+          {result && (
+            <div className="rounded-xl overflow-hidden border border-[var(--color-border)]">
+              <img
+                src={result}
+                alt="Generated"
+                className="w-full h-auto block max-h-80 object-contain bg-[var(--color-bg-tertiary)]"
+              />
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="px-4 py-3 border-t border-[var(--color-border)] flex gap-2 flex-shrink-0">
+          {result ? (
+            <>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="flex items-center gap-1.5"
+                onClick={() => { setResult(null); clearError(); handleGenerate(); }}
+                disabled={isGenerating}
+              >
+                <RefreshCw size={15} />
+                Retry
+              </Button>
+              <Button
+                variant="primary"
+                size="sm"
+                className="flex-1"
+                onClick={handleInsert}
+              >
+                Insert into chat
+              </Button>
+            </>
+          ) : (
+            <Button
+              variant="primary"
+              size="sm"
+              className="flex-1 flex items-center justify-center gap-2"
+              onClick={handleGenerate}
+              disabled={!prompt.trim() || isGenerating}
+            >
+              {isGenerating ? (
+                <>
+                  <Loader2 size={15} className="animate-spin" />
+                  Generating…
+                </>
+              ) : (
+                <>
+                  <Image size={15} />
+                  Generate
+                </>
+              )}
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/chat/QuickReplyBar.tsx
+++ b/src/components/chat/QuickReplyBar.tsx
@@ -1,0 +1,97 @@
+import { useRef } from 'react';
+import { useQuickReplyStore } from '../../stores/quickReplyStore';
+
+interface QuickReplyBarProps {
+  onPrefill: (text: string) => void;
+  onSend: (text: string) => void;
+  disabled?: boolean;
+}
+
+const LONG_PRESS_MS = 400;
+
+export function QuickReplyBar({ onPrefill, onSend, disabled = false }: QuickReplyBarProps) {
+  const sets = useQuickReplyStore((s) => s.sets);
+  const activeSetId = useQuickReplyStore((s) => s.activeSetId);
+
+  const activeSet = activeSetId ? sets.find((s) => s.id === activeSetId) : null;
+
+  if (!activeSet || activeSet.entries.length === 0) return null;
+
+  return (
+    <div
+      className="flex gap-2 overflow-x-auto px-3 py-2 border-t border-[var(--color-border)] bg-[var(--color-bg-secondary)]"
+      style={{ scrollbarWidth: 'none' }}
+      aria-label="Quick replies"
+    >
+      {activeSet.entries.map((entry) => (
+        <QuickReplyPill
+          key={entry.id}
+          label={entry.label}
+          message={entry.message}
+          onPrefill={onPrefill}
+          onSend={onSend}
+          disabled={disabled}
+        />
+      ))}
+    </div>
+  );
+}
+
+interface PillProps {
+  label: string;
+  message: string;
+  onPrefill: (text: string) => void;
+  onSend: (text: string) => void;
+  disabled: boolean;
+}
+
+function QuickReplyPill({ label, message, onPrefill, onSend, disabled }: PillProps) {
+  const timerRef = useRef<number | null>(null);
+  const firedRef = useRef(false);
+
+  const clearTimer = () => {
+    if (timerRef.current !== null) {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  };
+
+  const handlePointerDown = (e: React.PointerEvent) => {
+    if (disabled || e.button !== 0) return;
+    firedRef.current = false;
+    clearTimer();
+    timerRef.current = window.setTimeout(() => {
+      firedRef.current = true;
+      onSend(message);
+    }, LONG_PRESS_MS);
+  };
+
+  const handlePointerUp = () => {
+    clearTimer();
+    if (!firedRef.current && !disabled) {
+      onPrefill(message);
+    }
+    firedRef.current = false;
+  };
+
+  const handlePointerCancel = () => {
+    clearTimer();
+    firedRef.current = false;
+  };
+
+  return (
+    <button
+      type="button"
+      onPointerDown={handlePointerDown}
+      onPointerUp={handlePointerUp}
+      onPointerCancel={handlePointerCancel}
+      onPointerLeave={handlePointerCancel}
+      onContextMenu={(e) => e.preventDefault()}
+      disabled={disabled}
+      className="flex-shrink-0 px-3 py-1 rounded-full text-xs font-medium border border-[var(--color-border)] bg-[var(--color-bg-tertiary)] text-[var(--color-text-primary)] hover:bg-[var(--color-primary)]/10 hover:border-[var(--color-primary)]/40 active:scale-95 transition-all touch-none select-none disabled:opacity-40"
+      title={`Tap to prefill · hold to send: ${message}`}
+    >
+      {label}
+    </button>
+  );
+}

--- a/src/components/settings/QuickReplyPage.tsx
+++ b/src/components/settings/QuickReplyPage.tsx
@@ -1,0 +1,402 @@
+import { useState } from 'react';
+import { ArrowLeft, ChevronRight, ChevronDown, ChevronUp, Plus, Pencil, Trash2, Check, X, Zap } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { useQuickReplyStore, type QuickReplyEntry } from '../../stores/quickReplyStore';
+import { Button, Input } from '../ui';
+
+export function QuickReplyPage() {
+  const navigate = useNavigate();
+  const {
+    sets,
+    activeSetId,
+    setActiveSet,
+    createSet,
+    renameSet,
+    deleteSet,
+    addEntry,
+    updateEntry,
+    deleteEntry,
+    moveEntryUp,
+    moveEntryDown,
+  } = useQuickReplyStore();
+
+  // null = set list view; string = entry list view for that set id
+  const [viewSetId, setViewSetId] = useState<string | null>(null);
+  const [newSetName, setNewSetName] = useState('');
+  const [isAddingSet, setIsAddingSet] = useState(false);
+  const [renamingSetId, setRenamingSetId] = useState<string | null>(null);
+  const [renameDraft, setRenameDraft] = useState('');
+
+  // Entry editing state
+  const [editingEntryId, setEditingEntryId] = useState<string | null>(null);
+  const [isAddingEntry, setIsAddingEntry] = useState(false);
+  const [entryLabelDraft, setEntryLabelDraft] = useState('');
+  const [entryMessageDraft, setEntryMessageDraft] = useState('');
+
+  const currentSet = viewSetId ? sets.find((s) => s.id === viewSetId) ?? null : null;
+
+  // ── Helpers ────────────────────────────────────────────────────
+
+  const handleCreateSet = () => {
+    const name = newSetName.trim();
+    if (!name) return;
+    createSet(name);
+    setNewSetName('');
+    setIsAddingSet(false);
+  };
+
+  const startRename = (id: string, currentName: string) => {
+    setRenamingSetId(id);
+    setRenameDraft(currentName);
+  };
+
+  const commitRename = () => {
+    if (renamingSetId) renameSet(renamingSetId, renameDraft);
+    setRenamingSetId(null);
+    setRenameDraft('');
+  };
+
+  const handleDeleteSet = (id: string) => {
+    deleteSet(id);
+    if (viewSetId === id) setViewSetId(null);
+  };
+
+  const startAddEntry = () => {
+    setEditingEntryId(null);
+    setEntryLabelDraft('');
+    setEntryMessageDraft('');
+    setIsAddingEntry(true);
+  };
+
+  const startEditEntry = (entry: QuickReplyEntry) => {
+    setIsAddingEntry(false);
+    setEditingEntryId(entry.id);
+    setEntryLabelDraft(entry.label);
+    setEntryMessageDraft(entry.message);
+  };
+
+  const commitEntry = () => {
+    if (!viewSetId) return;
+    const label = entryLabelDraft.trim();
+    const message = entryMessageDraft;
+    if (!label || !message.trim()) return;
+    if (isAddingEntry) {
+      addEntry(viewSetId, label, message);
+      setIsAddingEntry(false);
+    } else if (editingEntryId) {
+      updateEntry(viewSetId, editingEntryId, label, message);
+      setEditingEntryId(null);
+    }
+    setEntryLabelDraft('');
+    setEntryMessageDraft('');
+  };
+
+  const cancelEntry = () => {
+    setIsAddingEntry(false);
+    setEditingEntryId(null);
+    setEntryLabelDraft('');
+    setEntryMessageDraft('');
+  };
+
+  // ── Entry form (shared for add + edit) ───────────────────────
+
+  const EntryForm = () => (
+    <div className="bg-[var(--color-bg-tertiary)] rounded-lg p-3 space-y-2">
+      <Input
+        value={entryLabelDraft}
+        onChange={(e) => setEntryLabelDraft(e.target.value)}
+        placeholder="Button label (e.g. Hello!)"
+        className="text-sm"
+        autoFocus
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') e.preventDefault();
+          if (e.key === 'Escape') cancelEntry();
+        }}
+      />
+      <textarea
+        value={entryMessageDraft}
+        onChange={(e) => setEntryMessageDraft(e.target.value)}
+        placeholder="Message text sent to the AI…"
+        rows={3}
+        className="w-full bg-[var(--color-bg-secondary)] text-sm text-[var(--color-text-primary)] placeholder:text-[var(--color-text-secondary)] rounded-lg px-3 py-2 resize-none focus:outline-none border border-[var(--color-border)] focus:border-[var(--color-primary)]"
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') cancelEntry();
+        }}
+      />
+      <div className="flex gap-2 justify-end">
+        <Button type="button" variant="ghost" size="sm" onClick={cancelEntry}>
+          Cancel
+        </Button>
+        <Button
+          type="button"
+          variant="primary"
+          size="sm"
+          onClick={commitEntry}
+          disabled={!entryLabelDraft.trim() || !entryMessageDraft.trim()}
+        >
+          Save
+        </Button>
+      </div>
+    </div>
+  );
+
+  // ── Entry list view ────────────────────────────────────────────
+
+  if (currentSet) {
+    return (
+      <div className="min-h-screen bg-[var(--color-bg-primary)]">
+        <header className="h-14 bg-[var(--color-bg-secondary)] border-b border-[var(--color-border)] flex items-center px-4 gap-3 safe-top">
+          <Button variant="ghost" size="sm" className="p-2" onClick={() => setViewSetId(null)} aria-label="Back">
+            <ArrowLeft size={24} />
+          </Button>
+          <h1 className="text-lg font-semibold text-[var(--color-text-primary)] flex-1 truncate">
+            {currentSet.name}
+          </h1>
+          <Button type="button" variant="ghost" size="sm" className="p-2" onClick={startAddEntry} aria-label="Add entry">
+            <Plus size={20} />
+          </Button>
+        </header>
+
+        <div className="max-w-2xl mx-auto p-4 space-y-3">
+          {isAddingEntry && <EntryForm />}
+
+          {currentSet.entries.length === 0 && !isAddingEntry && (
+            <div className="text-center py-12 text-[var(--color-text-secondary)]">
+              <Zap size={32} className="mx-auto mb-3 opacity-40" />
+              <p className="text-sm">No entries yet.</p>
+              <p className="text-xs mt-1">Tap + to add your first quick reply.</p>
+            </div>
+          )}
+
+          {currentSet.entries.map((entry, idx) => {
+            const isEditing = editingEntryId === entry.id;
+            return (
+              <div key={entry.id} className="bg-[var(--color-bg-secondary)] rounded-lg overflow-hidden">
+                {isEditing ? (
+                  <div className="p-3">
+                    <EntryForm />
+                  </div>
+                ) : (
+                  <div className="flex items-start gap-2 p-3">
+                    {/* Reorder buttons */}
+                    <div className="flex flex-col gap-0.5 flex-shrink-0 mt-0.5">
+                      <button
+                        type="button"
+                        onClick={() => moveEntryUp(currentSet.id, entry.id)}
+                        disabled={idx === 0}
+                        className="p-1 rounded text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] disabled:opacity-25 transition-colors"
+                        aria-label="Move up"
+                      >
+                        <ChevronUp size={14} />
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => moveEntryDown(currentSet.id, entry.id)}
+                        disabled={idx === currentSet.entries.length - 1}
+                        className="p-1 rounded text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] disabled:opacity-25 transition-colors"
+                        aria-label="Move down"
+                      >
+                        <ChevronDown size={14} />
+                      </button>
+                    </div>
+
+                    {/* Label + message preview */}
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-medium text-[var(--color-text-primary)] truncate">
+                        {entry.label}
+                      </p>
+                      <p className="text-xs text-[var(--color-text-secondary)] truncate mt-0.5">
+                        {entry.message}
+                      </p>
+                    </div>
+
+                    {/* Edit / Delete */}
+                    <div className="flex items-center gap-1 flex-shrink-0">
+                      <button
+                        type="button"
+                        onClick={() => startEditEntry(entry)}
+                        className="p-1.5 rounded text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-tertiary)] transition-colors"
+                        aria-label="Edit entry"
+                      >
+                        <Pencil size={15} />
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => deleteEntry(currentSet.id, entry.id)}
+                        className="p-1.5 rounded text-[var(--color-text-secondary)] hover:text-red-400 hover:bg-red-500/10 transition-colors"
+                        aria-label="Delete entry"
+                      >
+                        <Trash2 size={15} />
+                      </button>
+                    </div>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    );
+  }
+
+  // ── Set list view ──────────────────────────────────────────────
+
+  return (
+    <div className="min-h-screen bg-[var(--color-bg-primary)]">
+      <header className="h-14 bg-[var(--color-bg-secondary)] border-b border-[var(--color-border)] flex items-center px-4 gap-3 safe-top">
+        <Button variant="ghost" size="sm" className="p-2" onClick={() => navigate('/settings')} aria-label="Back">
+          <ArrowLeft size={24} />
+        </Button>
+        <h1 className="text-lg font-semibold text-[var(--color-text-primary)]">Quick Replies</h1>
+      </header>
+
+      <div className="max-w-2xl mx-auto p-4 space-y-6">
+        {/* Active Set selector */}
+        <section className="bg-[var(--color-bg-secondary)] rounded-lg p-4">
+          <h2 className="text-sm font-semibold text-[var(--color-text-primary)] mb-3">Active Set</h2>
+          {sets.length === 0 ? (
+            <p className="text-sm text-[var(--color-text-secondary)]">No sets yet. Create one below.</p>
+          ) : (
+            <div className="space-y-2">
+              <button
+                type="button"
+                onClick={() => setActiveSet(null)}
+                className={`w-full flex items-center gap-2 px-3 py-2 rounded-lg text-sm transition-colors ${
+                  activeSetId === null
+                    ? 'bg-[var(--color-primary)]/20 text-[var(--color-primary)] font-medium'
+                    : 'text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-tertiary)]'
+                }`}
+              >
+                {activeSetId === null && <Check size={14} />}
+                <span className={activeSetId === null ? '' : 'ml-[18px]'}>None (bar hidden)</span>
+              </button>
+              {sets.map((qs) => (
+                <button
+                  key={qs.id}
+                  type="button"
+                  onClick={() => setActiveSet(qs.id)}
+                  className={`w-full flex items-center gap-2 px-3 py-2 rounded-lg text-sm transition-colors ${
+                    activeSetId === qs.id
+                      ? 'bg-[var(--color-primary)]/20 text-[var(--color-primary)] font-medium'
+                      : 'text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-tertiary)]'
+                  }`}
+                >
+                  {activeSetId === qs.id ? <Check size={14} /> : <span className="w-[14px]" />}
+                  <span className="flex-1 text-left truncate">{qs.name}</span>
+                  <span className="text-xs opacity-60">{qs.entries.length} entries</span>
+                </button>
+              ))}
+            </div>
+          )}
+        </section>
+
+        {/* Manage Sets */}
+        <section className="space-y-2">
+          <div className="flex items-center justify-between px-1">
+            <h2 className="text-sm font-semibold text-[var(--color-text-primary)]">Manage Sets</h2>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="p-1.5 flex items-center gap-1 text-xs"
+              onClick={() => { setIsAddingSet(true); setNewSetName(''); }}
+            >
+              <Plus size={15} />
+              New Set
+            </Button>
+          </div>
+
+          {isAddingSet && (
+            <div className="bg-[var(--color-bg-secondary)] rounded-lg p-3 flex items-center gap-2">
+              <Input
+                value={newSetName}
+                onChange={(e) => setNewSetName(e.target.value)}
+                placeholder="Set name…"
+                className="flex-1 text-sm"
+                autoFocus
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') { e.preventDefault(); handleCreateSet(); }
+                  if (e.key === 'Escape') setIsAddingSet(false);
+                }}
+              />
+              <Button type="button" variant="primary" size="sm" className="p-1.5" onClick={handleCreateSet} disabled={!newSetName.trim()}>
+                <Check size={16} />
+              </Button>
+              <Button type="button" variant="ghost" size="sm" className="p-1.5" onClick={() => setIsAddingSet(false)}>
+                <X size={16} />
+              </Button>
+            </div>
+          )}
+
+          {sets.length === 0 && !isAddingSet && (
+            <div className="text-center py-10 text-[var(--color-text-secondary)]">
+              <Zap size={32} className="mx-auto mb-3 opacity-40" />
+              <p className="text-sm">No sets yet.</p>
+              <p className="text-xs mt-1">Create a set and add quick reply buttons to it.</p>
+            </div>
+          )}
+
+          {sets.map((qs) => (
+            <div key={qs.id} className="bg-[var(--color-bg-secondary)] rounded-lg overflow-hidden">
+              {renamingSetId === qs.id ? (
+                <div className="flex items-center gap-2 p-3">
+                  <Input
+                    value={renameDraft}
+                    onChange={(e) => setRenameDraft(e.target.value)}
+                    className="flex-1 text-sm"
+                    autoFocus
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') { e.preventDefault(); commitRename(); }
+                      if (e.key === 'Escape') setRenamingSetId(null);
+                    }}
+                  />
+                  <Button type="button" variant="primary" size="sm" className="p-1.5" onClick={commitRename} disabled={!renameDraft.trim()}>
+                    <Check size={16} />
+                  </Button>
+                  <Button type="button" variant="ghost" size="sm" className="p-1.5" onClick={() => setRenamingSetId(null)}>
+                    <X size={16} />
+                  </Button>
+                </div>
+              ) : (
+                <div className="flex items-center gap-2 px-3">
+                  {/* Navigate into set */}
+                  <button
+                    type="button"
+                    onClick={() => setViewSetId(qs.id)}
+                    className="flex-1 flex items-center gap-3 py-3 text-left min-w-0"
+                  >
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-medium text-[var(--color-text-primary)] truncate">{qs.name}</p>
+                      <p className="text-xs text-[var(--color-text-secondary)]">
+                        {qs.entries.length === 0 ? 'No entries' : `${qs.entries.length} entr${qs.entries.length === 1 ? 'y' : 'ies'}`}
+                      </p>
+                    </div>
+                    <ChevronRight size={16} className="text-[var(--color-text-secondary)] flex-shrink-0" />
+                  </button>
+                  {/* Rename */}
+                  <button
+                    type="button"
+                    onClick={() => startRename(qs.id, qs.name)}
+                    className="p-1.5 rounded text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-tertiary)] transition-colors"
+                    aria-label="Rename set"
+                  >
+                    <Pencil size={15} />
+                  </button>
+                  {/* Delete */}
+                  <button
+                    type="button"
+                    onClick={() => handleDeleteSet(qs.id)}
+                    className="p-1.5 rounded text-[var(--color-text-secondary)] hover:text-red-400 hover:bg-red-500/10 transition-colors"
+                    aria-label="Delete set"
+                  >
+                    <Trash2 size={15} />
+                  </button>
+                </div>
+              )}
+            </div>
+          ))}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { ArrowLeft, BookOpen, Check, ChevronRight, Eye, EyeOff, Key, Loader2, MessageSquare, Mic, Palette, Replace, Sliders, Trash2, UserPlus, Volume2 } from 'lucide-react';
+import { ArrowLeft, BookOpen, Check, ChevronRight, Eye, EyeOff, Globe, Key, Loader2, MessageSquare, Mic, Palette, Replace, Sliders, Trash2, UserPlus, Volume2 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useSettingsStore } from '../../stores/settingsStore';
 import { PROVIDERS, type SecretState } from '../../api/client';
@@ -49,6 +49,7 @@ export function SettingsPage() {
     secrets,
     activeProvider,
     activeModel,
+    customUrl,
     isLoading,
     isSaving,
     error,
@@ -59,11 +60,16 @@ export function SettingsPage() {
     deleteApiKey,
     setActiveProvider,
     setActiveModel,
+    setCustomUrl,
     clearMessages,
   } = useSettingsStore();
 
   const [apiKeyInputs, setApiKeyInputs] = useState<Record<string, string>>({});
   const [showApiKey, setShowApiKey] = useState<Record<string, boolean>>({});
+
+  // Custom endpoint fields — kept as local state and only persisted on Save/blur.
+  const [customUrlInput, setCustomUrlInput] = useState('');
+  const [customModelInput, setCustomModelInput] = useState('');
   const [speechLang, setSpeechLangState] = useState<string>(() => getSpeechLanguage());
   const { isSupported: isSpeechSupported } = useSpeechRecognition();
 
@@ -96,6 +102,10 @@ export function SettingsPage() {
     }
   }, [successMessage, error, clearMessages]);
 
+  // Sync local custom-endpoint inputs from store after fetchSettings resolves.
+  useEffect(() => { setCustomUrlInput(customUrl); }, [customUrl]);
+  useEffect(() => { setCustomModelInput(activeModel); }, [activeModel]);
+
   const handleSaveApiKey = async (providerId: string) => {
     const key = apiKeyInputs[providerId];
     if (!key?.trim()) return;
@@ -121,6 +131,10 @@ export function SettingsPage() {
   };
 
   const currentProvider = PROVIDERS.find((p) => p.id === activeProvider);
+
+  // Custom provider is "configured" when a URL is set, not by API key.
+  const isProviderConfigured = (provider: typeof PROVIDERS[number]) =>
+    provider.id === 'custom' ? !!customUrl : hasApiKey(provider.secretKey);
 
   return (
     <div className="min-h-screen bg-[var(--color-bg-primary)]">
@@ -166,7 +180,7 @@ export function SettingsPage() {
               </h2>
               <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
                 {PROVIDERS.map((provider) => {
-                  const configured = hasApiKey(provider.secretKey);
+                  const configured = isProviderConfigured(provider);
                   const isActive = activeProvider === provider.id;
 
                   return (
@@ -195,15 +209,76 @@ export function SettingsPage() {
                   );
                 })}
               </div>
-              {!hasApiKey(currentProvider?.secretKey || '') && (
+              {activeProvider !== 'custom' && !hasApiKey(currentProvider?.secretKey || '') && (
                 <p className="mt-2 text-xs text-[var(--color-text-secondary)]">
                   Configure an API key below to use this provider
                 </p>
               )}
+              {activeProvider === 'custom' && !customUrl && (
+                <p className="mt-2 text-xs text-[var(--color-text-secondary)]">
+                  Enter the endpoint URL below to use a local or custom model server
+                </p>
+              )}
             </section>
 
+            {/* Custom Endpoint Configuration */}
+            {activeProvider === 'custom' && (
+              <section className="bg-[var(--color-bg-secondary)] rounded-lg p-4 space-y-4">
+                <div className="flex items-center gap-2">
+                  <Globe size={16} className="text-[var(--color-text-secondary)]" />
+                  <h2 className="text-sm font-semibold text-[var(--color-text-primary)]">
+                    Custom Endpoint
+                  </h2>
+                </div>
+
+                <div>
+                  <label className="block text-xs text-[var(--color-text-secondary)] mb-1">
+                    Base URL
+                  </label>
+                  <div className="flex gap-2">
+                    <Input
+                      type="url"
+                      value={customUrlInput}
+                      onChange={(e) => setCustomUrlInput(e.target.value)}
+                      placeholder="http://localhost:11434/v1"
+                      className="flex-1"
+                    />
+                    <Button
+                      onClick={() => setCustomUrl(customUrlInput.trim())}
+                      disabled={isSaving || !customUrlInput.trim() || customUrlInput.trim() === customUrl}
+                      className="shrink-0"
+                    >
+                      {isSaving ? <Loader2 size={16} className="animate-spin" /> : 'Save'}
+                    </Button>
+                  </div>
+                  <p className="mt-1 text-xs text-[var(--color-text-secondary)]">
+                    OpenAI-compatible base URL. Examples: Ollama → <code>http://localhost:11434/v1</code>, LM Studio → <code>http://localhost:1234/v1</code>
+                  </p>
+                </div>
+
+                <div>
+                  <label className="block text-xs text-[var(--color-text-secondary)] mb-1">
+                    Model name
+                  </label>
+                  <Input
+                    value={customModelInput}
+                    onChange={(e) => setCustomModelInput(e.target.value)}
+                    onBlur={() => {
+                      if (customModelInput !== activeModel) {
+                        setActiveModel(customModelInput);
+                      }
+                    }}
+                    placeholder="e.g. llama3, mistral, codellama"
+                  />
+                  <p className="mt-1 text-xs text-[var(--color-text-secondary)]">
+                    Exact model identifier your endpoint expects. Changes are saved on blur.
+                  </p>
+                </div>
+              </section>
+            )}
+
             {/* Model Selection */}
-            {currentProvider && (
+            {currentProvider && activeProvider !== 'custom' && (
               <section className="bg-[var(--color-bg-secondary)] rounded-lg p-4">
                 <h2 className="text-sm font-semibold text-[var(--color-text-primary)] mb-3">
                   Model
@@ -229,7 +304,7 @@ export function SettingsPage() {
                 API Keys
               </h2>
               <div className="space-y-4">
-                {PROVIDERS.map((provider) => {
+                {PROVIDERS.filter((p) => p.id !== 'custom').map((provider) => {
                   const secretInfo = getSecretInfo(provider.secretKey);
                   const configured = !!secretInfo;
                   const inputValue = apiKeyInputs[provider.id] || '';

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { ArrowLeft, BookOpen, Check, ChevronRight, Eye, EyeOff, Globe, Key, Loader2, MessageSquare, Mic, Palette, Replace, Sliders, Trash2, UserPlus, Volume2 } from 'lucide-react';
+import { ArrowLeft, BookOpen, Check, ChevronRight, Eye, EyeOff, Globe, Key, Languages, Loader2, MessageSquare, Mic, Palette, Replace, Sliders, Trash2, UserPlus, Users, Volume2, Zap } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useSettingsStore } from '../../stores/settingsStore';
 import { PROVIDERS, type SecretState } from '../../api/client';
@@ -42,6 +42,8 @@ import {
 } from '../../hooks/themePreferences';
 import { useSpeechRecognition } from '../../hooks/useSpeechRecognition';
 import { useSpeechSynthesis } from '../../hooks/useSpeechSynthesis';
+import { useTranslateStore } from '../../stores/translateStore';
+import { TRANSLATE_PROVIDERS, TRANSLATE_LANGUAGES, type TranslateProvider } from '../../api/translateApi';
 
 export function SettingsPage() {
   const navigate = useNavigate();
@@ -89,6 +91,12 @@ export function SettingsPage() {
   const [ttsRate, setTtsRateState] = useState<number>(() => getTtsRate());
   const [ttsPitch, setTtsPitchState] = useState<number>(() => getTtsPitch());
   const [ttsAutoReadOn, setTtsAutoReadState] = useState<boolean>(() => getTtsAutoRead());
+
+  // Phase 7.2: Translation settings
+  const translateProvider = useTranslateStore((s) => s.provider);
+  const translateLang = useTranslateStore((s) => s.targetLang);
+  const setTranslateProvider = useTranslateStore((s) => s.setProvider);
+  const setTranslateLang = useTranslateStore((s) => s.setTargetLang);
 
   useEffect(() => {
     fetchSecrets();
@@ -471,6 +479,46 @@ export function SettingsPage() {
               </button>
             </section>
 
+            {/* Users (Phase 3.1) */}
+            <section className="bg-[var(--color-bg-secondary)] rounded-lg overflow-hidden">
+              <button
+                onClick={() => navigate('/settings/users')}
+                className="w-full flex items-center gap-3 p-4 hover:bg-[var(--color-bg-tertiary)] transition-colors text-left"
+              >
+                <div className="w-10 h-10 rounded-lg bg-[var(--color-primary)]/20 flex items-center justify-center">
+                  <Users size={20} className="text-[var(--color-primary)]" />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <h3 className="text-sm font-semibold text-[var(--color-text-primary)]">
+                    Users
+                  </h3>
+                  <p className="text-xs text-[var(--color-text-secondary)]">
+                    Manage accounts, roles, and access
+                  </p>
+                </div>
+                <ChevronRight size={20} className="text-[var(--color-text-secondary)]" />
+              </button>
+            </section>
+
+            {/* Quick Replies (Phase 10.2) */}
+            <section className="bg-[var(--color-bg-secondary)] rounded-lg overflow-hidden">
+              <button
+                onClick={() => navigate('/settings/quickreplies')}
+                className="w-full flex items-center gap-3 p-4 hover:bg-[var(--color-bg-tertiary)] transition-colors text-left"
+              >
+                <div className="w-10 h-10 rounded-lg bg-[var(--color-primary)]/20 flex items-center justify-center">
+                  <Zap size={20} className="text-[var(--color-primary)]" />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium text-[var(--color-text-primary)]">Quick Replies</p>
+                  <p className="text-xs text-[var(--color-text-secondary)] mt-0.5">
+                    Saved prompt shortcuts
+                  </p>
+                </div>
+                <ChevronRight size={20} className="text-[var(--color-text-secondary)]" />
+              </button>
+            </section>
+
             {/* Appearance (Phase 7.4) */}
             <section className="bg-[var(--color-bg-secondary)] rounded-lg p-4">
               <div className="flex items-center gap-2 mb-3">
@@ -775,6 +823,49 @@ export function SettingsPage() {
                 </div>
               </section>
             )}
+
+            {/* Translation (Phase 7.2) */}
+            <section className="bg-[var(--color-bg-secondary)] rounded-lg p-4">
+              <div className="flex items-center gap-2 mb-3">
+                <Languages size={16} className="text-[var(--color-text-secondary)]" />
+                <h2 className="text-sm font-semibold text-[var(--color-text-primary)]">
+                  Translation
+                </h2>
+              </div>
+              <p className="text-xs text-[var(--color-text-secondary)] mb-3">
+                Per-message translate button on AI messages. Google and Bing work without extra config.
+              </p>
+
+              <label className="block text-xs text-[var(--color-text-secondary)] mb-1">
+                Provider
+              </label>
+              <select
+                value={translateProvider}
+                onChange={(e) => setTranslateProvider(e.target.value as TranslateProvider)}
+                className="w-full bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] rounded-lg px-3 py-2 text-[var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)] mb-4"
+              >
+                {TRANSLATE_PROVIDERS.map((p) => (
+                  <option key={p.id} value={p.id}>
+                    {p.name}{p.free ? '' : ' (requires config)'}
+                  </option>
+                ))}
+              </select>
+
+              <label className="block text-xs text-[var(--color-text-secondary)] mb-1">
+                Target Language
+              </label>
+              <select
+                value={translateLang}
+                onChange={(e) => setTranslateLang(e.target.value)}
+                className="w-full bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] rounded-lg px-3 py-2 text-[var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]"
+              >
+                {TRANSLATE_LANGUAGES.map((lang) => (
+                  <option key={lang.code} value={lang.code}>
+                    {lang.label}
+                  </option>
+                ))}
+              </select>
+            </section>
 
             {/* Help Text */}
             <section className="text-center py-4">

--- a/src/components/settings/UserManagementPage.tsx
+++ b/src/components/settings/UserManagementPage.tsx
@@ -1,0 +1,297 @@
+import { useState, useEffect, useCallback } from 'react';
+import { ArrowLeft, Loader2, Trash2, UserX, UserCheck, ShieldAlert } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { adminApi, type AdminUserInfo } from '../../api/client';
+import { useAuthStore } from '../../stores/authStore';
+import { Avatar, Button } from '../ui';
+import { hasMinRole } from '../../utils/permissions';
+import type { UserRole } from '../../types';
+
+const ROLE_OPTIONS: { value: UserRole; label: string }[] = [
+  { value: 'end_user', label: 'User' },
+  { value: 'contributor', label: 'Contributor' },
+  { value: 'admin', label: 'Admin' },
+  { value: 'owner', label: 'Owner' },
+];
+
+const ROLE_COLOR: Record<UserRole, string> = {
+  owner: 'bg-amber-500/20 text-amber-400',
+  admin: 'bg-purple-500/20 text-purple-400',
+  contributor: 'bg-blue-500/20 text-blue-400',
+  end_user: 'bg-[var(--color-bg-tertiary)] text-[var(--color-text-secondary)]',
+};
+
+function getAvatarUrl(avatar: string) {
+  if (!avatar) return undefined;
+  if (avatar.startsWith('data:') || avatar.startsWith('http')) return avatar;
+  return `/thumbnail?type=avatar&file=${encodeURIComponent(avatar)}`;
+}
+
+export function UserManagementPage() {
+  const navigate = useNavigate();
+  const { currentUser } = useAuthStore();
+  const isOwner = currentUser?.role === 'owner';
+
+  const [users, setUsers] = useState<AdminUserInfo[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Per-user pending state: handle → action type
+  const [pending, setPending] = useState<Record<string, 'role' | 'toggle' | 'delete'>>({});
+  // Role select local state: handle → selected value (before save)
+  const [roleSelections, setRoleSelections] = useState<Record<string, UserRole>>({});
+  // Confirm delete state
+  const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const list = await adminApi.getUsers();
+      setUsers(list);
+      // Seed role selections from loaded data
+      const seeds: Record<string, UserRole> = {};
+      list.forEach(u => { seeds[u.handle] = u.role; });
+      setRoleSelections(seeds);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load users');
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  const handleSetRole = async (handle: string) => {
+    const newRole = roleSelections[handle];
+    setPending(p => ({ ...p, [handle]: 'role' }));
+    setError(null);
+    try {
+      await adminApi.setRole(handle, newRole);
+      setUsers(prev => prev.map(u => u.handle === handle ? { ...u, role: newRole } : u));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to change role');
+      // Revert selection on error
+      setRoleSelections(prev => ({
+        ...prev,
+        [handle]: users.find(u => u.handle === handle)?.role ?? prev[handle],
+      }));
+    } finally {
+      setPending(p => { const next = { ...p }; delete next[handle]; return next; });
+    }
+  };
+
+  const handleToggleEnabled = async (user: AdminUserInfo) => {
+    setPending(p => ({ ...p, [user.handle]: 'toggle' }));
+    setError(null);
+    try {
+      if (user.enabled) {
+        await adminApi.disableUser(user.handle);
+      } else {
+        await adminApi.enableUser(user.handle);
+      }
+      setUsers(prev => prev.map(u => u.handle === user.handle ? { ...u, enabled: !u.enabled } : u));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to update user');
+    } finally {
+      setPending(p => { const next = { ...p }; delete next[user.handle]; return next; });
+    }
+  };
+
+  const handleDelete = async (handle: string) => {
+    setConfirmDelete(null);
+    setPending(p => ({ ...p, [handle]: 'delete' }));
+    setError(null);
+    try {
+      await adminApi.deleteUser(handle);
+      setUsers(prev => prev.filter(u => u.handle !== handle));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to delete user');
+    } finally {
+      setPending(p => { const next = { ...p }; delete next[handle]; return next; });
+    }
+  };
+
+  // Can the current user modify this target user?
+  const canModify = (target: AdminUserInfo): boolean => {
+    if (!currentUser) return false;
+    if (target.handle === currentUser.handle) return false; // can't modify yourself
+    if (target.handle === 'default-user') return false;
+    // Admins can't modify owners
+    if (target.role === 'owner' && !isOwner) return false;
+    return true;
+  };
+
+  // Which roles can the current user assign?
+  const assignableRoles = isOwner
+    ? ROLE_OPTIONS
+    : ROLE_OPTIONS.filter(r => r.value !== 'owner');
+
+  return (
+    <div className="min-h-screen bg-[var(--color-bg-primary)]">
+      {/* Header */}
+      <div className="sticky top-0 z-10 h-14 bg-[var(--color-bg-secondary)] border-b border-[var(--color-border)] flex items-center px-4 gap-3 safe-top">
+        <Button variant="ghost" size="sm" onClick={() => navigate('/settings')} className="p-2" aria-label="Back">
+          <ArrowLeft size={20} />
+        </Button>
+        <h1 className="text-base font-semibold text-[var(--color-text-primary)]">Users</h1>
+      </div>
+
+      <div className="max-w-lg mx-auto p-4 space-y-4">
+        {error && (
+          <div className="p-3 bg-red-500/10 border border-red-500/30 rounded-lg text-sm text-red-400">
+            {error}
+          </div>
+        )}
+
+        {isLoading ? (
+          <div className="flex items-center justify-center py-16">
+            <Loader2 size={28} className="animate-spin text-[var(--color-primary)]" />
+          </div>
+        ) : (
+          <div className="bg-[var(--color-bg-secondary)] rounded-xl overflow-hidden">
+            <div className="px-4 py-3 border-b border-[var(--color-border)] flex items-center justify-between">
+              <h2 className="text-sm font-semibold text-[var(--color-text-primary)]">
+                All Users ({users.length})
+              </h2>
+            </div>
+
+            <ul className="divide-y divide-[var(--color-border)]">
+              {users.map(user => {
+                const isSelf = user.handle === currentUser?.handle;
+                const modifiable = canModify(user);
+                const isPending = !!pending[user.handle];
+                const selectedRole = roleSelections[user.handle] ?? user.role;
+                const roleChanged = selectedRole !== user.role;
+
+                return (
+                  <li key={user.handle} className={`px-4 py-3 ${!user.enabled ? 'opacity-60' : ''}`}>
+                    <div className="flex items-start gap-3">
+                      {/* Avatar */}
+                      <div className="relative shrink-0 mt-0.5">
+                        <Avatar
+                          src={getAvatarUrl(user.avatar)}
+                          alt={user.name}
+                          size="md"
+                        />
+                        {!user.enabled && (
+                          <div className="absolute -bottom-0.5 -right-0.5 w-4 h-4 rounded-full bg-[var(--color-bg-secondary)] flex items-center justify-center">
+                            <ShieldAlert size={10} className="text-red-400" />
+                          </div>
+                        )}
+                      </div>
+
+                      {/* Info */}
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2 flex-wrap">
+                          <span className="text-sm font-medium text-[var(--color-text-primary)] truncate">
+                            {user.name}
+                          </span>
+                          {isSelf && (
+                            <span className="text-xs text-[var(--color-text-secondary)]">(you)</span>
+                          )}
+                          <span className={`text-[10px] font-medium px-2 py-0.5 rounded-full ${ROLE_COLOR[user.role]}`}>
+                            {user.role.replace('_', ' ')}
+                          </span>
+                          {!user.enabled && (
+                            <span className="text-[10px] font-medium px-2 py-0.5 rounded-full bg-red-500/10 text-red-400">
+                              disabled
+                            </span>
+                          )}
+                        </div>
+                        <p className="text-xs text-[var(--color-text-secondary)] mt-0.5">@{user.handle}</p>
+
+                        {/* Role selector (only for modifiable users) */}
+                        {modifiable && (
+                          <div className="flex items-center gap-2 mt-2">
+                            <select
+                              value={selectedRole}
+                              onChange={e => setRoleSelections(prev => ({ ...prev, [user.handle]: e.target.value as UserRole }))}
+                              disabled={isPending}
+                              className="text-xs bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] rounded-lg px-2 py-1 text-[var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)] disabled:opacity-50"
+                            >
+                              {assignableRoles.map(opt => (
+                                <option key={opt.value} value={opt.value}>{opt.label}</option>
+                              ))}
+                              {/* Allow showing owner option as disabled for admins viewing an owner */}
+                              {!isOwner && user.role === 'owner' && (
+                                <option value="owner" disabled>Owner</option>
+                              )}
+                            </select>
+                            {roleChanged && (
+                              <Button
+                                size="sm"
+                                onClick={() => handleSetRole(user.handle)}
+                                disabled={isPending}
+                                className="text-xs py-1 px-2"
+                              >
+                                {pending[user.handle] === 'role'
+                                  ? <Loader2 size={12} className="animate-spin" />
+                                  : 'Save'}
+                              </Button>
+                            )}
+                          </div>
+                        )}
+                      </div>
+
+                      {/* Actions */}
+                      {modifiable && (
+                        <div className="flex items-center gap-1 shrink-0">
+                          {/* Enable / Disable */}
+                          <button
+                            onClick={() => handleToggleEnabled(user)}
+                            disabled={isPending}
+                            className="p-2 rounded-lg text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-tertiary)] transition-colors disabled:opacity-50"
+                            aria-label={user.enabled ? 'Disable user' : 'Enable user'}
+                            title={user.enabled ? 'Disable user' : 'Enable user'}
+                          >
+                            {pending[user.handle] === 'toggle'
+                              ? <Loader2 size={16} className="animate-spin" />
+                              : user.enabled
+                                ? <UserX size={16} />
+                                : <UserCheck size={16} className="text-green-400" />}
+                          </button>
+
+                          {/* Delete */}
+                          {confirmDelete === user.handle ? (
+                            <div className="flex items-center gap-1">
+                              <button
+                                onClick={() => handleDelete(user.handle)}
+                                disabled={isPending}
+                                className="text-xs px-2 py-1 rounded-lg bg-red-500/20 text-red-400 hover:bg-red-500/30 transition-colors disabled:opacity-50"
+                              >
+                                {pending[user.handle] === 'delete'
+                                  ? <Loader2 size={12} className="animate-spin" />
+                                  : 'Confirm'}
+                              </button>
+                              <button
+                                onClick={() => setConfirmDelete(null)}
+                                className="text-xs px-2 py-1 rounded-lg text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-tertiary)] transition-colors"
+                              >
+                                Cancel
+                              </button>
+                            </div>
+                          ) : (
+                            <button
+                              onClick={() => setConfirmDelete(user.handle)}
+                              disabled={isPending}
+                              className="p-2 rounded-lg text-[var(--color-text-secondary)] hover:text-red-400 hover:bg-[var(--color-bg-tertiary)] transition-colors disabled:opacity-50"
+                              aria-label="Delete user"
+                              title="Delete user"
+                            >
+                              <Trash2 size={16} />
+                            </button>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/settings/index.ts
+++ b/src/components/settings/index.ts
@@ -1,3 +1,5 @@
 export { SettingsPage } from './SettingsPage';
 export { GenerationSettingsPage } from './GenerationSettingsPage';
 export { InvitationManager } from './InvitationManager';
+export { UserManagementPage } from './UserManagementPage';
+export { QuickReplyPage } from './QuickReplyPage';

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -380,6 +380,16 @@ interface ChatState {
   deleteChat: (avatarUrl: string, fileName: string) => Promise<void>;
   renameChat: (avatarUrl: string, fileName: string, newName: string) => Promise<void>;
   importChat: (avatarUrl: string, characterName: string, file: File) => Promise<void>;
+  /** Phase 7.1: append a generated image as a standalone chat message and
+   *  persist it to the backend. `speakerName`/`speakerAvatar` identify who
+   *  "sent" it (usually the current character). */
+  insertImageMessage: (
+    dataUrl: string,
+    prompt: string,
+    speakerName: string,
+    speakerAvatar?: string,
+    character?: CharacterInfo
+  ) => Promise<void>;
 }
 
 let messageIdCounter = 0;
@@ -1959,6 +1969,31 @@ export const useChatStore = create<ChatState>((set, get) => ({
       await fetchChatFiles(avatarUrl);
     } catch (error) {
       set({ error: error instanceof Error ? error.message : 'Failed to import chat' });
+    }
+  },
+
+  // ---- Phase 7.1: Insert Generated Image as Chat Message ----
+  insertImageMessage: async (
+    dataUrl: string,
+    _prompt: string,
+    speakerName: string,
+    speakerAvatar?: string,
+    character?: CharacterInfo
+  ) => {
+    const msg = createMessage({
+      name: speakerName,
+      isUser: false,
+      isSystem: false,
+      content: '',
+      timestamp: Date.now(),
+      images: [dataUrl],
+      characterAvatar: speakerAvatar,
+    });
+    set((state) => ({ messages: [...state.messages, msg] }));
+
+    const { currentChatFile } = get();
+    if (currentChatFile && character) {
+      await saveChatToBackend(get().messages, character, currentChatFile);
     }
   },
 

--- a/src/stores/imageGenStore.ts
+++ b/src/stores/imageGenStore.ts
@@ -1,0 +1,107 @@
+import { create } from 'zustand';
+import { imageGenApi, type ImageGenBackend } from '../api/imageGenApi';
+
+const STORAGE_KEY = 'sillytavern_imagegen_config';
+
+interface ImageGenConfig {
+  backend: ImageGenBackend;
+  sdUrl: string;
+  sdAuth: string;
+  pollinationsModel: string;
+  width: number;
+  height: number;
+  steps: number;
+  cfgScale: number;
+}
+
+const DEFAULT_CONFIG: ImageGenConfig = {
+  backend: 'pollinations',
+  sdUrl: 'http://localhost:7860',
+  sdAuth: '',
+  pollinationsModel: 'flux',
+  width: 1024,
+  height: 1024,
+  steps: 20,
+  cfgScale: 7,
+};
+
+function loadConfig(): ImageGenConfig {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) return { ...DEFAULT_CONFIG, ...JSON.parse(stored) };
+  } catch { /* ignore */ }
+  return { ...DEFAULT_CONFIG };
+}
+
+function saveConfig(config: ImageGenConfig) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(config));
+}
+
+interface ImageGenState extends ImageGenConfig {
+  isGenerating: boolean;
+  error: string | null;
+
+  setConfig: (patch: Partial<ImageGenConfig>) => void;
+  /** Generate an image and return its data URI, or null on failure. */
+  generate: (prompt: string, negativePrompt?: string) => Promise<string | null>;
+  clearError: () => void;
+}
+
+export const useImageGenStore = create<ImageGenState>((set, get) => ({
+  ...loadConfig(),
+  isGenerating: false,
+  error: null,
+
+  setConfig: (patch) => {
+    set((s) => {
+      const next = { ...s, ...patch };
+      const config: ImageGenConfig = {
+        backend: next.backend,
+        sdUrl: next.sdUrl,
+        sdAuth: next.sdAuth,
+        pollinationsModel: next.pollinationsModel,
+        width: next.width,
+        height: next.height,
+        steps: next.steps,
+        cfgScale: next.cfgScale,
+      };
+      saveConfig(config);
+      return next;
+    });
+  },
+
+  generate: async (prompt, negativePrompt) => {
+    const { backend, sdUrl, sdAuth, pollinationsModel, width, height, steps, cfgScale } = get();
+    set({ isGenerating: true, error: null });
+    try {
+      let result;
+      if (backend === 'sdwebui') {
+        result = await imageGenApi.generateSdWebui({
+          url: sdUrl,
+          auth: sdAuth || undefined,
+          prompt,
+          negativePrompt: negativePrompt || undefined,
+          width,
+          height,
+          steps,
+          cfgScale,
+        });
+      } else {
+        result = await imageGenApi.generatePollinations({
+          prompt,
+          negativePrompt: negativePrompt || undefined,
+          model: pollinationsModel,
+          width,
+          height,
+        });
+      }
+      set({ isGenerating: false });
+      return `data:image/${result.format};base64,${result.base64}`;
+    } catch (e) {
+      set({ isGenerating: false, error: e instanceof Error ? e.message : 'Generation failed' });
+      return null;
+    }
+  },
+
+  clearError: () => set({ error: null }),
+}));

--- a/src/stores/quickReplyStore.ts
+++ b/src/stores/quickReplyStore.ts
@@ -1,0 +1,128 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export interface QuickReplyEntry {
+  id: string;
+  label: string;
+  message: string;
+}
+
+export interface QuickReplySet {
+  id: string;
+  name: string;
+  entries: QuickReplyEntry[];
+}
+
+interface QuickReplyState {
+  sets: QuickReplySet[];
+  activeSetId: string | null;
+
+  setActiveSet: (id: string | null) => void;
+
+  createSet: (name: string) => string;
+  renameSet: (id: string, name: string) => void;
+  deleteSet: (id: string) => void;
+
+  addEntry: (setId: string, label: string, message: string) => void;
+  updateEntry: (setId: string, entryId: string, label: string, message: string) => void;
+  deleteEntry: (setId: string, entryId: string) => void;
+  moveEntryUp: (setId: string, entryId: string) => void;
+  moveEntryDown: (setId: string, entryId: string) => void;
+}
+
+function uid(): string {
+  return Math.random().toString(36).slice(2, 10);
+}
+
+export const useQuickReplyStore = create<QuickReplyState>()(
+  persist(
+    (set) => ({
+      sets: [],
+      activeSetId: null,
+
+      setActiveSet: (id) => set({ activeSetId: id }),
+
+      createSet: (name) => {
+        const id = uid();
+        set((s) => ({ sets: [...s.sets, { id, name: name.trim() || 'New Set', entries: [] }] }));
+        return id;
+      },
+
+      renameSet: (id, name) =>
+        set((s) => ({
+          sets: s.sets.map((qs) =>
+            qs.id === id ? { ...qs, name: name.trim() || qs.name } : qs
+          ),
+        })),
+
+      deleteSet: (id) =>
+        set((s) => ({
+          sets: s.sets.filter((qs) => qs.id !== id),
+          activeSetId: s.activeSetId === id ? null : s.activeSetId,
+        })),
+
+      addEntry: (setId, label, message) =>
+        set((s) => ({
+          sets: s.sets.map((qs) =>
+            qs.id === setId
+              ? {
+                  ...qs,
+                  entries: [
+                    ...qs.entries,
+                    { id: uid(), label: label.trim(), message },
+                  ],
+                }
+              : qs
+          ),
+        })),
+
+      updateEntry: (setId, entryId, label, message) =>
+        set((s) => ({
+          sets: s.sets.map((qs) =>
+            qs.id === setId
+              ? {
+                  ...qs,
+                  entries: qs.entries.map((e) =>
+                    e.id === entryId ? { ...e, label: label.trim(), message } : e
+                  ),
+                }
+              : qs
+          ),
+        })),
+
+      deleteEntry: (setId, entryId) =>
+        set((s) => ({
+          sets: s.sets.map((qs) =>
+            qs.id === setId
+              ? { ...qs, entries: qs.entries.filter((e) => e.id !== entryId) }
+              : qs
+          ),
+        })),
+
+      moveEntryUp: (setId, entryId) =>
+        set((s) => ({
+          sets: s.sets.map((qs) => {
+            if (qs.id !== setId) return qs;
+            const idx = qs.entries.findIndex((e) => e.id === entryId);
+            if (idx <= 0) return qs;
+            const entries = [...qs.entries];
+            [entries[idx - 1], entries[idx]] = [entries[idx], entries[idx - 1]];
+            return { ...qs, entries };
+          }),
+        })),
+
+      moveEntryDown: (setId, entryId) =>
+        set((s) => ({
+          sets: s.sets.map((qs) => {
+            if (qs.id !== setId) return qs;
+            const idx = qs.entries.findIndex((e) => e.id === entryId);
+            if (idx < 0 || idx >= qs.entries.length - 1) return qs;
+            const entries = [...qs.entries];
+            [entries[idx], entries[idx + 1]] = [entries[idx + 1], entries[idx]];
+            return { ...qs, entries };
+          }),
+        })),
+    }),
+    { name: 'quick-reply-store' }
+  )
+);

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -5,6 +5,8 @@ interface SettingsState {
   secrets: SecretsResponse;
   activeProvider: string;
   activeModel: string;
+  /** Base URL for the custom OpenAI-compatible endpoint (e.g. http://localhost:11434/v1). */
+  customUrl: string;
   isLoading: boolean;
   isSaving: boolean;
   error: string | null;
@@ -17,6 +19,7 @@ interface SettingsState {
   deleteApiKey: (secretKey: string) => Promise<void>;
   setActiveProvider: (provider: string) => Promise<void>;
   setActiveModel: (model: string) => Promise<void>;
+  setCustomUrl: (url: string) => Promise<void>;
   clearMessages: () => void;
 }
 
@@ -24,6 +27,7 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
   secrets: {},
   activeProvider: 'openai',
   activeModel: 'gpt-4o',
+  customUrl: '',
   isLoading: false,
   isSaving: false,
   error: null,
@@ -71,13 +75,18 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
         model = (oaiSettings.claude_model as string) || 'claude-3-5-sonnet-20241022';
       } else if (chatCompletionSource === 'makersuite') {
         model = (oaiSettings.google_model as string) || 'gemini-1.5-pro';
+      } else if (chatCompletionSource === 'custom') {
+        model = (oaiSettings.custom_model as string) || '';
       }
+
+      const customUrl = (oaiSettings.custom_url as string) || '';
 
       console.log('[Settings] Loaded provider:', chatCompletionSource, 'model:', model);
 
       set({
         activeProvider: chatCompletionSource,
         activeModel: model,
+        customUrl,
         isLoading: false,
       });
     } catch (error) {
@@ -149,7 +158,8 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
     set({ isSaving: true, error: null });
     try {
       const providerInfo = PROVIDERS.find((p) => p.id === provider);
-      const defaultModel = providerInfo?.models[0] || 'gpt-4o';
+      // For custom, there's no preset model list — preserve whatever is in custom_model.
+      const defaultModel = provider === 'custom' ? get().activeModel : (providerInfo?.models[0] || 'gpt-4o');
 
       // Get current settings first to merge properly
       const response = await settingsApi.getSettings();
@@ -174,6 +184,7 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
       } else if (provider === 'makersuite') {
         oaiSettings.google_model = defaultModel;
       }
+      // 'custom': custom_url / custom_model are managed by setCustomUrl / setActiveModel separately.
 
       settings.oai_settings = oaiSettings;
 
@@ -219,6 +230,8 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
         oaiSettings.claude_model = model;
       } else if (activeProvider === 'makersuite') {
         oaiSettings.google_model = model;
+      } else if (activeProvider === 'custom') {
+        oaiSettings.custom_model = model;
       }
 
       settings.oai_settings = oaiSettings;
@@ -230,6 +243,31 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
       set({
         isSaving: false,
         error: error instanceof Error ? error.message : 'Failed to save model',
+      });
+    }
+  },
+
+  setCustomUrl: async (url: string) => {
+    set({ isSaving: true, error: null });
+    try {
+      const response = await settingsApi.getSettings();
+      let settings: Record<string, unknown> = {};
+      if (typeof response.settings === 'string') {
+        try {
+          settings = JSON.parse(response.settings);
+        } catch {
+          settings = {};
+        }
+      }
+      const oaiSettings = (settings.oai_settings as Record<string, unknown>) || {};
+      oaiSettings.custom_url = url;
+      settings.oai_settings = oaiSettings;
+      await settingsApi.saveSettings(settings);
+      set({ customUrl: url, isSaving: false, successMessage: 'Endpoint URL saved' });
+    } catch (error) {
+      set({
+        isSaving: false,
+        error: error instanceof Error ? error.message : 'Failed to save endpoint URL',
       });
     }
   },

--- a/src/stores/translateStore.ts
+++ b/src/stores/translateStore.ts
@@ -1,0 +1,95 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import { translateText, type TranslateProvider } from '../api/translateApi';
+
+interface TranslateState {
+  // Persisted settings
+  provider: TranslateProvider;
+  targetLang: string;
+
+  // Session state (not persisted)
+  cache: Map<string, string>;   // messageId → translated text
+  pending: Set<string>;         // messageIds currently being fetched
+  visible: Set<string>;         // messageIds with translation panel open
+
+  setProvider: (p: TranslateProvider) => void;
+  setTargetLang: (l: string) => void;
+  /** Toggle the translation panel for a message. Fetches from API if not cached. */
+  toggleTranslation: (messageId: string, text: string) => Promise<void>;
+}
+
+export const useTranslateStore = create<TranslateState>()(
+  persist(
+    (set, get) => ({
+      provider: 'google',
+      targetLang: 'en',
+      cache: new Map(),
+      pending: new Set(),
+      visible: new Set(),
+
+      setProvider: (p) =>
+        // Changing provider invalidates all cached translations
+        set({ provider: p, cache: new Map(), visible: new Set() }),
+
+      setTargetLang: (l) =>
+        // Changing target language invalidates all cached translations
+        set({ targetLang: l, cache: new Map(), visible: new Set() }),
+
+      toggleTranslation: async (messageId, text) => {
+        const { visible, cache, pending, provider, targetLang } = get();
+
+        // --- Hide ---
+        if (visible.has(messageId)) {
+          const next = new Set(visible);
+          next.delete(messageId);
+          set({ visible: next });
+          return;
+        }
+
+        // Debounce: ignore if already fetching
+        if (pending.has(messageId)) return;
+
+        // --- Show from cache ---
+        if (cache.has(messageId)) {
+          const next = new Set(visible);
+          next.add(messageId);
+          set({ visible: next });
+          return;
+        }
+
+        // --- Fetch then show ---
+        // Add to visible immediately so the panel mounts with a loading state
+        const nextPending = new Set(pending);
+        nextPending.add(messageId);
+        const nextVisible = new Set(visible);
+        nextVisible.add(messageId);
+        set({ pending: nextPending, visible: nextVisible });
+
+        try {
+          const translated = await translateText(text, targetLang, provider);
+          const s = get();
+          const newCache = new Map(s.cache);
+          newCache.set(messageId, translated);
+          const newPending = new Set(s.pending);
+          newPending.delete(messageId);
+          set({ cache: newCache, pending: newPending });
+        } catch (err) {
+          console.error('Translation failed:', err);
+          const s = get();
+          const newPending = new Set(s.pending);
+          newPending.delete(messageId);
+          const newVisible = new Set(s.visible);
+          newVisible.delete(messageId);
+          set({ pending: newPending, visible: newVisible });
+        }
+      },
+    }),
+    {
+      name: 'st-mobile-translate',
+      partialize: (state) => ({
+        provider: state.provider,
+        targetLang: state.targetLang,
+      }),
+    }
+  )
+);


### PR DESCRIPTION
## Summary

- **Phase 10.1 — Custom OpenAI-compatible endpoint support**: configure custom base URL, API key, and model for any OpenAI-compatible backend (LM Studio, Ollama, etc.)
- **Phase 10.2 — Quick Replies**: persisted sets of prompt shortcuts; tap to prefill, long-press to send; full CRUD + reorder in Settings
- **Phase 10.2 — Image Generation**: Pollinations and SD WebUI backends; inline ImageGenModal in chat
- **Phase 10.2 — Translation**: Google / Bing / LibreTranslate providers; per-message translate action
- **Phase 10.2 — User Management**: admin page to list, promote/demote, and remove users

## Changed files

| Area | Files |
|------|-------|
| API | `src/api/client.ts`, `src/api/imageGenApi.ts`, `src/api/translateApi.ts` |
| Stores | `src/stores/chatStore.ts`, `src/stores/imageGenStore.ts`, `src/stores/quickReplyStore.ts`, `src/stores/translateStore.ts` |
| Chat UI | `src/components/chat/ChatInput.tsx`, `src/components/chat/ChatMessage.tsx`, `src/components/chat/ChatView.tsx`, `src/components/chat/ImageGenModal.tsx`, `src/components/chat/QuickReplyBar.tsx` |
| Settings | `src/components/settings/SettingsPage.tsx`, `src/components/settings/QuickReplyPage.tsx`, `src/components/settings/UserManagementPage.tsx`, `src/components/settings/index.ts` |
| Routing | `src/App.tsx` |

## Test plan

- [ ] Custom endpoint: configure a custom base URL in Settings → API, send a message, confirm it routes to that endpoint
- [ ] Quick Replies: create a set + entries in Settings → Quick Replies; verify pill bar appears above chat input; tap prefills, long-press sends
- [ ] Image gen: open ImageGenModal, generate an image with Pollinations backend
- [ ] Translate: tap translate on a chat message, confirm translated text appears
- [ ] User Management: as admin, open Settings → Users, demote/remove a user

🤖 Generated with [Claude Code](https://claude.com/claude-code)