### PR TITLE
feat: Phase 7.1/7.5 — extension system + summarization

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import { ProfilePage } from './components/auth/ProfilePage';
 import { RequireRole } from './components/auth/RequireRole';
 import { MainLayout } from './components/layout/MainLayout';
 import { ChatView } from './components/chat/ChatView';
-import { SettingsPage, GenerationSettingsPage, InvitationManager, UserManagementPage, QuickReplyPage } from './components/settings';
+import { SettingsPage, GenerationSettingsPage, InvitationManager, UserManagementPage, QuickReplyPage, ExtensionsPage } from './components/settings';
 import { WorldInfoPage } from './components/worldinfo';
 import { RegexScriptPage } from './components/regexscripts';
 import { InviteAcceptPage } from './components/auth/InviteAcceptPage';
@@ -24,6 +24,7 @@ function App() {
         <Route path="/settings/invitations" element={<RequireRole minRole="admin"><InvitationManager /></RequireRole>} />
         <Route path="/settings/users" element={<RequireRole minRole="admin"><UserManagementPage /></RequireRole>} />
         <Route path="/settings/quickreplies" element={<RequireRole minRole="end_user"><QuickReplyPage /></RequireRole>} />
+        <Route path="/settings/extensions" element={<RequireRole minRole="end_user"><ExtensionsPage /></RequireRole>} />
         <Route path="/invite/:token" element={<InviteAcceptPage />} />
         <Route path="/" element={<MainLayout />}>
           <Route index element={<ChatView />} />

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -9,6 +9,7 @@ import type { ChatLayoutMode, AvatarShape } from '../../hooks/displayPreferences
 import { useRegexScriptStore } from '../../stores/regexScriptStore';
 import { applyRegexScripts, getActiveScripts } from '../../utils/regexScripts';
 import { useTranslateStore } from '../../stores/translateStore';
+import { useExtensionStore } from '../../stores/extensionStore';
 
 interface ChatMessageProps {
   /** Unique message id — used as TTS tracking key. */
@@ -157,12 +158,16 @@ export function ChatMessage({
     return scripts.length > 0 ? applyRegexScripts(content, scripts) : content;
   }, [content, regexScripts, characterAvatar, isUser]);
 
+  // Phase 7.1: Extension gates
+  const ttsEnabled = useExtensionStore((s) => s.enabled.tts);
+  const translateEnabled = useExtensionStore((s) => s.enabled.translate);
+
   // Phase 6.3: TTS — only wired for non-user, non-system messages.
   const { isSupported: ttsSupported, isSpeaking, speak, stop } = useSpeechSynthesis();
-  const showTtsButton = ttsSupported && !isUser && !isSystem && content.length > 0;
+  const showTtsButton = ttsEnabled && ttsSupported && !isUser && !isSystem && content.length > 0;
 
   // Phase 7.2: Translation
-  const showTranslateButton = !isUser && !isSystem && content.length > 0;
+  const showTranslateButton = translateEnabled && !isUser && !isSystem && content.length > 0;
   const translatedText = useTranslateStore((s) => s.cache.get(messageId));
   const isTranslating = useTranslateStore((s) => s.pending.has(messageId));
   const showTranslation = useTranslateStore((s) => s.visible.has(messageId));

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -7,9 +7,12 @@ import { ChatInput } from './ChatInput';
 import { ChatActionBar } from './ChatActionBar';
 import { GroupChatControls } from './GroupChatControls';
 import { AuthorNote } from './AuthorNote';
+import { SummaryPanel } from './SummaryPanel';
 import { TypingIndicator } from './TypingIndicator';
 import { ImageGenModal } from './ImageGenModal';
 import { QuickReplyBar } from './QuickReplyBar';
+import { useExtensionStore } from '../../stores/extensionStore';
+import { useSummarizeStore } from '../../stores/summarizeStore';
 import { useCharacterSprites } from '../../hooks/useCharacterSprites';
 import {
   getExpressionThumbnailUrl,
@@ -274,6 +277,32 @@ export function ChatView() {
       }
     }
   }, [isStreaming, messages]);
+
+  // Phase 7.5: Auto-summarize — trigger after AI response if enabled and threshold reached.
+  const wasSendingRef = useRef(false);
+  useEffect(() => {
+    if (isSending) {
+      wasSendingRef.current = true;
+      return;
+    }
+    if (!wasSendingRef.current) return;
+    wasSendingRef.current = false;
+
+    const sumStore = useSummarizeStore.getState();
+    if (!sumStore.autoSummarize) return;
+    if (!currentChatFile || !selectedCharacter) return;
+
+    const nonSystemCount = messages.filter((m) => !m.isSystem).length;
+    const existing = sumStore.getSummary(currentChatFile);
+    const lastCount = existing?.messageCount ?? 0;
+    if (nonSystemCount - lastCount >= sumStore.autoTriggerEvery) {
+      sumStore.generateSummary(messages, currentChatFile, selectedCharacter.name);
+    }
+  }, [isSending, messages, currentChatFile, selectedCharacter]);
+
+  // Phase 7.1/7.5: extension-gated features
+  const imageGenEnabled = useExtensionStore((s) => s.enabled.imageGen);
+  const summarizeEnabled = useExtensionStore((s) => s.enabled.summarize);
 
   const handleSend = (content: string, images?: string[]) => {
     if (isGroupChatMode && groupChatCharacters.length >= 2) {
@@ -753,6 +782,11 @@ export function ChatView() {
       {/* Phase 8.1: Author's Note — collapsible panel for per-chat instructions */}
       {currentChatFile && <AuthorNote fileName={currentChatFile} />}
 
+      {/* Phase 7.5: Summary panel — shown when summarize extension is enabled */}
+      {summarizeEnabled && currentChatFile && selectedCharacter && (
+        <SummaryPanel chatFile={currentChatFile} characterName={selectedCharacter.name} />
+      )}
+
       {/* Phase 10.2: Quick Reply Bar */}
       <QuickReplyBar
         onPrefill={(text) => { setPrefillText(text); setPrefillNonce((n) => n + 1); }}
@@ -770,7 +804,7 @@ export function ChatView() {
         droppedImages={droppedImages}
         droppedImagesNonce={droppedImagesNonce}
         onEditLast={lastUserMessageId && !isSending ? () => setEditLastNonce((n) => n + 1) : undefined}
-        onImageGen={!isGroupChatMode && selectedCharacter ? () => setIsImageGenOpen(true) : undefined}
+        onImageGen={imageGenEnabled && !isGroupChatMode && selectedCharacter ? () => setIsImageGenOpen(true) : undefined}
       />
 
       {/* Phase 7.1: Image generation modal */}

--- a/src/components/chat/SummaryPanel.tsx
+++ b/src/components/chat/SummaryPanel.tsx
@@ -1,0 +1,132 @@
+import { useState, useCallback } from 'react';
+import { ChevronDown, ChevronUp, FileText, Loader2, RefreshCw, Trash2 } from 'lucide-react';
+import { useSummarizeStore } from '../../stores/summarizeStore';
+import { useChatStore } from '../../stores/chatStore';
+
+interface SummaryPanelProps {
+  chatFile: string;
+  characterName: string;
+}
+
+export function SummaryPanel({ chatFile, characterName }: SummaryPanelProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const summary = useSummarizeStore((s) => s.summaries[chatFile] ?? null);
+  const isGenerating = useSummarizeStore((s) => s.isGenerating);
+  const error = useSummarizeStore((s) => s.error);
+  const generateSummary = useSummarizeStore((s) => s.generateSummary);
+  const clearSummary = useSummarizeStore((s) => s.clearSummary);
+  const clearError = useSummarizeStore((s) => s.clearError);
+
+  const messages = useChatStore((s) => s.messages);
+
+  const handleGenerate = useCallback(() => {
+    clearError();
+    generateSummary(messages, chatFile, characterName);
+  }, [messages, chatFile, characterName, generateSummary, clearError]);
+
+  const handleClear = useCallback(() => {
+    clearSummary(chatFile);
+    setIsExpanded(false);
+  }, [chatFile, clearSummary]);
+
+  const hasSummary = !!summary?.text;
+  const generatedDate = summary
+    ? new Date(summary.generatedAt).toLocaleString(undefined, {
+        month: 'short',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+      })
+    : null;
+
+  return (
+    <div className="border-t border-[var(--color-border)]">
+      <button
+        type="button"
+        onClick={() => setIsExpanded((v) => !v)}
+        className="w-full flex items-center gap-2 px-4 py-2 text-sm hover:bg-[var(--color-bg-tertiary)] transition-colors"
+        aria-expanded={isExpanded}
+        aria-label="Toggle summary panel"
+      >
+        {isGenerating ? (
+          <Loader2 size={14} className="text-[var(--color-primary)] animate-spin" />
+        ) : (
+          <FileText
+            size={14}
+            className={hasSummary ? 'text-[var(--color-primary)]' : 'text-[var(--color-text-secondary)]'}
+          />
+        )}
+        <span
+          className={`font-medium ${
+            hasSummary ? 'text-[var(--color-primary)]' : 'text-[var(--color-text-secondary)]'
+          }`}
+        >
+          Summary
+        </span>
+        {hasSummary && generatedDate && (
+          <span className="text-xs text-[var(--color-text-secondary)] ml-1">
+            ({summary.messageCount} msgs)
+          </span>
+        )}
+        {isGenerating && (
+          <span className="text-xs text-[var(--color-text-secondary)] ml-1">generating…</span>
+        )}
+        <span className="ml-auto text-[var(--color-text-secondary)]">
+          {isExpanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+        </span>
+      </button>
+
+      {isExpanded && (
+        <div className="px-4 pb-3 space-y-2 bg-[var(--color-bg-secondary)]">
+          {error && (
+            <p className="text-xs text-red-400 bg-red-400/10 rounded px-2 py-1">{error}</p>
+          )}
+
+          {hasSummary ? (
+            <>
+              <p className="text-xs text-[var(--color-text-secondary)]">
+                Generated {generatedDate} · {summary!.messageCount} messages
+              </p>
+              <p className="text-sm text-[var(--color-text-primary)] leading-relaxed whitespace-pre-wrap">
+                {summary!.text}
+              </p>
+            </>
+          ) : (
+            <p className="text-xs text-[var(--color-text-secondary)] italic">
+              No summary yet. Generate one to help the AI remember long conversations.
+            </p>
+          )}
+
+          <div className="flex items-center gap-2 pt-1">
+            <button
+              type="button"
+              onClick={handleGenerate}
+              disabled={isGenerating}
+              className="flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-lg bg-[var(--color-primary)] text-white hover:bg-[var(--color-primary)]/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {isGenerating ? (
+                <Loader2 size={12} className="animate-spin" />
+              ) : (
+                <RefreshCw size={12} />
+              )}
+              {hasSummary ? 'Regenerate' : 'Generate'}
+            </button>
+
+            {hasSummary && (
+              <button
+                type="button"
+                onClick={handleClear}
+                disabled={isGenerating}
+                className="flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-lg border border-[var(--color-border)] text-[var(--color-text-secondary)] hover:text-red-400 hover:border-red-400/50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                <Trash2 size={12} />
+                Clear
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/settings/ExtensionsPage.tsx
+++ b/src/components/settings/ExtensionsPage.tsx
@@ -1,0 +1,230 @@
+import { useState } from 'react';
+import {
+  ArrowLeft,
+  Volume2,
+  Image,
+  Languages,
+  FileText,
+  ChevronDown,
+  ChevronUp,
+  Loader2,
+} from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { useExtensionStore, type ExtensionId } from '../../stores/extensionStore';
+import { useSummarizeStore } from '../../stores/summarizeStore';
+
+interface ExtensionCardProps {
+  id: ExtensionId;
+  icon: React.ReactNode;
+  name: string;
+  description: string;
+  settingsHint?: string;
+  children?: React.ReactNode;
+}
+
+function ExtensionCard({ id, icon, name, description, settingsHint, children }: ExtensionCardProps) {
+  const [showSettings, setShowSettings] = useState(false);
+  const enabled = useExtensionStore((s) => s.enabled[id]);
+  const setEnabled = useExtensionStore((s) => s.setEnabled);
+
+  return (
+    <div className="bg-[var(--color-bg-secondary)] rounded-lg overflow-hidden">
+      <div className="flex items-center gap-3 p-4">
+        <div className="w-10 h-10 rounded-lg bg-[var(--color-primary)]/20 flex items-center justify-center flex-shrink-0">
+          {icon}
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-medium text-[var(--color-text-primary)]">{name}</p>
+          <p className="text-xs text-[var(--color-text-secondary)] mt-0.5">{description}</p>
+        </div>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={enabled}
+          onClick={() => setEnabled(id, !enabled)}
+          className={`relative w-11 h-6 rounded-full transition-colors flex-shrink-0 ${
+            enabled ? 'bg-[var(--color-primary)]' : 'bg-[var(--color-bg-tertiary)]'
+          }`}
+        >
+          <span
+            className={`absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full shadow transition-transform ${
+              enabled ? 'translate-x-5' : 'translate-x-0'
+            }`}
+          />
+        </button>
+      </div>
+
+      {children && enabled && (
+        <>
+          <button
+            type="button"
+            onClick={() => setShowSettings((v) => !v)}
+            className="w-full flex items-center gap-2 px-4 py-2 text-xs text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-tertiary)] transition-colors border-t border-[var(--color-border)]"
+          >
+            <span className="flex-1 text-left">{settingsHint ?? 'Settings'}</span>
+            {showSettings ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
+          </button>
+          {showSettings && (
+            <div className="px-4 pb-4 pt-2 border-t border-[var(--color-border)] bg-[var(--color-bg-primary)]/40">
+              {children}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+function SummarizeSettings() {
+  const autoSummarize = useSummarizeStore((s) => s.autoSummarize);
+  const autoTriggerEvery = useSummarizeStore((s) => s.autoTriggerEvery);
+  const injectionDepth = useSummarizeStore((s) => s.injectionDepth);
+  const injectionRole = useSummarizeStore((s) => s.injectionRole);
+  const isGenerating = useSummarizeStore((s) => s.isGenerating);
+  const setAutoSummarize = useSummarizeStore((s) => s.setAutoSummarize);
+  const setAutoTriggerEvery = useSummarizeStore((s) => s.setAutoTriggerEvery);
+  const setInjectionDepth = useSummarizeStore((s) => s.setInjectionDepth);
+  const setInjectionRole = useSummarizeStore((s) => s.setInjectionRole);
+
+  const inputClass =
+    'px-2 py-1 text-xs rounded border border-[var(--color-border)] bg-[var(--color-bg-primary)] text-[var(--color-text-primary)] focus:outline-none focus:ring-1 focus:ring-[var(--color-primary)]';
+  const labelClass = 'flex items-center justify-between text-xs text-[var(--color-text-secondary)] mb-2';
+
+  return (
+    <div className="space-y-3">
+      {/* Auto-summarize toggle */}
+      <div className={labelClass}>
+        <span>Auto-summarize</span>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={autoSummarize}
+          onClick={() => setAutoSummarize(!autoSummarize)}
+          disabled={isGenerating}
+          className={`relative w-9 h-5 rounded-full transition-colors ${
+            autoSummarize ? 'bg-[var(--color-primary)]' : 'bg-[var(--color-bg-tertiary)]'
+          }`}
+        >
+          <span
+            className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform ${
+              autoSummarize ? 'translate-x-4' : 'translate-x-0'
+            }`}
+          />
+        </button>
+      </div>
+
+      {/* Trigger interval */}
+      <div className={labelClass}>
+        <span>Trigger every N messages</span>
+        <input
+          type="number"
+          min={5}
+          max={100}
+          value={autoTriggerEvery}
+          onChange={(e) => setAutoTriggerEvery(parseInt(e.target.value, 10))}
+          className={`${inputClass} w-16 text-center`}
+        />
+      </div>
+
+      {/* Injection depth */}
+      <div className={labelClass}>
+        <span>
+          Injection depth
+          <span className="block text-[10px] text-[var(--color-text-secondary)]/60">
+            Messages from end (999 = before all history)
+          </span>
+        </span>
+        <input
+          type="number"
+          min={0}
+          max={999}
+          value={injectionDepth}
+          onChange={(e) => setInjectionDepth(parseInt(e.target.value, 10))}
+          className={`${inputClass} w-16 text-center`}
+        />
+      </div>
+
+      {/* Injection role */}
+      <div className={labelClass}>
+        <span>Injection role</span>
+        <select
+          value={injectionRole}
+          onChange={(e) => setInjectionRole(e.target.value as 'system' | 'user')}
+          className={inputClass}
+        >
+          <option value="system">System</option>
+          <option value="user">User</option>
+        </select>
+      </div>
+
+      {isGenerating && (
+        <div className="flex items-center gap-2 text-xs text-[var(--color-text-secondary)]">
+          <Loader2 size={12} className="animate-spin" />
+          <span>Generating summary…</span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function ExtensionsPage() {
+  const navigate = useNavigate();
+
+  return (
+    <div className="min-h-screen bg-[var(--color-bg-primary)]">
+      {/* Header */}
+      <div className="sticky top-0 z-10 bg-[var(--color-bg-primary)] border-b border-[var(--color-border)] px-4 py-3 flex items-center gap-3">
+        <button
+          type="button"
+          onClick={() => navigate('/settings')}
+          className="p-2 -ml-2 rounded-lg hover:bg-[var(--color-bg-secondary)] transition-colors"
+          aria-label="Back"
+        >
+          <ArrowLeft size={20} className="text-[var(--color-text-primary)]" />
+        </button>
+        <div>
+          <h1 className="text-base font-semibold text-[var(--color-text-primary)]">Extensions</h1>
+          <p className="text-xs text-[var(--color-text-secondary)]">Enable or disable built-in features</p>
+        </div>
+      </div>
+
+      <div className="p-4 space-y-3 max-w-xl mx-auto">
+        <p className="text-xs text-[var(--color-text-secondary)] pb-1">
+          Toggle built-in extensions on or off. Disabled extensions are hidden throughout the app.
+          Configure TTS voices and translation providers in the main Settings page.
+        </p>
+
+        <ExtensionCard
+          id="tts"
+          icon={<Volume2 size={20} className="text-[var(--color-primary)]" />}
+          name="Text-to-Speech"
+          description="Read AI messages aloud using your device's speech engine. Supports auto-read on new messages."
+        />
+
+        <ExtensionCard
+          id="imageGen"
+          icon={<Image size={20} className="text-[var(--color-primary)]" />}
+          name="Image Generation"
+          description="Generate images from prompts using Pollinations or a local Stable Diffusion WebUI. Images are inserted inline in chat."
+        />
+
+        <ExtensionCard
+          id="translate"
+          icon={<Languages size={20} className="text-[var(--color-primary)]" />}
+          name="Translation"
+          description="Translate AI messages to your preferred language. Tap the globe icon on any message. Configure provider and language in Settings."
+        />
+
+        <ExtensionCard
+          id="summarize"
+          icon={<FileText size={20} className="text-[var(--color-primary)]" />}
+          name="Summarization"
+          description="Condense long conversations into a summary injected into the AI's context, preventing memory loss over long chats."
+          settingsHint="Configure auto-summarize and injection"
+        >
+          <SummarizeSettings />
+        </ExtensionCard>
+      </div>
+    </div>
+  );
+}

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -519,6 +519,25 @@ export function SettingsPage() {
               </button>
             </section>
 
+            {/* Extensions (Phase 7.1) */}
+            <section className="bg-[var(--color-bg-secondary)] rounded-lg overflow-hidden">
+              <button
+                onClick={() => navigate('/settings/extensions')}
+                className="w-full flex items-center gap-3 p-4 hover:bg-[var(--color-bg-tertiary)] transition-colors text-left"
+              >
+                <div className="w-10 h-10 rounded-lg bg-[var(--color-primary)]/20 flex items-center justify-center">
+                  <MessageSquare size={20} className="text-[var(--color-primary)]" />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium text-[var(--color-text-primary)]">Extensions</p>
+                  <p className="text-xs text-[var(--color-text-secondary)] mt-0.5">
+                    TTS, image gen, translation, summarization
+                  </p>
+                </div>
+                <ChevronRight size={20} className="text-[var(--color-text-secondary)]" />
+              </button>
+            </section>
+
             {/* Appearance (Phase 7.4) */}
             <section className="bg-[var(--color-bg-secondary)] rounded-lg p-4">
               <div className="flex items-center gap-2 mb-3">

--- a/src/components/settings/index.ts
+++ b/src/components/settings/index.ts
@@ -3,3 +3,4 @@ export { GenerationSettingsPage } from './GenerationSettingsPage';
 export { InvitationManager } from './InvitationManager';
 export { UserManagementPage } from './UserManagementPage';
 export { QuickReplyPage } from './QuickReplyPage';
+export { ExtensionsPage } from './ExtensionsPage';

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -26,6 +26,7 @@ import {
 import { getInstructTemplate, formatInstructPrompt } from '../utils/instructTemplates';
 import { useRegexScriptStore } from './regexScriptStore';
 import { applyRegexScripts, getActiveScripts } from '../utils/regexScripts';
+import { useSummarizeStore } from './summarizeStore';
 
 export interface ChatMessage {
   id: string;
@@ -703,6 +704,12 @@ Choose the emotion that best matches how ${character.name} would feel based on t
     ? useChatStore.getState().getAuthorNote(currentChatFile)
     : null;
 
+  // Phase 7.5: Chat Summary — inject at configurable depth (default 999 = before all history)
+  const summarizeState = useSummarizeStore.getState();
+  const chatSummary = currentChatFile ? summarizeState.getSummary(currentChatFile) : null;
+  const summaryDepth = summarizeState.injectionDepth;
+  const summaryRole = summarizeState.injectionRole;
+
   // Persona @ depth
   const personaAtDepth =
     persona && persona.descriptionPosition === 'at_depth' && personaDescription
@@ -745,6 +752,13 @@ Choose the emotion that best matches how ${character.name} would feel based on t
         content: sub(authorNote.content),
       });
     }
+    // Phase 7.5: Chat Summary injection at depth
+    if (chatSummary && depthFromEnd === summaryDepth) {
+      historyWithInsertions.push({
+        role: summaryRole,
+        content: `[Summary of earlier conversation: ${chatSummary.text}]`,
+      });
+    }
     if (personaAtDepth && depthFromEnd === personaAtDepth.depth) {
       historyWithInsertions.push({
         role: personaAtDepth.role,
@@ -781,6 +795,13 @@ Choose the emotion that best matches how ${character.name} would feel based on t
     historyWithInsertions.unshift({
       role: authorNote.role,
       content: sub(authorNote.content),
+    });
+  }
+  // Phase 7.5: summary fallback — prepend before all history if depth exceeds history length
+  if (chatSummary && summaryDepth > recentMessages.length) {
+    historyWithInsertions.unshift({
+      role: summaryRole,
+      content: `[Summary of earlier conversation: ${chatSummary.text}]`,
     });
   }
   if (personaAtDepth && personaAtDepth.depth > recentMessages.length) {

--- a/src/stores/extensionStore.ts
+++ b/src/stores/extensionStore.ts
@@ -1,0 +1,27 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export type ExtensionId = 'tts' | 'imageGen' | 'translate' | 'summarize';
+
+interface ExtensionState {
+  enabled: Record<ExtensionId, boolean>;
+  setEnabled: (id: ExtensionId, on: boolean) => void;
+}
+
+const DEFAULTS: Record<ExtensionId, boolean> = {
+  tts: true,
+  imageGen: true,
+  translate: true,
+  summarize: false,
+};
+
+export const useExtensionStore = create<ExtensionState>()(
+  persist(
+    (set) => ({
+      enabled: { ...DEFAULTS },
+      setEnabled: (id, on) =>
+        set((s) => ({ enabled: { ...s.enabled, [id]: on } })),
+    }),
+    { name: 'st-mobile-extensions' }
+  )
+);

--- a/src/stores/summarizeStore.ts
+++ b/src/stores/summarizeStore.ts
@@ -1,0 +1,193 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import { api } from '../api/client';
+import { useSettingsStore } from './settingsStore';
+
+export interface ChatSummary {
+  text: string;
+  generatedAt: number;
+  /** Number of non-system messages when this summary was generated. */
+  messageCount: number;
+}
+
+interface SummarizeState {
+  // --- persisted settings ---
+  autoSummarize: boolean;
+  /** Trigger a new summary every N non-system messages since the last summary. */
+  autoTriggerEvery: number;
+  /** Depth from the END of history to inject the summary (999 = before all history). */
+  injectionDepth: number;
+  injectionRole: 'system' | 'user';
+
+  // --- persisted data ---
+  /** Keyed by chat file name (e.g. "character_2024-01-01@12:00:00.jsonl"). */
+  summaries: Record<string, ChatSummary>;
+
+  // --- session state ---
+  isGenerating: boolean;
+  error: string | null;
+
+  // --- actions ---
+  setAutoSummarize: (on: boolean) => void;
+  setAutoTriggerEvery: (n: number) => void;
+  setInjectionDepth: (d: number) => void;
+  setInjectionRole: (r: 'system' | 'user') => void;
+  getSummary: (chatFile: string) => ChatSummary | null;
+  clearSummary: (chatFile: string) => void;
+  clearError: () => void;
+  generateSummary: (
+    chatMessages: { name: string; isUser: boolean; isSystem: boolean; content: string }[],
+    chatFile: string,
+    characterName: string
+  ) => Promise<void>;
+}
+
+async function* parseSSEStream(
+  stream: ReadableStream<Uint8Array>
+): AsyncGenerator<string> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop() || '';
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed === 'data: [DONE]') continue;
+        if (trimmed.startsWith('data: ')) {
+          const data = trimmed.slice(6);
+          if (!data || data === '[DONE]') continue;
+          try {
+            const json = JSON.parse(data);
+            const content =
+              json.choices?.[0]?.delta?.content ||
+              json.choices?.[0]?.text ||
+              json.delta?.text ||
+              (json.type === 'content_block_delta' ? json.delta?.text : null) ||
+              json.content ||
+              json.message?.content?.[0]?.text ||
+              '';
+            if (content) yield content;
+          } catch {
+            if (data.length > 0 && data !== 'undefined') yield data;
+          }
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+export const useSummarizeStore = create<SummarizeState>()(
+  persist(
+    (set, get) => ({
+      autoSummarize: false,
+      autoTriggerEvery: 20,
+      injectionDepth: 999,
+      injectionRole: 'system',
+      summaries: {},
+      isGenerating: false,
+      error: null,
+
+      setAutoSummarize: (on) => set({ autoSummarize: on }),
+      setAutoTriggerEvery: (n) =>
+        set({ autoTriggerEvery: Math.max(5, Math.min(100, Math.round(n))) }),
+      setInjectionDepth: (d) => set({ injectionDepth: Math.max(0, Math.round(d)) }),
+      setInjectionRole: (r) => set({ injectionRole: r }),
+
+      getSummary: (chatFile) => get().summaries[chatFile] ?? null,
+
+      clearSummary: (chatFile) =>
+        set((s) => {
+          const { [chatFile]: _removed, ...rest } = s.summaries;
+          return { summaries: rest };
+        }),
+
+      clearError: () => set({ error: null }),
+
+      generateSummary: async (chatMessages, chatFile, characterName) => {
+        if (get().isGenerating) return;
+        set({ isGenerating: true, error: null });
+
+        try {
+          const { activeProvider, activeModel } = useSettingsStore.getState();
+
+          // Use the last 40 non-system messages for the transcript
+          const sample = chatMessages
+            .filter((m) => !m.isSystem)
+            .slice(-40);
+
+          if (sample.length === 0) {
+            set({ isGenerating: false });
+            return;
+          }
+
+          const transcript = sample
+            .map((m) => `${m.isUser ? 'User' : characterName}: ${m.content}`)
+            .join('\n');
+
+          const context: { role: 'user' | 'assistant' | 'system'; content: string }[] = [
+            {
+              role: 'system',
+              content: `You are a concise summarizer. Produce a 2-4 sentence summary of the following roleplay/chat conversation between the user and ${characterName}. Focus on key events, emotional beats, and story progression. Write in third person, past tense. Do not add commentary or analysis beyond the summary itself.`,
+            },
+            {
+              role: 'user',
+              content: `Summarize this conversation:\n\n${transcript}`,
+            },
+          ];
+
+          const stream = await api.generateMessage(
+            context,
+            characterName,
+            activeProvider,
+            activeModel,
+          );
+
+          if (!stream) {
+            set({ isGenerating: false, error: 'No response from API' });
+            return;
+          }
+
+          let text = '';
+          for await (const token of parseSSEStream(stream)) {
+            text += token;
+          }
+          text = text.trim();
+
+          if (text) {
+            const messageCount = chatMessages.filter((m) => !m.isSystem).length;
+            set((s) => ({
+              summaries: {
+                ...s.summaries,
+                [chatFile]: { text, generatedAt: Date.now(), messageCount },
+              },
+            }));
+          }
+        } catch (err) {
+          set({ error: err instanceof Error ? err.message : 'Summarization failed' });
+        } finally {
+          set({ isGenerating: false });
+        }
+      },
+    }),
+    {
+      name: 'st-mobile-summarize',
+      partialize: (s) => ({
+        autoSummarize: s.autoSummarize,
+        autoTriggerEvery: s.autoTriggerEvery,
+        injectionDepth: s.injectionDepth,
+        injectionRole: s.injectionRole,
+        summaries: s.summaries,
+      }),
+    }
+  )
+);


### PR DESCRIPTION
## Summary

- **Phase 7.1 — Extension System Architecture**: a lightweight built-in extension hub at `/settings/extensions`; enable/disable toggles for TTS, image generation, translation, and summarization; disabled extensions hide their UI throughout the app
- **Phase 7.5 — Summarization**: LLM-powered chat summarization with manual trigger and auto-summarize; summary injected into the AI context at a configurable depth; per-chat persistence

## Changed files

| Area | Files |
|------|-------|
| Stores | `src/stores/extensionStore.ts` (new), `src/stores/summarizeStore.ts` (new), `src/stores/chatStore.ts` |
| Chat UI | `src/components/chat/ChatMessage.tsx`, `src/components/chat/ChatView.tsx`, `src/components/chat/SummaryPanel.tsx` (new) |
| Settings | `src/components/settings/ExtensionsPage.tsx` (new), `src/components/settings/SettingsPage.tsx`, `src/components/settings/index.ts` |
| Routing | `src/App.tsx` |

## Details

**Extension store** (`extensionStore.ts`): persisted Zustand store with a per-extension enabled flag. Defaults: TTS/imageGen/translate = on, summarize = off.

**Extensions page** (`/settings/extensions`, available to `end_user`): four toggle cards — TTS, Image Generation, Translation, and Summarization. The Summarization card expands to show inline settings (auto-trigger interval, injection depth, injection role).

**Summarize store** (`summarizeStore.ts`): `generateSummary` calls the active LLM with a transcript of the last 40 non-system messages and a "summarize in 2–4 sentences" system prompt. Result stored per chat file name. Settings: `autoSummarize`, `autoTriggerEvery` (5–100 messages), `injectionDepth` (default 999 = before all history), `injectionRole`.

**Summary panel** (`SummaryPanel.tsx`): collapsible panel between Author's Note and Quick Reply Bar. Shows summary text, generation timestamp, message count. Generate/Regenerate + Clear buttons with loading/error states.

**Context injection** (`chatStore.ts`): summary inserted at configured depth using the same pattern as Author's Note. At depth 999 (default) it prepends before all history — ideal for representing "what happened before the current context window."

**Auto-summarize** (`ChatView.tsx`): fires after each AI response completes when `messages since last summary ≥ autoTriggerEvery`.

**Extension gating**: TTS and translate buttons in `ChatMessage` respect the store; imageGen button in `ChatView` respects the store.

## Test plan

- [ ] Settings → Extensions: verify all four toggle cards render; toggle each off and confirm the feature disappears (TTS button on messages, globe icon, image gen button in input, summary panel)
- [ ] Summarize: enable extension, open a chat with several messages, expand Summary panel, tap Generate — confirm a summary appears
- [ ] Auto-summarize: enable auto-summarize with a low threshold (e.g. 5), send enough messages — confirm summary regenerates automatically
- [ ] Summary injection: generate a summary, then send a new message — confirm the summary text appears in the AI's context (check via a prompt that asks the AI what was discussed earlier)
- [ ] Persistence: reload page — confirm extension toggles and summaries survive

🤖 Generated with [Claude Code](https://claude.com/claude-code)