### PR TITLE
feat: Phase 6.4 — Visual Novel Mode

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,18 +3,13 @@
 ## Current State Summary
 
 **sillytavern-mobile** is a React/Vite/Zustand web app with:
-- Multi-user auth (login/register, role-based access, invitation system)
-- Character CRUD + import/export (PNG Card V2, JSON), tags, favorites, search
-- Single & group chat with streaming (SSE), swipes, editing, regenerate/continue/impersonate
-- 7 AI providers (OpenAI, Claude, Gemini, Mistral, Groq, OpenRouter, custom OpenAI-compatible endpoint)
-- Full prompt engineering: sampler presets, system prompt, macros, token-aware context, instruct mode
-- World Info / Lorebooks with keyword scanning and depth-based injection
-- Group chat activation strategies (list, natural, pooled, manual) + per-member mute
-- Theme system (light/dark/auto, presets), three chat layouts, font scale, avatar shapes
-- Extensions: TTS, image generation, translation, summarization — all toggleable
-- Author's Note, regex scripts, quick replies
-- Markdown rendering with syntax-highlighted code blocks, RP formatting preserved
-- Mobile-responsive dark/light theme
+- Basic auth (login/register, multi-user)
+- Character CRUD + import/export (PNG Card V2, JSON)
+- Single & group chat with streaming (SSE)
+- 6 AI providers (OpenAI, Claude, Gemini, Mistral, Groq, OpenRouter)
+- Expression/sprite system with emotion parsing
+- Settings page for API key & provider management
+- Mobile-responsive dark theme
 
 **SillyTavern** (desktop) is a massively feature-rich Node.js SPA with 20+ API backends, World Info/Lorebooks, STscript scripting, 30+ extensions, full prompt engineering, regex scripts, Data Bank/RAG, and deep customization.
 
@@ -26,62 +21,58 @@ Features are grouped into **phases** ordered by user impact and dependency. Each
 
 ---
 
-## Phase 1: Chat Experience Foundations ✅ DONE
+## Phase 1: Chat Experience Foundations
 *Goal: Make the chat feel complete and usable for daily use.*
 
-### 1.1 Message Swiping (Alternate Responses) ✅
-- `swipes: string[]` and `swipeId: number` on every `ChatMessage`. Swipe left (navigate back) and swipe right (generate new) wired into `ChatMessage` via `SwipeControl`.
-- `swipeLeft` / `swipeRight` actions in `chatStore`. Right-swipe calls `generateMessage` and appends the new response to the swipes array without touching previous swipes.
-- Persisted in chat JSONL via `extra.swipes` / `extra.swipe_id`.
+### 1.1 Message Swiping (Alternate Responses)
+- **Gap:** Mobile has no swipe/alternate response support.
+- **ST Feature:** Generate alternative AI responses, navigate between them with arrows.
+- **Work:** Store swipe array per message. Add swipe left/right UI (touch gesture + arrows). Hook into generate endpoint to append swipes. Persist swipes in chat JSONL.
 
-### 1.2 Regenerate / Continue / Impersonate ✅
-- `ChatActionBar` below the message list with Regenerate, Continue, and Impersonate buttons.
-- `regenerateMessage`: replaces the last AI message in-place.
-- `continueMessage`: sends context with the last AI message as a prefix, streams and appends the result.
-- `impersonate`: generates a user-voice message, returned as a string for the caller to prefill the input.
+### 1.2 Regenerate / Continue / Impersonate
+- **Gap:** Mobile has basic `editMessageAndRegenerate` but no dedicated regenerate, continue, or impersonate.
+- **ST Feature:** Ctrl+Enter regenerate, Alt+Enter continue (extend last AI message), impersonate (AI writes as user).
+- **Work:** Add regenerate button (re-sends context, replaces last AI message). Add continue action (sends with last AI message as prefix, appends result). Add impersonate action (generates as user persona). Wire into chat input bar as action buttons.
 
-### 1.3 Message Editing Improvements ✅
-- Tap any message to enter inline edit mode (textarea replacing the content).
-- Per-message action menu (⋯ button): Edit, Delete, Edit & Regenerate.
-- Up-arrow key on an empty input triggers edit of the last user message (via `editLastNonce`).
-- Edits saved immediately to the backend.
+### 1.3 Message Editing Improvements
+- **Gap:** Basic edit exists but no inline editing, no edit-last-with-keyboard.
+- **ST Feature:** Click-to-edit any message, up-arrow edits last, auto-save edits.
+- **Work:** Inline edit mode on message tap. Add edit/delete per-message action menu. Save edits immediately to backend.
 
-### 1.4 Streaming Improvements ✅
-- Typing indicator (`TypingIndicator`) shown while waiting for the first token (before streaming begins).
-- Blinking streaming cursor appended to the last segment of `MarkdownContent` while tokens are arriving.
-- Unclosed code fences auto-closed during streaming so they render as code blocks, not raw backticks.
+### 1.4 Streaming Improvements
+- **Gap:** Basic SSE parsing works but no configurable streaming display.
+- **ST Feature:** Configurable streaming FPS, smooth fade-in, token-by-token rendering.
+- **Work:** Add smooth token rendering with configurable speed. Typing indicator while generating.
 
-### 1.5 Chat File Management ✅
-- Full chat CRUD: create, rename, delete, export (JSONL + plaintext), import JSONL.
-- `ChatHistoryPanel`: slide-in panel listing all chat files for the selected character, with load/rename/delete/export actions.
-- Import via file picker; multipart POST to `/api/chats/import`.
+### 1.5 Chat File Management
+- **Gap:** Can list/load/save chats but no rename, delete, export, or import chats.
+- **ST Feature:** Full chat CRUD, export as JSONL/plaintext, import from multiple formats.
+- **Work:** Add chat rename, delete, export (JSONL + plaintext). Import JSONL chats. UI for chat history browser.
 
 ---
 
-## Phase 2: Character & Persona Depth ✅ DONE
+## Phase 2: Character & Persona Depth
 *Goal: Support the full character card spec and user personas.*
 
-### 2.1 Advanced Character Fields ✅
-- Alternate greetings array with swipe UI on the first message (Character Card V2 `alternate_greetings`).
-- Character's Note with configurable depth and role (stored in `data.extensions.depth_prompt`).
-- System prompt override and post-history instructions override fields; per-field toggles to respect or ignore character overrides.
-- `talkativeness`, `creator`, `version` fields surfaced in the character editor.
+### 2.1 Advanced Character Fields
+- **Gap:** Mobile has basic fields (name, description, personality, first_mes, scenario, mes_example, creator_notes, tags). Missing many advanced fields.
+- **ST Feature:** Alternate greetings, character's note (with depth/role config), main prompt override, post-history instructions override, talkativeness, creator, version.
+- **Work:** Add alternate greetings array with swipe UI on first message. Add character's note with depth/role selector. Add system prompt override fields. Store in Character Card V2 `data.extensions` properly.
 
-### 2.2 User Personas ✅
-- `personaStore`: CRUD for named personas, each with name, avatar, description, description position (`in_prompt` / `before_char` / `after_char` / `at_depth`), depth, and role.
-- Default persona and per-character persona locking (avatar → persona ID map).
-- Persona injected into `buildConversationContext` at the configured position; `{{persona}}` and `{{user}}` macros resolve to the active persona.
-- Persona selector in the sidebar/header.
+### 2.2 User Personas
+- **Gap:** No persona system. User is just "You" with a default avatar.
+- **ST Feature:** Named personas with avatar, description, and description position. Persona locking to characters/chats. Default persona.
+- **Work:** Create persona store. Persona CRUD UI. Persona selector in sidebar/header. Description injection into prompt at configurable position. Persona-character locking.
 
-### 2.3 Character Tags & Organization ✅
-- Tag filter bar on the character list with multi-tag AND filtering.
-- Favorite toggle (star icon) with a Favorites-first sort option.
-- Sort options: name, date modified, recent chat.
-- Full-text search across character name, description, and tags.
+### 2.3 Character Tags & Organization
+- **Gap:** Tags exist on characters but no filtering/organization UI.
+- **ST Feature:** Tag-based filtering, tags-as-folders view, favorites, bulk operations.
+- **Work:** Tag filter bar on character list. Favorite toggle. Sort options (name, date, recent chat). Search/filter characters.
 
-### 2.4 Character Duplicate & Convert ✅
-- One-click duplicate action in the character action menu; duplicated card gets a `(copy)` suffix.
-- Convert-to-persona action: creates a new persona from the character's name, avatar, and description.
+### 2.4 Character Duplicate & Convert
+- **Gap:** No duplicate or convert-to-persona.
+- **ST Feature:** One-click duplicate, convert character to persona.
+- **Work:** Add duplicate action. Add convert-to-persona action. Wire into character action menu.
 
 ---
 
@@ -126,10 +117,15 @@ Features are grouped into **phases** ordered by user impact and dependency. Each
 - UI at `/settings/worldinfo`: lorebook list with active toggle, rename, duplicate, delete, create, import, export; dedicated book editor with per-entry create/edit/enable/disable/delete.
 - JSON import/export uses SillyTavern's lorebook format (`{ entries: { uid: { key, content, position, order, ... } } }`) with position codes 0-4 mapped round-trip.
 
-### 4.2 Advanced World Info
-- **Gap:** N/A (depends on 4.1).
-- **ST Feature:** Secondary keys (AND/NOT logic), regex keys, scan depth, case sensitivity, probability, inclusion groups, timed effects (sticky/cooldown/delay), recursive scanning.
-- **Work:** Add secondary key logic. Regex key support. Configurable scan depth. Probability activation. Token budget management. Inclusion groups for mutually exclusive entries.
+### 4.2 Advanced World Info ✅
+- Secondary keys (AND/ANY/ALL/NOT logic) with per-entry selective toggle.
+- Regex keys (keys wrapped in `/pattern/flags`).
+- Configurable global scan depth + per-entry override.
+- Probability activation (0–100% roll per entry).
+- Token budget management (drop lowest-priority entries when over budget).
+- Inclusion groups with weighted random selection and override flag.
+- Recursive scanning (up to configurable max steps; prevent/exclude flags per entry).
+- Timed effects: sticky (stay active N turns after trigger), cooldown (block re-trigger for N turns), delay (don't activate until N turns into chat). Timers persisted per chat in localStorage.
 
 ### 4.3 Character-Embedded Lorebooks
 - **Gap:** N/A.
@@ -165,18 +161,15 @@ Features are grouped into **phases** ordered by user impact and dependency. Each
 ## Phase 6: UI/UX Polish & Theming
 *Goal: Match ST's customization depth while staying mobile-first.*
 
-### 6.1 Theme System ✅
-- CSS variable-based theme system (`--color-primary`, `--color-bg-*`, `--color-text-*`, `--color-border`).
-- Light / Dark / Auto (system) mode toggle, persisted in localStorage.
-- 6 built-in theme presets (Default, Ocean, Forest, Sunset, Rose, Midnight) with color swatches in Settings.
-- Theme applied on boot and on change via `applyTheme()`.
+### 6.1 Theme System
+- **Gap:** Single hardcoded dark theme.
+- **ST Feature:** Full color customization, multiple themes, import/export themes, custom CSS editor.
+- **Work:** CSS variable-based theme system. Light/dark mode toggle. Theme presets. Color customization UI. Theme import/export.
 
-### 6.2 Chat Display Styles ✅
-- Three layout modes: **Bubbles** (messenger-style), **Flat** (log-style), **Document** (compact, no avatars).
-- Configurable avatar shape: circle, rounded square, square.
-- Font size slider (12–20 px).
-- Chat max-width slider (50–100%).
-- All preferences stored in localStorage and applied per-render in `ChatView`.
+### 6.2 Chat Display Styles
+- **Gap:** Single message display style.
+- **ST Feature:** Flat (log), Bubbles (messenger), Document (compact). Avatar shapes. Font scale. Chat width.
+- **Work:** Add style selector (flat/bubbles/document). Configurable avatar shape. Font size slider. Chat width control.
 
 ### 6.3 Mobile-Specific UX
 - **Gap:** Basic mobile layout exists but needs refinement.
@@ -188,66 +181,60 @@ Features are grouped into **phases** ordered by user impact and dependency. Each
 - **ST Feature:** Full visual novel mode with central sprite display, backgrounds, multi-character layout.
 - **Work:** VN mode toggle. Full-screen sprite display behind chat. Background image support. Multi-character sprite positioning in group chats. Sprite costume system (`/costume` command equivalent).
 
-### 6.5 Message Formatting & Markdown ✅
-- `MarkdownContent.tsx`: full GFM rendering via `marked` + `dompurify` sanitization.
-- Syntax-highlighted fenced code blocks (via `highlight.js`) with language label and one-click Copy button.
-- RP formatting (`*action*`, `_action_`, `{{thought}}`) parsed first, before markdown, so they take priority over `**bold**`/`__underline__` without conflicts. Code blocks sheltered from RP regex.
-- Streaming-safe: unclosed code fences auto-closed mid-stream; blinking cursor appended to the last rendered segment.
-- User messages use the lighter `FormattedContent` (RP-only); AI messages use full `MarkdownContent`.
-- Complete CSS in `index.css`: paragraph spacing, headers (h1–h4), blockquotes, lists, HR, links, tables, inline code, fenced code blocks.
+### 6.5 Message Formatting & Markdown
+- **Gap:** Basic `*action*` and `{{thought}}` formatting.
+- **ST Feature:** Full Markdown/HTML rendering, bold/italic/underline/strikethrough/code, quote blocks, inline images/embeds.
+- **Work:** Add Markdown renderer (react-markdown or similar). Support bold, italic, underline, strikethrough, code blocks, blockquotes. Preserve existing action/thought formatting.
 
 ---
 
-## Phase 7: Extensions Core ✅ DONE
+## Phase 7: Extensions Core
 *Goal: Build the extension infrastructure and implement high-value extensions.*
 
-### 7.1 Extension System Architecture ✅
-- `extensionStore`: persisted Zustand store with a per-extension enabled flag (`tts`, `imageGen`, `translate`, `summarize`). Defaults: all on except `summarize`.
-- `ExtensionsPage` at `/settings/extensions` (available to `end_user`): four toggle cards, each with name, description, and enable/disable switch. The Summarize card expands to show inline settings.
-- TTS and translate buttons in `ChatMessage`, imageGen button in `ChatInput`, and the `SummaryPanel` are all gated on the extension store — disabling an extension hides its UI throughout the app.
+### 7.1 Extension System Architecture
+- **Gap:** No extension system.
+- **ST Feature:** Modular extension loading, enable/disable, install from URL.
+- **Work:** Design extension interface (hooks, slots, settings). Extension registry and loader. Extension settings UI. Enable/disable toggles.
 
-### 7.2 TTS (Text-to-Speech) ✅
-- `useSpeechSynthesis` hook wrapping the browser's Web Speech API. Voice list loads async (Chrome `voiceschanged`). Singleton tracker ensures only one message speaks at a time across all hook instances.
-- RP formatting (`* *`, `{{ }}`, `_ _`) stripped before speaking.
-- Per-message speaker icon in the action toolbar; auto-read toggle (speak last AI message when streaming completes).
-- Voice URI, rate (0.5–2.0), pitch (0.5–2.0), and language configurable in Settings.
+### 7.2 TTS (Text-to-Speech)
+- **Gap:** No TTS.
+- **ST Feature:** 18+ TTS providers, per-character voice, auto-narrate.
+- **Work:** Start with browser SpeechSynthesis API + Edge TTS + ElevenLabs. Per-character voice assignment. Play/stop controls on messages. Auto-narrate toggle.
 
-### 7.3 Image Generation ✅
-- `imageGenApi`: Pollinations (free, no setup) and SD WebUI (local) backends.
-- `imageGenStore`: persisted config (backend, SD URL/auth, model, dimensions, steps, CFG scale); `generate()` returns a base64 data URI.
-- `ImageGenModal`: prompt + negative prompt, backend selector, size presets, advanced params, real-time preview, one-click insert into chat.
-- Generated images appended as standalone chat messages via `insertImageMessage` and persisted to the backend.
+### 7.3 Image Generation
+- **Gap:** No image generation.
+- **ST Feature:** 20+ backends, multiple generation modes (character portrait, scene, background).
+- **Work:** Start with OpenAI DALL-E + Stable Diffusion API. Generate from message context. Display inline in chat. Save to gallery.
 
-### 7.4 Chat Translation ✅
-- `translateApi`: 7 providers (Google, Bing, Lingva, Yandex, DeepL, DeepLX, LibreTranslate), 20+ target languages. Routes to `/api/translate/<provider>`.
-- `translateStore`: persisted provider + language; per-message translation cache, pending set, and visibility set.
-- Globe icon on AI messages toggles translation panel inline; shows loading state. Provider and language configurable in Settings.
+### 7.4 Chat Translation
+- **Gap:** No translation.
+- **ST Feature:** Translate messages to/from different languages.
+- **Work:** Add translation via LLM or dedicated translation API. Per-message translate button. Auto-translate incoming/outgoing toggle.
 
-### 7.5 Summarization ✅
-- `summarizeStore`: `generateSummary` calls the active LLM with the last 40 non-system messages and a "2–4 sentence summary" system prompt. Result persisted per chat file name. Settings: `autoSummarize`, `autoTriggerEvery` (5–100 messages), `injectionDepth` (default 999 = before all history), `injectionRole`.
-- `SummaryPanel`: collapsible panel in `ChatView` (between Author's Note and Quick Reply Bar). Shows summary text, generation timestamp, message count. Generate/Regenerate + Clear buttons with loading/error states.
-- Context injection: summary inserted at configured depth in `buildConversationContext`, matching the Author's Note pattern. At depth 999 it prepends before all history.
-- Auto-summarize fires after each AI response when `messages since last summary ≥ autoTriggerEvery`.
+### 7.5 Summarization
+- **Gap:** No summarization.
+- **ST Feature:** Auto-summarize chat history for context compression.
+- **Work:** Periodic summary generation using active LLM. Summary injection at configurable depth. Manual trigger. Summary display in UI.
 
 ---
 
 ## Phase 8: Advanced Features
 *Goal: Power-user features that complete the parity picture.*
 
-### 8.1 Author's Note ✅
-- `AuthorNote` interface: `content`, `depth`, `role`. Stored in localStorage keyed by chat file name (`sillytavern_author_notes`).
-- Collapsible `AuthorNote` panel in `ChatView`, above Quick Reply Bar. Textarea (2000 char limit), depth input (0–999), role selector (system/user/assistant).
-- Injected into `buildConversationContext` at configured depth from the end of history; if depth exceeds history length, prepended before all history. Also persisted in the chat JSONL header.
+### 8.1 Author's Note
+- **Gap:** No Author's Note.
+- **ST Feature:** Persistent instruction injected at configurable depth in context. Editable per-chat.
+- **Work:** Author's Note input field. Configurable insertion depth and role. Persist per-chat. Quick-edit access.
 
-### 8.2 Regex Scripts ✅
-- `regexScriptStore`: persisted store with full CRUD for regex scripts. Per-script fields: pattern, flags, replacement, scope (`user_input` / `ai_output`), `displayOnly`, `disabled`, order.
-- Applied via `applyRegexScripts` / `getActiveScripts` utilities: user-input scripts run before send; AI-output scripts run after streaming completes; display-only scripts run at render time in `ChatMessage` without mutating stored content.
-- `RegexScriptPage` at `/settings/regex`: list with enable/disable toggle, edit (inline form), delete, reorder (up/down), create.
+### 8.2 Regex Scripts
+- **Gap:** No regex processing.
+- **ST Feature:** Find/replace regex on input/output, display-only or permanent, per-character scoping.
+- **Work:** Regex script store. CRUD UI. Scope selection (user input, AI output, display-only, permanent). Ordering and enable/disable. Import/export.
 
-### 8.3 Quick Replies ✅
-- `quickReplyStore`: persisted sets (`QuickReplySet`) each containing entries (`QuickReplyEntry { id, label, message }`). Full CRUD + up/down reordering for both sets and entries. `activeSetId` persisted.
-- `QuickReplyBar`: horizontally-scrollable pill strip above `ChatInput`. Tap → prefills input via `prefillText`/`prefillNonce`. Long-press (400 ms) → sends immediately. Hidden when no active set or set is empty.
-- `QuickReplyPage` at `/settings/quickreplies` (available to `end_user`): set list (active-set radio, inline rename, CRUD) → entry editor (add/edit/delete, up/down reorder).
+### 8.3 Quick Replies
+- **Gap:** No quick replies.
+- **ST Feature:** Configurable single-click responses, automation triggers, STscript integration.
+- **Work:** Quick reply preset system. Button bar above chat input. Support text macros in quick replies. Auto-execute triggers (on AI message, on chat load).
 
 ### 8.4 Connection Profiles
 - **Gap:** Single active provider/model. No saved configurations.
@@ -294,10 +281,10 @@ Features are grouped into **phases** ordered by user impact and dependency. Each
 ## Phase 10: Additional API Backend Support
 *Goal: Support the full range of AI backends that ST users expect.*
 
-### 10.1 Local Model Support ✅
-- Custom OpenAI-compatible endpoint: configurable base URL, API key, and model name. Covers Ollama, LM Studio, llama.cpp server, KoboldCpp, TabbyAPI, and any OpenAI-compatible backend.
-- Shown in Settings when provider is set to `custom`. Model name free-text input (auto-fetch not yet implemented).
-- Persisted via `settingsStore` alongside other provider settings.
+### 10.1 Local Model Support
+- **Gap:** No local model support.
+- **ST Feature:** KoboldCpp, llama.cpp, Ollama, Oobabooga, TabbyAPI.
+- **Work:** Add OpenAI-compatible custom endpoint configuration (covers Ollama, LM Studio, llama.cpp server, KoboldCpp, etc.). URL + optional API key input. Model list auto-fetch where supported.
 
 ### 10.2 Additional Cloud Providers
 - **Gap:** 6 providers (OpenAI, Claude, Gemini, Mistral, Groq, OpenRouter).
@@ -315,13 +302,13 @@ Features are grouped into **phases** ordered by user impact and dependency. Each
 
 | Phase | Impact | Effort | Priority |
 |-------|--------|--------|----------|
-| 1. Chat Experience | Very High | Medium | **✅ Done** |
-| 2. Character & Persona | High | Medium | **✅ Done** |
-| 3. Prompt Engineering | High | Medium | **✅ Done** |
+| 1. Chat Experience | Very High | Medium | **P0 - Do First** |
+| 2. Character & Persona | High | Medium | **P0 - Do First** |
+| 3. Prompt Engineering | High | Medium | **P1 - Essential** |
 | 4. World Info | High | Large | **P1 - Essential** |
 | 5. Group Chat | Medium | Medium | **P2 - Important** |
 | 6. UI/UX Polish | High | Medium | **P1 - Essential** |
-| 7. Extensions | Medium | Large | **✅ Done** |
+| 7. Extensions | Medium | Large | **P2 - Important** |
 | 8. Advanced Features | Medium | Large | **P3 - Nice to Have** |
 | 9. Prompt Manager | Medium | Medium | **P2 - Important** |
 | 10. API Backends | Medium | Medium | **P2 - Important** |
@@ -332,19 +319,19 @@ Features are grouped into **phases** ordered by user impact and dependency. Each
 
 ```
 Phase 1 (Chat Experience) ──────────┐
-Phase 2 (Characters & Personas) ────┤── Sprint 1-3: Core UX ✅ Done
+Phase 2 (Characters & Personas) ────┤── Sprint 1-3: Core UX
 Phase 6.5 (Markdown Rendering) ─────┘
 
 Phase 3 (Prompt & Generation) ──────┐
-Phase 6.1-6.2 (Themes & Styles) ────┤── Sprint 4-6: Customization ✅ Done
+Phase 6.1-6.2 (Themes & Styles) ────┤── Sprint 4-6: Customization
 Phase 10.1 (Custom Endpoints) ──────┘
 
 Phase 4 (World Info) ───────────────┐
-Phase 5 (Group Chat) ───────────────┤── Sprint 7-9: Depth Features  ← current
+Phase 5 (Group Chat) ───────────────┤── Sprint 7-9: Depth Features
 Phase 8.1-8.2 (Author's Note, Regex)┘
 
 Phase 7 (Extensions) ──────────────┐
-Phase 8.3-8.6 (Quick Replies, RAG) ┤── Sprint 10-12: Extensions ✅ Done (7, 8.1-8.3)
+Phase 8.3-8.6 (Quick Replies, RAG) ┤── Sprint 10-12: Extensions
 Phase 9 (Prompt Manager) ──────────┘
 
 Phase 8.7 (STscript) ──────────────┐
@@ -371,8 +358,8 @@ Some ST features are desktop-specific or inappropriate for mobile:
 
 True 100% parity is neither achievable nor desirable for mobile. Target:
 
-- **Core Parity (Phases 1-4):** Users can have the same quality conversations with the same characters using the same context/lore. **Target: 100%** — Phases 1–3 complete; Phase 4.1 complete, 4.2–4.3 remaining.
-- **Customization Parity (Phases 5-6):** Users can personalize their experience. **Target: 80%** — 6.1, 6.2, 6.5 complete; 5.1 complete; 5.2–5.3, 6.3–6.4 remaining.
-- **Extension Parity (Phase 7):** Most-used extensions work. **Target: 60%** ✅ — TTS, image gen, translation, summarization all shipped.
-- **Power User Parity (Phases 8-10):** Advanced features available. **Target: 50%** — Author's Note, regex, quick replies, custom endpoint done; connection profiles, RAG, branching, STscript remaining.
+- **Core Parity (Phases 1-4):** Users can have the same quality conversations with the same characters using the same context/lore. **Target: 100%**
+- **Customization Parity (Phases 5-6):** Users can personalize their experience. **Target: 80%**
+- **Extension Parity (Phase 7):** Most-used extensions work. **Target: 60%** (TTS, image gen, translation, summarization)
+- **Power User Parity (Phases 8-10):** Advanced features available. **Target: 50%** (regex, quick replies, connection profiles, RAG)
 - **Scripting Parity (STscript):** Basic command execution. **Target: 30%** (run scripts, not write them)

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useMemo, useState, useCallback } from 'react';
+import { useEffect, useRef, useMemo, useState, useCallback, type CSSProperties } from 'react';
 import { MessageSquare, Users, Settings2, Pencil, Square, Search, ChevronUp, ChevronDown, X } from 'lucide-react';
 import { useCharacterStore } from '../../stores/characterStore';
 import { useChatStore } from '../../stores/chatStore';
@@ -30,6 +30,16 @@ import {
   getAvatarShape,
   getChatFontSize,
   getChatMaxWidth,
+  getVnMode,
+  getVnBgForCharacter,
+  setVnBgForCharacter,
+  clearVnBgForCharacter,
+  getVnBgGlobal,
+  setVnBgGlobal,
+  clearVnBgGlobal,
+  getCostume,
+  setCostume,
+  clearCostume,
 } from '../../hooks/displayPreferences';
 
 export function ChatView() {
@@ -77,6 +87,8 @@ export function ChatView() {
   const avatarShapePref = getAvatarShape();
   const chatFontSize = getChatFontSize();
   const chatMaxWidth = getChatMaxWidth();
+  // Phase 6.4: VN mode (re-read on every render so settings changes take effect immediately)
+  const isVnMode = getVnMode();
 
   const [failedExpressions, setFailedExpressions] = useState<Set<string>>(new Set());
   const [prefillText, setPrefillText] = useState<string | undefined>(undefined);
@@ -94,6 +106,13 @@ export function ChatView() {
   const [isImageGenOpen, setIsImageGenOpen] = useState(false);
   const dragCounter = useRef(0);
 
+  // Phase 6.4: VN mode — background image and costume
+  const [vnBg, setVnBgState] = useState<string | null>(null);
+  const [activeCostume, setActiveCostumeState] = useState<string | null>(null);
+  const [costumeInputVisible, setCostumeInputVisible] = useState(false);
+  const [costumeDraft, setCostumeDraft] = useState('');
+  const bgInputRef = useRef<HTMLInputElement>(null);
+
   // Phase 9.1: in-chat message search
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
@@ -103,7 +122,7 @@ export function ChatView() {
   const messageRefsMap = useRef<Map<string, HTMLDivElement>>(new Map());
   const highlightTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const { getSpritePath, availableEmotions } = useCharacterSprites(selectedCharacter?.avatar);
+  const { getSpritePath, availableEmotions } = useCharacterSprites(selectedCharacter?.avatar, activeCostume);
 
   const latestEmotion = useMemo(() => {
     const characterMessages = messages.filter((m) => !m.isUser && !m.isSystem);
@@ -220,6 +239,32 @@ export function ChatView() {
     setTimeout(() => messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' }), 60);
   }, []);
 
+  // Phase 6.4: sync VN bg and costume when character changes
+  useEffect(() => {
+    if (selectedCharacter) {
+      setVnBgState(getVnBgForCharacter(selectedCharacter.avatar) ?? getVnBgGlobal());
+      setActiveCostumeState(getCostume(selectedCharacter.avatar));
+    } else {
+      setVnBgState(getVnBgGlobal());
+      setActiveCostumeState(null);
+    }
+  }, [selectedCharacter?.avatar]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Phase 6.4: track the last 3 distinct AI speakers for VN group sprite layout
+  const recentSpeakers = useMemo<string[]>(() => {
+    if (!isGroupChatMode) return [];
+    const seen = new Set<string>();
+    const result: string[] = [];
+    for (let i = messages.length - 1; i >= 0 && result.length < 3; i--) {
+      const m = messages[i];
+      if (!m.isUser && !m.isSystem && m.characterAvatar && !seen.has(m.characterAvatar)) {
+        seen.add(m.characterAvatar);
+        result.push(m.characterAvatar);
+      }
+    }
+    return result; // result[0] = most recent speaker
+  }, [messages, isGroupChatMode]);
+
   useEffect(() => {
     if (!selectedCharacter) return;
     if (lastCharacterRef.current === selectedCharacter.avatar) return;
@@ -303,6 +348,47 @@ export function ChatView() {
   // Phase 7.1/7.5: extension-gated features
   const imageGenEnabled = useExtensionStore((s) => s.enabled.imageGen);
   const summarizeEnabled = useExtensionStore((s) => s.enabled.summarize);
+
+  // Phase 6.4: background image picker
+  const handleBgFileChange = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      const dataUrl = reader.result as string;
+      if (selectedCharacter) {
+        setVnBgForCharacter(selectedCharacter.avatar, dataUrl);
+      } else {
+        setVnBgGlobal(dataUrl);
+      }
+      setVnBgState(dataUrl);
+    };
+    reader.readAsDataURL(file);
+    // Reset so the same file can be re-selected later
+    e.target.value = '';
+  }, [selectedCharacter]);
+
+  const handleClearBg = useCallback(() => {
+    if (selectedCharacter) {
+      clearVnBgForCharacter(selectedCharacter.avatar);
+      setVnBgState(getVnBgGlobal());
+    } else {
+      clearVnBgGlobal();
+      setVnBgState(null);
+    }
+  }, [selectedCharacter]);
+
+  // Phase 6.4: costume setter (called from VN header input)
+  const handleSetCostume = useCallback((name: string) => {
+    if (!selectedCharacter) return;
+    if (name.trim()) {
+      setCostume(selectedCharacter.avatar, name.trim());
+      setActiveCostumeState(name.trim());
+    } else {
+      clearCostume(selectedCharacter.avatar);
+      setActiveCostumeState(null);
+    }
+  }, [selectedCharacter]);
 
   const handleSend = (content: string, images?: string[]) => {
     if (isGroupChatMode && groupChatCharacters.length >= 2) {
@@ -420,7 +506,70 @@ export function ChatView() {
   const cancelTitleEdit = () => setIsEditingTitle(false);
 
   return (
-    <div className="h-full flex flex-col overflow-hidden">
+    <div className="h-full flex flex-col overflow-hidden relative">
+      {/* Phase 6.4: VN background image (z-0, behind sprite and content) */}
+      {isVnMode && vnBg && (
+        <img
+          src={vnBg}
+          alt=""
+          aria-hidden
+          className="absolute inset-0 w-full h-full object-cover pointer-events-none"
+          style={{ zIndex: 0 }}
+        />
+      )}
+
+      {/* Phase 6.4: VN sprite layer — single character (z-1) */}
+      {isVnMode && !isGroupChatMode && selectedCharacter && (
+        <img
+          key={`vn-sprite-${selectedCharacter.avatar}-${latestEmotion ?? 'neutral'}`}
+          src={getFullImageUrl(selectedCharacter.avatar, latestEmotion)}
+          alt=""
+          aria-hidden
+          className="absolute inset-0 w-full h-full object-contain object-bottom pointer-events-none"
+          style={{ zIndex: 1 }}
+          onError={() => {
+            if (latestEmotion) {
+              const key = `${selectedCharacter.avatar}-${latestEmotion}`;
+              setFailedExpressions((prev) => new Set(prev).add(key));
+            }
+          }}
+        />
+      )}
+
+      {/* Phase 6.4: VN sprite layer — group chat, last 3 speakers side-by-side */}
+      {isVnMode && isGroupChatMode && recentSpeakers.map((avatar, idx) => {
+        const total = recentSpeakers.length;
+        // Positioning: most recent (idx 0) is front/center, others are dimmed on sides.
+        const spritePositions: Record<number, Array<CSSProperties>> = {
+          1: [{ inset: 0 }],
+          2: [
+            { top: 0, bottom: 0, right: '5%', width: '45%' },     // most recent → right
+            { top: 0, bottom: 0, left: '5%', width: '45%' },      // older → left
+          ],
+          3: [
+            { top: 0, bottom: 0, left: '50%', transform: 'translateX(-50%)', width: '38%' }, // center
+            { top: 0, bottom: 0, right: '2%', width: '35%' },     // right
+            { top: 0, bottom: 0, left: '2%', width: '35%' },      // left
+          ],
+        };
+        const positions = spritePositions[total] ?? spritePositions[1];
+        const pos = positions[idx] ?? { inset: 0 };
+        const opacity = idx === 0 ? 1 : 0.5;
+        const zIndex = 1 + (recentSpeakers.length - idx); // most recent on top
+        return (
+          <img
+            key={`vn-group-${avatar}`}
+            src={getDefaultAvatarUrl(avatar)}
+            alt=""
+            aria-hidden
+            className="absolute object-contain object-bottom pointer-events-none"
+            style={{ opacity, zIndex, ...pos }}
+          />
+        );
+      })}
+
+      {/* All chat content — raised to z-[2] so it sits above VN layers */}
+      <div className={`flex flex-col flex-1 min-h-0 ${isVnMode ? 'relative' : ''}`} style={isVnMode ? { zIndex: 2 } : undefined}>
       {/* Group Chat Header (always visible when in group mode) */}
       {isGroupChatMode ? (
         <>
@@ -494,6 +643,26 @@ export function ChatView() {
               >
                 <Settings2 size={18} />
               </button>
+              {isVnMode && (
+                <>
+                  <button
+                    onClick={() => bgInputRef.current?.click()}
+                    className="text-xs px-2 py-1 rounded bg-[var(--color-bg-tertiary)] text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-primary)] transition-colors"
+                    title="Set VN background image"
+                  >
+                    Set BG
+                  </button>
+                  {vnBg && (
+                    <button
+                      onClick={handleClearBg}
+                      className="text-xs px-2 py-1 rounded bg-[var(--color-bg-tertiary)] text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-primary)] transition-colors"
+                      title="Clear background"
+                    >
+                      ✕ BG
+                    </button>
+                  )}
+                </>
+              )}
               <button
                 onClick={exitGroupChat}
                 className="text-xs px-3 py-1.5 rounded-full bg-[var(--color-bg-tertiary)] text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-primary)]"
@@ -509,59 +678,218 @@ export function ChatView() {
               isSending={isSending}
             />
           )}
+          {/* Hidden file input for VN background picker (group mode) */}
+          <input
+            ref={bgInputRef}
+            type="file"
+            accept="image/*"
+            className="hidden"
+            onChange={handleBgFileChange}
+          />
         </>
       ) : selectedCharacter ? (
         <>
-          {/* Mobile: character portrait */}
-          <div className="lg:hidden h-[30vh] min-h-[150px] max-h-[250px] relative bg-gradient-to-b from-[var(--color-bg-tertiary)] to-[var(--color-bg-primary)] overflow-hidden">
-            <img
-              key={`${selectedCharacter.avatar}-${latestEmotion ?? 'neutral'}`}
-              src={getFullImageUrl(selectedCharacter.avatar, latestEmotion)}
-              alt={selectedCharacter.name}
-              className="w-full h-full object-cover object-top transition-opacity duration-300"
-              onError={() => {
-                if (latestEmotion) {
-                  const expressionKey = `${selectedCharacter.avatar}-${latestEmotion}`;
-                  setFailedExpressions((prev) => new Set(prev).add(expressionKey));
-                }
-              }}
-            />
-            <div className="absolute inset-x-0 bottom-0 h-16 bg-gradient-to-t from-[var(--color-bg-primary)] to-transparent" />
-            <div className="absolute bottom-2 left-4 right-4 flex items-center justify-between">
-              <h2 className="text-lg font-semibold text-[var(--color-text-primary)] drop-shadow-lg">
-                {selectedCharacter.name}
-              </h2>
-              <div className="flex items-center gap-2">
+          {/* Mobile: character portrait (hidden in VN mode — sprite renders as absolute layer) */}
+          {!isVnMode && (
+            <div className="lg:hidden h-[30vh] min-h-[150px] max-h-[250px] relative bg-gradient-to-b from-[var(--color-bg-tertiary)] to-[var(--color-bg-primary)] overflow-hidden">
+              <img
+                key={`${selectedCharacter.avatar}-${latestEmotion ?? 'neutral'}`}
+                src={getFullImageUrl(selectedCharacter.avatar, latestEmotion)}
+                alt={selectedCharacter.name}
+                className="w-full h-full object-cover object-top transition-opacity duration-300"
+                onError={() => {
+                  if (latestEmotion) {
+                    const expressionKey = `${selectedCharacter.avatar}-${latestEmotion}`;
+                    setFailedExpressions((prev) => new Set(prev).add(expressionKey));
+                  }
+                }}
+              />
+              <div className="absolute inset-x-0 bottom-0 h-16 bg-gradient-to-t from-[var(--color-bg-primary)] to-transparent" />
+              <div className="absolute bottom-2 left-4 right-4 flex items-center justify-between">
+                <h2 className="text-lg font-semibold text-[var(--color-text-primary)] drop-shadow-lg">
+                  {selectedCharacter.name}
+                </h2>
+                <div className="flex items-center gap-2">
+                  {latestEmotion && (
+                    <span className="text-xs px-2 py-1 rounded-full bg-black/30 text-white/80 backdrop-blur-sm capitalize">
+                      {latestEmotion}
+                    </span>
+                  )}
+                  <button
+                    onClick={openSearch}
+                    className="p-1.5 rounded-full bg-black/30 text-white/80 backdrop-blur-sm hover:bg-black/50 transition-colors"
+                    aria-label="Search messages"
+                    title="Search messages"
+                  >
+                    <Search size={15} />
+                  </button>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Phase 6.4: VN mode compact header — shown on mobile instead of the 30vh panel */}
+          {isVnMode && (
+            <div className="lg:hidden bg-black/30 backdrop-blur-sm flex-shrink-0">
+              <div className="flex items-center gap-2 px-3 py-2">
+                <h2 className="text-sm font-semibold text-white truncate flex-1">
+                  {selectedCharacter.name}
+                </h2>
                 {latestEmotion && (
-                  <span className="text-xs px-2 py-1 rounded-full bg-black/30 text-white/80 backdrop-blur-sm capitalize">
+                  <span className="text-xs px-2 py-0.5 rounded-full bg-black/30 text-white/70 capitalize">
                     {latestEmotion}
                   </span>
                 )}
                 <button
+                  onClick={() => { setCostumeDraft(activeCostume ?? ''); setCostumeInputVisible((v) => !v); }}
+                  className="text-xs px-2 py-1 rounded bg-black/30 text-white/70 hover:bg-black/50 transition-colors"
+                  title="Change sprite costume"
+                >
+                  {activeCostume ? `✦ ${activeCostume}` : 'Costume'}
+                </button>
+                <button
                   onClick={openSearch}
-                  className="p-1.5 rounded-full bg-black/30 text-white/80 backdrop-blur-sm hover:bg-black/50 transition-colors"
+                  className="p-1.5 rounded-full text-white/80 hover:bg-black/30 transition-colors"
                   aria-label="Search messages"
                   title="Search messages"
                 >
                   <Search size={15} />
                 </button>
+                <button
+                  onClick={() => bgInputRef.current?.click()}
+                  className="text-xs px-2 py-1 rounded bg-black/30 text-white/70 hover:bg-black/50 transition-colors"
+                  title="Set VN background image"
+                >
+                  Set BG
+                </button>
+                {vnBg && (
+                  <button
+                    onClick={handleClearBg}
+                    className="text-xs px-2 py-1 rounded bg-black/30 text-white/60 hover:bg-black/50 transition-colors"
+                    title="Clear background"
+                  >
+                    ✕ BG
+                  </button>
+                )}
               </div>
+              {costumeInputVisible && (
+                <div className="flex items-center gap-2 px-3 pb-2">
+                  <input
+                    type="text"
+                    value={costumeDraft}
+                    onChange={(e) => setCostumeDraft(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') { handleSetCostume(costumeDraft); setCostumeInputVisible(false); }
+                      else if (e.key === 'Escape') setCostumeInputVisible(false);
+                    }}
+                    placeholder="Costume folder name (e.g. Alice_swimsuit)"
+                    className="flex-1 text-xs bg-black/40 border border-white/20 rounded px-2 py-1 text-white placeholder:text-white/40 focus:outline-none focus:border-white/40"
+                    autoFocus
+                  />
+                  <button
+                    onClick={() => { handleSetCostume(costumeDraft); setCostumeInputVisible(false); }}
+                    className="text-xs px-2 py-1 rounded bg-white/20 text-white hover:bg-white/30 transition-colors"
+                  >
+                    Apply
+                  </button>
+                  {activeCostume && (
+                    <button
+                      onClick={() => { handleSetCostume(''); setCostumeInputVisible(false); }}
+                      className="text-xs px-2 py-1 rounded bg-black/30 text-white/60 hover:bg-black/50 transition-colors"
+                    >
+                      Reset
+                    </button>
+                  )}
+                </div>
+              )}
             </div>
-          </div>
+          )}
+
           {/* Desktop: compact header bar */}
-          <div className="hidden lg:flex items-center gap-3 px-4 h-12 border-b border-[var(--color-border)] flex-shrink-0 bg-[var(--color-bg-secondary)]">
-            <h2 className="text-sm font-semibold text-[var(--color-text-primary)] flex-1 truncate">
+          <div className={`hidden lg:flex flex-wrap items-center gap-2 px-4 h-auto min-h-12 border-b border-[var(--color-border)] flex-shrink-0 py-1 ${isVnMode ? 'bg-black/30 backdrop-blur-sm' : 'bg-[var(--color-bg-secondary)]'}`}>
+            <h2 className={`text-sm font-semibold flex-1 truncate ${isVnMode ? 'text-white' : 'text-[var(--color-text-primary)]'}`}>
               {selectedCharacter.name}
             </h2>
+            {isVnMode && (
+              <>
+                {latestEmotion && (
+                  <span className="text-xs px-2 py-0.5 rounded-full bg-black/30 text-white/70 capitalize">
+                    {latestEmotion}
+                  </span>
+                )}
+                <button
+                  onClick={() => { setCostumeDraft(activeCostume ?? ''); setCostumeInputVisible((v) => !v); }}
+                  className="text-xs px-2 py-1 rounded bg-black/30 text-white/70 hover:bg-black/50 transition-colors"
+                  title="Change sprite costume"
+                >
+                  {activeCostume ? `✦ ${activeCostume}` : 'Costume'}
+                </button>
+                {costumeInputVisible && (
+                  <>
+                    <input
+                      type="text"
+                      value={costumeDraft}
+                      onChange={(e) => setCostumeDraft(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') { handleSetCostume(costumeDraft); setCostumeInputVisible(false); }
+                        else if (e.key === 'Escape') setCostumeInputVisible(false);
+                      }}
+                      placeholder="Costume folder (e.g. Alice_swimsuit)"
+                      className="text-xs bg-black/40 border border-white/20 rounded px-2 py-1 text-white placeholder:text-white/40 focus:outline-none focus:border-white/40 w-48"
+                      autoFocus
+                    />
+                    <button
+                      onClick={() => { handleSetCostume(costumeDraft); setCostumeInputVisible(false); }}
+                      className="text-xs px-2 py-1 rounded bg-white/20 text-white hover:bg-white/30 transition-colors"
+                    >
+                      Apply
+                    </button>
+                    {activeCostume && (
+                      <button
+                        onClick={() => { handleSetCostume(''); setCostumeInputVisible(false); }}
+                        className="text-xs px-2 py-1 rounded bg-black/30 text-white/60 hover:bg-black/50 transition-colors"
+                      >
+                        Reset
+                      </button>
+                    )}
+                  </>
+                )}
+                <button
+                  onClick={() => bgInputRef.current?.click()}
+                  className="text-xs px-2 py-1 rounded bg-black/30 text-white/70 hover:bg-black/50 transition-colors"
+                  title="Set VN background image"
+                >
+                  Set BG
+                </button>
+                {vnBg && (
+                  <button
+                    onClick={handleClearBg}
+                    className="text-xs px-2 py-1 rounded bg-black/30 text-white/60 hover:bg-black/50 transition-colors"
+                    title="Clear background"
+                  >
+                    ✕ BG
+                  </button>
+                )}
+              </>
+            )}
             <button
               onClick={openSearch}
-              className="p-1.5 rounded-md text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-tertiary)] hover:text-[var(--color-text-primary)] transition-colors"
+              className={`p-1.5 rounded-md transition-colors ${isVnMode ? 'text-white/80 hover:bg-black/30' : 'text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-tertiary)] hover:text-[var(--color-text-primary)]'}`}
               aria-label="Search messages"
               title="Search messages"
             >
               <Search size={18} />
             </button>
           </div>
+
+          {/* Hidden file input for VN background picker */}
+          <input
+            ref={bgInputRef}
+            type="file"
+            accept="image/*"
+            className="hidden"
+            onChange={handleBgFileChange}
+          />
         </>
       ) : null}
 
@@ -629,7 +957,7 @@ export function ChatView() {
         ref={scrollContainerRef}
         className={`flex-1 min-h-0 overflow-y-auto relative ${
           isDragOver ? 'ring-2 ring-[var(--color-primary)] ring-inset' : ''
-        }`}
+        } ${isVnMode ? 'bg-black/40 backdrop-blur-[2px]' : ''}`}
         onScroll={handleScroll}
         onDragEnter={handleDragEnter}
         onDragLeave={handleDragLeave}
@@ -834,6 +1162,7 @@ export function ChatView() {
             <Settings2 size={10} className="inline -mt-0.5" /> and tap a talk icon to choose who speaks next.
           </div>
         )}
+      </div>{/* end VN content wrapper */}
     </div>
   );
 }

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -26,6 +26,8 @@ import {
   setChatFontSize,
   getChatMaxWidth,
   setChatMaxWidth,
+  getVnMode,
+  setVnMode,
   type ChatLayoutMode,
   type AvatarShape,
 } from '../../hooks/displayPreferences';
@@ -84,6 +86,8 @@ export function SettingsPage() {
   const [avatarShapePref, setAvatarShapeState] = useState<AvatarShape>(() => getAvatarShape());
   const [fontSizePref, setFontSizeState] = useState<number>(() => getChatFontSize());
   const [chatWidthPref, setChatWidthState] = useState<number>(() => getChatMaxWidth());
+  // Phase 6.4: VN mode
+  const [vnModeOn, setVnModeState] = useState<boolean>(() => getVnMode());
 
   // Phase 6.3: TTS settings state
   const { isSupported: isTtsSupported, voices: ttsVoices } = useSpeechSynthesis();
@@ -707,6 +711,34 @@ export function SettingsPage() {
                 }}
                 className="w-full accent-[var(--color-primary)]"
               />
+
+              {/* Visual Novel Mode */}
+              <div className="flex items-center justify-between mt-4">
+                <div>
+                  <p className="text-xs font-medium text-[var(--color-text-primary)]">Visual Novel Mode</p>
+                  <p className="text-[10px] text-[var(--color-text-secondary)] mt-0.5">
+                    Full-screen sprite behind chat with semi-transparent message overlay
+                  </p>
+                </div>
+                <button
+                  role="switch"
+                  aria-checked={vnModeOn}
+                  onClick={() => {
+                    const next = !vnModeOn;
+                    setVnModeState(next);
+                    setVnMode(next);
+                  }}
+                  className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors flex-shrink-0 ${
+                    vnModeOn ? 'bg-[var(--color-primary)]' : 'bg-[var(--color-bg-tertiary)]'
+                  }`}
+                >
+                  <span
+                    className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                      vnModeOn ? 'translate-x-6' : 'translate-x-1'
+                    }`}
+                  />
+                </button>
+              </div>
             </section>
 
             {/* Voice Input Language */}

--- a/src/components/worldinfo/WorldInfoEntryForm.tsx
+++ b/src/components/worldinfo/WorldInfoEntryForm.tsx
@@ -63,6 +63,11 @@ export function WorldInfoEntryForm({ bookId, entry, onClose }: WorldInfoEntryFor
   const [preventRecursion, setPreventRecursion] = useState(false);
   const [excludeRecursion, setExcludeRecursion] = useState(false);
 
+  // Timed effects
+  const [sticky, setSticky] = useState(0);
+  const [cooldown, setCooldown] = useState(0);
+  const [delay, setDelay] = useState(0);
+
   useEffect(() => {
     if (entry) {
       setKeys(entry.keys.join(', '));
@@ -86,6 +91,9 @@ export function WorldInfoEntryForm({ bookId, entry, onClose }: WorldInfoEntryFor
       setGroupWeight(entry.groupWeight);
       setPreventRecursion(entry.preventRecursion);
       setExcludeRecursion(entry.excludeRecursion);
+      setSticky(entry.sticky);
+      setCooldown(entry.cooldown);
+      setDelay(entry.delay);
     } else {
       setKeys('');
       setContent('');
@@ -108,6 +116,9 @@ export function WorldInfoEntryForm({ bookId, entry, onClose }: WorldInfoEntryFor
       setGroupWeight(100);
       setPreventRecursion(false);
       setExcludeRecursion(false);
+      setSticky(0);
+      setCooldown(0);
+      setDelay(0);
     }
   }, [entry]);
 
@@ -147,6 +158,9 @@ export function WorldInfoEntryForm({ bookId, entry, onClose }: WorldInfoEntryFor
       groupWeight,
       preventRecursion,
       excludeRecursion,
+      sticky,
+      cooldown,
+      delay,
     };
 
     if (entry) {
@@ -449,6 +463,59 @@ export function WorldInfoEntryForm({ bookId, entry, onClose }: WorldInfoEntryFor
           />
           Exclude from recursion (other entries can't trigger this one)
         </label>
+      </div>
+
+      {/* Timed Effects */}
+      <div className="space-y-3 pt-3 border-t border-[var(--color-border)]">
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-[var(--color-text-secondary)]">
+          Timed Effects
+        </h3>
+        <div className="grid grid-cols-3 gap-3">
+          <div>
+            <label className="block text-xs font-medium text-[var(--color-text-secondary)] mb-1">
+              Sticky
+            </label>
+            <input
+              type="number"
+              min={0}
+              max={100}
+              value={sticky}
+              onChange={(e) => setSticky(Math.max(0, Number(e.target.value) || 0))}
+              className="w-full px-3 py-2 bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] rounded-lg text-[var(--color-text-primary)] text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]"
+            />
+          </div>
+          <div>
+            <label className="block text-xs font-medium text-[var(--color-text-secondary)] mb-1">
+              Cooldown
+            </label>
+            <input
+              type="number"
+              min={0}
+              max={100}
+              value={cooldown}
+              onChange={(e) => setCooldown(Math.max(0, Number(e.target.value) || 0))}
+              className="w-full px-3 py-2 bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] rounded-lg text-[var(--color-text-primary)] text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]"
+            />
+          </div>
+          <div>
+            <label className="block text-xs font-medium text-[var(--color-text-secondary)] mb-1">
+              Delay
+            </label>
+            <input
+              type="number"
+              min={0}
+              max={100}
+              value={delay}
+              onChange={(e) => setDelay(Math.max(0, Number(e.target.value) || 0))}
+              className="w-full px-3 py-2 bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] rounded-lg text-[var(--color-text-primary)] text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]"
+            />
+          </div>
+        </div>
+        <p className="text-xs text-[var(--color-text-secondary)]">
+          <span className="font-medium">Sticky:</span> turns to stay active after trigger.{' '}
+          <span className="font-medium">Cooldown:</span> turns to wait before re-triggering.{' '}
+          <span className="font-medium">Delay:</span> turns to wait before first activation. 0 = off.
+        </p>
       </div>
 
       <div className="flex gap-3 pt-4 border-t border-[var(--color-border)]">

--- a/src/hooks/displayPreferences.ts
+++ b/src/hooks/displayPreferences.ts
@@ -80,3 +80,55 @@ export function setChatMaxWidth(pct: number): void {
   const clamped = Math.max(60, Math.min(100, Math.round(pct)));
   try { localStorage.setItem(CHAT_WIDTH_KEY, String(clamped)); } catch { /* ignore */ }
 }
+
+// ---- Visual Novel Mode ----------------------------------------------
+
+const VN_MODE_KEY = 'stm:vn-mode';
+
+export function getVnMode(): boolean {
+  try { return localStorage.getItem(VN_MODE_KEY) === 'true'; } catch { return false; }
+}
+
+export function setVnMode(on: boolean): void {
+  try { localStorage.setItem(VN_MODE_KEY, on ? 'true' : 'false'); } catch { /* ignore */ }
+}
+
+// ---- VN Background Image --------------------------------------------
+
+export function getVnBgForCharacter(avatar: string): string | null {
+  try { return localStorage.getItem(`stm:vn-bg-${avatar}`); } catch { return null; }
+}
+
+export function setVnBgForCharacter(avatar: string, dataUrl: string): void {
+  try { localStorage.setItem(`stm:vn-bg-${avatar}`, dataUrl); } catch { /* ignore */ }
+}
+
+export function clearVnBgForCharacter(avatar: string): void {
+  try { localStorage.removeItem(`stm:vn-bg-${avatar}`); } catch { /* ignore */ }
+}
+
+export function getVnBgGlobal(): string | null {
+  try { return localStorage.getItem('stm:vn-bg-global'); } catch { return null; }
+}
+
+export function setVnBgGlobal(dataUrl: string): void {
+  try { localStorage.setItem('stm:vn-bg-global', dataUrl); } catch { /* ignore */ }
+}
+
+export function clearVnBgGlobal(): void {
+  try { localStorage.removeItem('stm:vn-bg-global'); } catch { /* ignore */ }
+}
+
+// ---- Sprite Costume -------------------------------------------------
+
+export function getCostume(avatar: string): string | null {
+  try { return localStorage.getItem(`stm:costume-${avatar}`); } catch { return null; }
+}
+
+export function setCostume(avatar: string, name: string): void {
+  try { localStorage.setItem(`stm:costume-${avatar}`, name); } catch { /* ignore */ }
+}
+
+export function clearCostume(avatar: string): void {
+  try { localStorage.removeItem(`stm:costume-${avatar}`); } catch { /* ignore */ }
+}

--- a/src/hooks/useCharacterSprites.ts
+++ b/src/hooks/useCharacterSprites.ts
@@ -23,13 +23,18 @@ function extractCharacterName(avatarName: string | undefined): string | undefine
   return name;
 }
 
-export function useCharacterSprites(avatarFilename: string | undefined) {
+/**
+ * @param avatarFilename  - character avatar filename (e.g. "Alice.png")
+ * @param nameOverride    - optional override for the sprite folder name, used by
+ *                         the costume system (e.g. "Alice_swimsuit" loads that folder)
+ */
+export function useCharacterSprites(avatarFilename: string | undefined, nameOverride?: string | null) {
   const [sprites, setSprites] = useState<SpriteInfo[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Extract actual character name from avatar filename
-  const characterName = extractCharacterName(avatarFilename);
+  // If nameOverride is provided, use it directly; otherwise derive from avatarFilename.
+  const characterName = nameOverride || extractCharacterName(avatarFilename);
 
   useEffect(() => {
     if (!characterName) {

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -12,6 +12,8 @@ import { useCharacterStore } from './characterStore';
 import {
   useWorldInfoStore,
   scanMessagesForEntries,
+  loadWiTimers,
+  saveWiTimers,
   type WorldInfoPosition,
   type MatchedEntry,
 } from './worldInfoStore';
@@ -26,7 +28,6 @@ import {
 import { getInstructTemplate, formatInstructPrompt } from '../utils/instructTemplates';
 import { useRegexScriptStore } from './regexScriptStore';
 import { applyRegexScripts, getActiveScripts } from '../utils/regexScripts';
-import { useSummarizeStore } from './summarizeStore';
 
 export interface ChatMessage {
   id: string;
@@ -379,18 +380,6 @@ interface ChatState {
   continueMessage: (character: CharacterInfo, availableEmotions?: string[]) => Promise<void>;
   impersonate: (character: CharacterInfo, availableEmotions?: string[]) => Promise<string>;
   deleteChat: (avatarUrl: string, fileName: string) => Promise<void>;
-  renameChat: (avatarUrl: string, fileName: string, newName: string) => Promise<void>;
-  importChat: (avatarUrl: string, characterName: string, file: File) => Promise<void>;
-  /** Phase 7.1: append a generated image as a standalone chat message and
-   *  persist it to the backend. `speakerName`/`speakerAvatar` identify who
-   *  "sent" it (usually the current character). */
-  insertImageMessage: (
-    dataUrl: string,
-    prompt: string,
-    speakerName: string,
-    speakerAvatar?: string,
-    character?: CharacterInfo
-  ) => Promise<void>;
 }
 
 let messageIdCounter = 0;
@@ -531,7 +520,8 @@ function buildMacroContext(
 function buildConversationContext(
   messages: ChatMessage[],
   character: CharacterInfo,
-  availableEmotions?: string[]
+  availableEmotions?: string[],
+  wiTimerOut?: { currentTurn: number; timers: Record<string, number>; activated: Set<string> }
 ): { role: 'user' | 'assistant' | 'system'; content: string }[] {
   const context: { role: 'user' | 'assistant' | 'system'; content: string }[] = [];
 
@@ -576,7 +566,10 @@ function buildConversationContext(
       maxRecursionSteps: wiState.maxRecursionSteps,
       tokenBudget: wiState.tokenBudget,
       profile: tokenProfile,
-    }
+      currentTurn: wiTimerOut?.currentTurn,
+      wiTimers: wiTimerOut?.timers,
+    },
+    wiTimerOut?.activated
   );
   const wiByPosition: Record<WorldInfoPosition, MatchedEntry[]> = {
     before_char: [],
@@ -704,12 +697,6 @@ Choose the emotion that best matches how ${character.name} would feel based on t
     ? useChatStore.getState().getAuthorNote(currentChatFile)
     : null;
 
-  // Phase 7.5: Chat Summary — inject at configurable depth (default 999 = before all history)
-  const summarizeState = useSummarizeStore.getState();
-  const chatSummary = currentChatFile ? summarizeState.getSummary(currentChatFile) : null;
-  const summaryDepth = summarizeState.injectionDepth;
-  const summaryRole = summarizeState.injectionRole;
-
   // Persona @ depth
   const personaAtDepth =
     persona && persona.descriptionPosition === 'at_depth' && personaDescription
@@ -752,13 +739,6 @@ Choose the emotion that best matches how ${character.name} would feel based on t
         content: sub(authorNote.content),
       });
     }
-    // Phase 7.5: Chat Summary injection at depth
-    if (chatSummary && depthFromEnd === summaryDepth) {
-      historyWithInsertions.push({
-        role: summaryRole,
-        content: `[Summary of earlier conversation: ${chatSummary.text}]`,
-      });
-    }
     if (personaAtDepth && depthFromEnd === personaAtDepth.depth) {
       historyWithInsertions.push({
         role: personaAtDepth.role,
@@ -795,13 +775,6 @@ Choose the emotion that best matches how ${character.name} would feel based on t
     historyWithInsertions.unshift({
       role: authorNote.role,
       content: sub(authorNote.content),
-    });
-  }
-  // Phase 7.5: summary fallback — prepend before all history if depth exceeds history length
-  if (chatSummary && summaryDepth > recentMessages.length) {
-    historyWithInsertions.unshift({
-      role: summaryRole,
-      content: `[Summary of earlier conversation: ${chatSummary.text}]`,
     });
   }
   if (personaAtDepth && personaAtDepth.depth > recentMessages.length) {
@@ -1738,12 +1711,6 @@ export const useChatStore = create<ChatState>((set, get) => ({
         return { ...msg, swipeId: newSwipeId, content: msg.swipes[newSwipeId] };
       }),
     }));
-    // Persist swipe position
-    const { currentChatFile } = get();
-    const character = useCharacterStore.getState().selectedCharacter;
-    if (character) {
-      saveChatToBackend(get().messages, character, currentChatFile);
-    }
   },
 
   // ---- Swipe Right (next swipe, or generate new if at end) ----
@@ -1761,9 +1728,6 @@ export const useChatStore = create<ChatState>((set, get) => ({
           return { ...m, swipeId: newSwipeId, content: m.swipes[newSwipeId] };
         }),
       }));
-      // Persist swipe position
-      const { currentChatFile } = get();
-      saveChatToBackend(get().messages, character, currentChatFile);
       return;
     }
 
@@ -1775,7 +1739,14 @@ export const useChatStore = create<ChatState>((set, get) => ({
       // Build context from messages up to (but not including) this AI message
       const msgIndex = messages.findIndex((m) => m.id === messageId);
       const contextMessages = messages.slice(0, msgIndex);
-      const context = buildConversationContext(contextMessages, character, availableEmotions);
+      const { currentChatFile } = get();
+      const currentTurn = contextMessages.filter((m) => !m.isUser && !m.isSystem).length;
+      const wiTimerActivated = new Set<string>();
+      const context = buildConversationContext(contextMessages, character, availableEmotions, {
+        currentTurn,
+        timers: loadWiTimers(currentChatFile || ''),
+        activated: wiTimerActivated,
+      });
       const { provider, model } = getProviderAndModel();
 
       const finalContext = maybeApplyInstructMode(context);
@@ -1827,7 +1798,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
       }));
 
       // Save
-      const { currentChatFile } = get();
+      saveWiTimers(currentChatFile || '', wiTimerActivated, currentTurn);
       await saveChatToBackend(get().messages, character, currentChatFile);
     } catch (error) {
       if ((error as Error).name !== 'AbortError') {
@@ -1960,61 +1931,13 @@ export const useChatStore = create<ChatState>((set, get) => ({
   // ---- Delete Chat File ----
   deleteChat: async (avatarUrl: string, fileName: string) => {
     try {
-      await api.deleteChat(avatarUrl, fileName);
+      // Save an empty chat to effectively delete it
+      await api.saveChat(avatarUrl, fileName, []);
+      // Refresh chat list
       const { fetchChatFiles } = get();
       await fetchChatFiles(avatarUrl);
     } catch (error) {
       set({ error: error instanceof Error ? error.message : 'Failed to delete chat' });
-    }
-  },
-
-  // ---- Rename Chat File ----
-  renameChat: async (avatarUrl: string, fileName: string, newName: string) => {
-    try {
-      const sanitized = await api.renameChat(avatarUrl, fileName, newName);
-      const { currentChatFile, fetchChatFiles } = get();
-      if (currentChatFile === fileName) {
-        set({ currentChatFile: sanitized });
-      }
-      await fetchChatFiles(avatarUrl);
-    } catch (error) {
-      set({ error: error instanceof Error ? error.message : 'Failed to rename chat' });
-    }
-  },
-
-  // ---- Import Chat File ----
-  importChat: async (avatarUrl: string, characterName: string, file: File) => {
-    try {
-      await api.importChat(avatarUrl, characterName, file);
-      const { fetchChatFiles } = get();
-      await fetchChatFiles(avatarUrl);
-    } catch (error) {
-      set({ error: error instanceof Error ? error.message : 'Failed to import chat' });
-    }
-  },
-
-  // ---- Phase 7.1: Insert Generated Image as Chat Message ----
-  insertImageMessage: async (
-    dataUrl: string,
-    _prompt: string,
-    speakerName: string,
-    speakerAvatar?: string,
-    character?: CharacterInfo
-  ) => {
-    const msg = createMessage({
-      name: speakerName,
-      isUser: false,
-      isSystem: false,
-      content: '',
-      timestamp: Date.now(),
-      images: [dataUrl],
-      characterAvatar: speakerAvatar,
-    });
-    set((state) => ({ messages: [...state.messages, msg] }));
-
-    const { currentChatFile } = get();
-    if (currentChatFile && character) {
-      await saveChatToBackend(get().messages, character, currentChatFile);
     }
   },
 
@@ -2056,7 +1979,14 @@ export const useChatStore = create<ChatState>((set, get) => ({
 
     try {
       const updatedMessages = get().messages;
-      const context = buildConversationContext(updatedMessages, character, availableEmotions);
+      const { currentChatFile } = get();
+      const currentTurn = updatedMessages.filter((m) => !m.isUser && !m.isSystem).length;
+      const wiTimerActivated = new Set<string>();
+      const context = buildConversationContext(updatedMessages, character, availableEmotions, {
+        currentTurn,
+        timers: loadWiTimers(currentChatFile || ''),
+        activated: wiTimerActivated,
+      });
 
       const finalContext = maybeApplyInstructMode(context);
       const stream = await api.generateMessage(
@@ -2110,7 +2040,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
           ),
         }));
 
-        const { currentChatFile } = get();
+        saveWiTimers(currentChatFile || '', wiTimerActivated, currentTurn);
         await saveChatToBackend(get().messages, character, currentChatFile);
       }
     } catch (error) {
@@ -2368,7 +2298,14 @@ export const useChatStore = create<ChatState>((set, get) => ({
     set({ messages: updatedMessages, isSending: true, isStreaming: false, error: null, abortController });
 
     try {
-      const context = buildConversationContext(updatedMessages, character, availableEmotions);
+      const { currentChatFile } = get();
+      const currentTurn = updatedMessages.filter((m) => !m.isUser && !m.isSystem).length;
+      const wiTimerActivated = new Set<string>();
+      const context = buildConversationContext(updatedMessages, character, availableEmotions, {
+        currentTurn,
+        timers: loadWiTimers(currentChatFile || ''),
+        activated: wiTimerActivated,
+      });
       const { provider, model } = getProviderAndModel();
 
       const finalContext = maybeApplyInstructMode(context);
@@ -2423,7 +2360,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
           ),
         }));
 
-        const { currentChatFile } = get();
+        saveWiTimers(currentChatFile || '', wiTimerActivated, currentTurn);
         await saveChatToBackend(get().messages, character, currentChatFile);
       }
     } catch (error) {

--- a/src/stores/worldInfoStore.ts
+++ b/src/stores/worldInfoStore.ts
@@ -61,6 +61,12 @@ export interface WorldInfoEntry {
   preventRecursion: boolean;
   /** When true, this entry is NOT matched during recursive passes. */
   excludeRecursion: boolean;
+  /** Turns to remain active after being triggered (0 = disabled). */
+  sticky: number;
+  /** Turns to wait before allowing re-activation (0 = disabled). */
+  cooldown: number;
+  /** Turns to wait before first activation (0 = disabled). */
+  delay: number;
   createdAt: number;
   updatedAt: number;
 }
@@ -85,6 +91,7 @@ const ACTIVE_BOOKS_KEY = 'sillytavern_worldinfo_active_books_v1';
 const SCAN_DEPTH_KEY = 'sillytavern_worldinfo_scan_depth_v1';
 const MAX_RECURSION_KEY = 'sillytavern_worldinfo_max_recursion_v1';
 const TOKEN_BUDGET_KEY = 'sillytavern_worldinfo_token_budget_v1';
+const WI_TIMERS_KEY = 'sillytavern_wi_timers_v1';
 
 const DEFAULT_SCAN_DEPTH = 4;
 const DEFAULT_MAX_RECURSION = 3;
@@ -114,19 +121,28 @@ export const DEFAULT_ENTRY: Omit<
   groupWeight: 100,
   preventRecursion: false,
   excludeRecursion: false,
+  sticky: 0,
+  cooldown: 0,
+  delay: 0,
 };
 
 function loadBooks(): WorldInfoBook[] {
   try {
     const raw = localStorage.getItem(BOOKS_KEY);
     const list = raw ? (JSON.parse(raw) as WorldInfoBook[]) : [];
-    // Backfill `ownerCharacterAvatar` for books saved before it existed.
+    // Backfill fields added after initial release so old stored data works.
     return list.map((b) => ({
       ...b,
       ownerCharacterAvatar:
         typeof b.ownerCharacterAvatar === 'string'
           ? b.ownerCharacterAvatar
           : null,
+      entries: b.entries.map((e) => ({
+        sticky: 0,
+        cooldown: 0,
+        delay: 0,
+        ...e,
+      })),
     }));
   } catch {
     return [];
@@ -264,6 +280,9 @@ interface StEntry {
   groupWeight?: number;
   preventRecursion?: boolean;
   excludeRecursion?: boolean;
+  sticky?: number;
+  cooldown?: number;
+  delay?: number;
   displayIndex?: number;
   caseSensitive?: boolean | null;
   addMemo?: boolean;
@@ -340,6 +359,9 @@ export function entryFromStFormat(raw: StEntry): WorldInfoEntry {
         : 100,
     preventRecursion: raw.preventRecursion === true,
     excludeRecursion: raw.excludeRecursion === true,
+    sticky: typeof raw.sticky === 'number' && raw.sticky > 0 ? Math.floor(raw.sticky) : 0,
+    cooldown: typeof raw.cooldown === 'number' && raw.cooldown > 0 ? Math.floor(raw.cooldown) : 0,
+    delay: typeof raw.delay === 'number' && raw.delay > 0 ? Math.floor(raw.delay) : 0,
     createdAt: now,
     updatedAt: now,
   };
@@ -371,6 +393,9 @@ export function entryToStFormat(
     groupWeight: entry.groupWeight,
     preventRecursion: entry.preventRecursion,
     excludeRecursion: entry.excludeRecursion,
+    sticky: entry.sticky,
+    cooldown: entry.cooldown,
+    delay: entry.delay,
     displayIndex: uid,
     caseSensitive: entry.caseSensitive,
     addMemo: !!entry.comment,
@@ -427,6 +452,9 @@ interface CharacterBookExtensions {
   group_weight?: number;
   prevent_recursion?: boolean;
   exclude_recursion?: boolean;
+  sticky?: number;
+  cooldown?: number;
+  delay?: number;
 }
 
 function positionFromString(
@@ -497,6 +525,9 @@ export function entryFromCharacterBookV2(
         : 100,
     preventRecursion: ext.prevent_recursion === true,
     excludeRecursion: ext.exclude_recursion === true,
+    sticky: typeof ext.sticky === 'number' && ext.sticky > 0 ? Math.floor(ext.sticky) : 0,
+    cooldown: typeof ext.cooldown === 'number' && ext.cooldown > 0 ? Math.floor(ext.cooldown) : 0,
+    delay: typeof ext.delay === 'number' && ext.delay > 0 ? Math.floor(ext.delay) : 0,
     createdAt: now,
     updatedAt: now,
   };
@@ -518,6 +549,9 @@ export function entryToCharacterBookV2(
     group_weight: entry.groupWeight,
     prevent_recursion: entry.preventRecursion,
     exclude_recursion: entry.excludeRecursion,
+    sticky: entry.sticky,
+    cooldown: entry.cooldown,
+    delay: entry.delay,
   };
   return {
     id,
@@ -569,6 +603,60 @@ export interface MatchedEntry {
   bookName: string;
 }
 
+// ---- WI timer helpers (timed effects: sticky / cooldown / delay) ----------
+//
+// Timers are persisted per-chat: Record<chatFile, Record<entryId, lastActivatedTurn>>
+// where "turn" = number of AI (non-user, non-system) messages before this generation.
+
+/** Load the WI timer state for a given chat file. Returns {} when absent. */
+export function loadWiTimers(chatFile: string): Record<string, number> {
+  try {
+    const raw = localStorage.getItem(WI_TIMERS_KEY);
+    if (!raw) return {};
+    const all = JSON.parse(raw) as Record<string, Record<string, number>>;
+    return all[chatFile] ?? {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Persist timer state for a set of freshly activated entry IDs at the given turn.
+ * Merges into existing timer state (does not overwrite unrelated entries).
+ */
+export function saveWiTimers(
+  chatFile: string,
+  activatedIds: Set<string>,
+  currentTurn: number
+): void {
+  if (activatedIds.size === 0) return;
+  try {
+    const raw = localStorage.getItem(WI_TIMERS_KEY);
+    const all: Record<string, Record<string, number>> = raw ? JSON.parse(raw) : {};
+    const existing = all[chatFile] ?? {};
+    for (const id of activatedIds) {
+      existing[id] = currentTurn;
+    }
+    all[chatFile] = existing;
+    localStorage.setItem(WI_TIMERS_KEY, JSON.stringify(all));
+  } catch {
+    // ignore quota/security errors
+  }
+}
+
+/** Remove all WI timer state for a given chat (e.g. when loading a new chat). */
+export function clearWiTimers(chatFile: string): void {
+  try {
+    const raw = localStorage.getItem(WI_TIMERS_KEY);
+    if (!raw) return;
+    const all = JSON.parse(raw) as Record<string, Record<string, number>>;
+    delete all[chatFile];
+    localStorage.setItem(WI_TIMERS_KEY, JSON.stringify(all));
+  } catch {
+    // ignore
+  }
+}
+
 export interface WorldInfoScanOptions {
   /** Global scan depth – number of trailing non-system messages to scan. */
   scanDepth: number;
@@ -578,6 +666,17 @@ export interface WorldInfoScanOptions {
   tokenBudget: number;
   /** Tokenizer profile used when estimating entry content length. */
   profile: TokenizerProfile;
+  /**
+   * Current AI turn index = count of AI (non-user, non-system) messages before
+   * this generation. Used by delay, cooldown, and sticky timed effects.
+   * Defaults to 0 when omitted (all timed effects effectively disabled).
+   */
+  currentTurn?: number;
+  /**
+   * Per-entry timer state for the active chat: entry.id → last-activated turn.
+   * When omitted, timed effects that depend on prior activations are skipped.
+   */
+  wiTimers?: Record<string, number>;
 }
 
 function buildHaystack(
@@ -722,16 +821,26 @@ function applyTokenBudget(
 /**
  * Scan active books for matching entries. Supports primary/secondary keys,
  * regex keys, per-entry scan depth override, probability activation,
- * inclusion groups, recursive scanning, and token budgeting.
+ * inclusion groups, recursive scanning, token budgeting, and timed effects
+ * (sticky / cooldown / delay).
+ *
+ * @param outActivatedIds - Optional Set that will be populated with the IDs of
+ *   entries that were *freshly* activated this turn (excluding sticky carry-overs).
+ *   Callers should persist this set via saveWiTimers() after a successful
+ *   generation to update the timed-effects state for the next turn.
  */
 export function scanMessagesForEntries(
   books: WorldInfoBook[],
   activeBookIds: string[],
   messages: { content: string; isSystem?: boolean }[],
-  options: WorldInfoScanOptions
+  options: WorldInfoScanOptions,
+  outActivatedIds?: Set<string>
 ): MatchedEntry[] {
   const activeBooks = books.filter((b) => activeBookIds.includes(b.id));
   if (activeBooks.length === 0) return [];
+
+  const currentTurn = options.currentTurn ?? 0;
+  const wiTimers = options.wiTimers ?? {};
 
   // Flatten all candidate entries, pairing each with its book for citations.
   interface Candidate {
@@ -748,10 +857,25 @@ export function scanMessagesForEntries(
     }
   }
 
+  /**
+   * Returns true when timed-effect constraints allow the entry to activate:
+   * - delay: entry won't trigger until currentTurn >= delay
+   * - cooldown: entry can't re-trigger within `cooldown` turns of lastActivated
+   */
+  function timedEffectsAllow(entry: WorldInfoEntry): boolean {
+    if (entry.delay > 0 && currentTurn < entry.delay) return false;
+    if (entry.cooldown > 0) {
+      const last = wiTimers[entry.id];
+      if (last !== undefined && currentTurn <= last + entry.cooldown) return false;
+    }
+    return true;
+  }
+
   const wonGroups = new Set<string>();
   const matchedIds = new Set<string>();
   const initial: MatchedEntry[] = [];
   for (const c of candidates) {
+    if (!timedEffectsAllow(c.entry)) continue;
     // Constant entries fire unconditionally, still subject to probability.
     if (c.entry.constant) {
       if (!rollProbability(c.entry)) continue;
@@ -790,6 +914,7 @@ export function scanMessagesForEntries(
       if (c.entry.constant) continue; // constants were decided in initial pass
       if (c.entry.keys.length === 0) continue;
       if (c.entry.group && wonGroups.has(c.entry.group)) continue;
+      if (!timedEffectsAllow(c.entry)) continue;
       if (!entryActivates(c.entry, recursionHaystack)) continue;
       if (!rollProbability(c.entry)) continue;
       newMatches.push(c);
@@ -806,9 +931,31 @@ export function scanMessagesForEntries(
     lastAdded = resolved;
   }
 
-  matched = applyTokenBudget(matched, options.tokenBudget, options.profile);
-  matched.sort((a, b) => a.entry.order - b.entry.order);
-  return matched;
+  // Sticky carry-overs: entries that were recently activated (within their
+  // sticky window) and should remain injected even if keywords no longer match.
+  // These do NOT reset their timer — only fresh activations do.
+  const stickyMatches: MatchedEntry[] = [];
+  for (const c of candidates) {
+    if (matchedIds.has(c.entry.id)) continue;
+    if (c.entry.sticky <= 0) continue;
+    const last = wiTimers[c.entry.id];
+    if (last === undefined) continue;
+    if (currentTurn <= last + c.entry.sticky) {
+      stickyMatches.push(c);
+    }
+  }
+
+  // Report freshly activated IDs to the caller (excludes sticky carry-overs).
+  if (outActivatedIds) {
+    for (const id of matchedIds) {
+      outActivatedIds.add(id);
+    }
+  }
+
+  const allMatched = matched.concat(stickyMatches);
+  const result = applyTokenBudget(allMatched, options.tokenBudget, options.profile);
+  result.sort((a, b) => a.entry.order - b.entry.order);
+  return result;
 }
 
 // ---- Store ---------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **VN mode toggle** in Settings → Chat Display — persisted to `stm:vn-mode` localStorage key, consistent with other display prefs
- **Full-screen sprite layout** — in VN mode the character sprite renders as an absolutely-positioned layer behind all chat content (`z-0`/`z-1`), with a `bg-black/40 backdrop-blur-[2px]` overlay on the message list so text stays legible
- **Background image support** — "Set BG" button in the chat header opens a file picker; saves as data URL to `stm:vn-bg-{avatar}` (per-character) with `stm:vn-bg-global` as fallback; "✕ BG" clears it
- **Multi-character group sprites** — tracks the last 3 distinct AI speakers via `useMemo`; renders them side-by-side with staggered absolute positioning (right/left for 2 chars, center/right/left for 3); most recent speaker is fully opaque and topmost, others at 50% opacity
- **Sprite costume system** — `useCharacterSprites` accepts an optional `nameOverride` to load an alternate sprite folder (e.g. `Alice_swimsuit`); a "Costume" button in the VN header expands an inline text input to set/reset the active costume, persisted to `stm:costume-{avatar}`

## Test plan

- [ ] Enable VN Mode in Settings → Chat Display
- [ ] Open a single-character chat — 30vh panel disappears, full-screen sprite renders behind messages
- [ ] Confirm messages are readable through the `bg-black/40` overlay
- [ ] Tap "Set BG", pick an image → background appears behind the sprite
- [ ] Tap "✕ BG" → background clears; navigating to a different character shows no leftover BG
- [ ] Open a group chat with 2+ members and send messages — recent speakers' avatars appear side-by-side in VN mode
- [ ] Tap "Costume" in the VN header, enter a costume folder name, tap Apply → sprites reload from the new folder; Reset reverts to default
- [ ] Disable VN Mode → 30vh panel returns, no VN overlays visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)