### PR TITLE
fix: resolve tsc -b errors blocking Docker build

### DIFF
--- a/src/components/settings/UserManagementPage.tsx
+++ b/src/components/settings/UserManagementPage.tsx
@@ -4,7 +4,6 @@ import { useNavigate } from 'react-router-dom';
 import { adminApi, type AdminUserInfo } from '../../api/client';
 import { useAuthStore } from '../../stores/authStore';
 import { Avatar, Button } from '../ui';
-import { hasMinRole } from '../../utils/permissions';
 import type { UserRole } from '../../types';
 
 const ROLE_OPTIONS: { value: UserRole; label: string }[] = [

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -380,6 +380,15 @@ interface ChatState {
   continueMessage: (character: CharacterInfo, availableEmotions?: string[]) => Promise<void>;
   impersonate: (character: CharacterInfo, availableEmotions?: string[]) => Promise<string>;
   deleteChat: (avatarUrl: string, fileName: string) => Promise<void>;
+  renameChat: (avatarUrl: string, originalFile: string, renamedFile: string) => Promise<void>;
+  importChat: (avatarUrl: string, characterName: string, file: File) => Promise<void>;
+  insertImageMessage: (
+    dataUrl: string,
+    prompt: string,
+    characterName: string,
+    characterAvatar: string,
+    character: CharacterInfo
+  ) => Promise<void>;
 }
 
 let messageIdCounter = 0;
@@ -1939,6 +1948,50 @@ export const useChatStore = create<ChatState>((set, get) => ({
     } catch (error) {
       set({ error: error instanceof Error ? error.message : 'Failed to delete chat' });
     }
+  },
+
+  // ---- Rename Chat File ----
+  renameChat: async (avatarUrl: string, originalFile: string, renamedFile: string) => {
+    try {
+      await api.renameChat(avatarUrl, originalFile, renamedFile);
+      const { fetchChatFiles } = get();
+      await fetchChatFiles(avatarUrl);
+    } catch (error) {
+      set({ error: error instanceof Error ? error.message : 'Failed to rename chat' });
+    }
+  },
+
+  // ---- Import Chat File ----
+  importChat: async (avatarUrl: string, characterName: string, file: File) => {
+    try {
+      await api.importChat(avatarUrl, characterName, file);
+      const { fetchChatFiles } = get();
+      await fetchChatFiles(avatarUrl);
+    } catch (error) {
+      set({ error: error instanceof Error ? error.message : 'Failed to import chat' });
+    }
+  },
+
+  // ---- Insert Image Message (image gen result inline) ----
+  insertImageMessage: async (
+    dataUrl: string,
+    prompt: string,
+    characterName: string,
+    characterAvatar: string,
+    character: CharacterInfo
+  ) => {
+    const { addMessage, currentChatFile } = get();
+    addMessage({
+      name: characterName,
+      isUser: false,
+      isSystem: false,
+      content: prompt ? `*${prompt}*` : '',
+      timestamp: Date.now(),
+      characterAvatar,
+      images: [dataUrl],
+    });
+    // Persist to backend (non-fatal if it fails)
+    await saveChatToBackend(get().messages, character, currentChatFile);
   },
 
   // ---- Send Message (updated with abort support) ----

--- a/src/stores/worldInfoStore.ts
+++ b/src/stores/worldInfoStore.ts
@@ -138,10 +138,10 @@ function loadBooks(): WorldInfoBook[] {
           ? b.ownerCharacterAvatar
           : null,
       entries: b.entries.map((e) => ({
-        sticky: 0,
-        cooldown: 0,
-        delay: 0,
         ...e,
+        sticky: e.sticky ?? 0,
+        cooldown: e.cooldown ?? 0,
+        delay: e.delay ?? 0,
       })),
     }));
   } catch {


### PR DESCRIPTION
## Summary

Fixes pre-existing TypeScript errors that caused `npm run build` (and therefore the Docker build) to fail with exit code 2.

- **chatStore** — `insertImageMessage`, `renameChat`, `importChat` were called in `ChatHistoryPanel` and `ImageGenModal` but never declared in `ChatState` or implemented; added both
- **worldInfoStore** — TS2783 duplicate-key error from `sticky/cooldown/delay` defaults placed before the spread; fixed with nullish coalescing after the spread
- **UserManagementPage** — removed unused `hasMinRole` import (TS6133)

## Test plan

- [ ] `docker compose up -d --build frontend` completes without error
- [ ] Chat history panel rename and import still work
- [ ] Image generation modal inserts result into chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)