### PR TITLE
feat: Phase 7.1 + 7.3 — Extension system + image generation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,10 +5,13 @@ import { ProfilePage } from './components/auth/ProfilePage';
 import { RequireRole } from './components/auth/RequireRole';
 import { MainLayout } from './components/layout/MainLayout';
 import { ChatView } from './components/chat/ChatView';
-import { SettingsPage, GenerationSettingsPage, InvitationManager, UserManagementPage, QuickReplyPage, ExtensionsPage, DataBankPage } from './components/settings';
+import { SettingsPage, GenerationSettingsPage, InvitationManager, UserManagementPage, QuickReplyPage, ExtensionsPage, DataBankPage, GalleryPage } from './components/settings';
 import { WorldInfoPage } from './components/worldinfo';
 import { RegexScriptPage } from './components/regexscripts';
 import { InviteAcceptPage } from './components/auth/InviteAcceptPage';
+
+// Phase 7.1: Register all built-in extensions at app startup.
+import './extensions';
 
 function App() {
   return (
@@ -26,6 +29,7 @@ function App() {
         <Route path="/settings/quickreplies" element={<RequireRole minRole="end_user"><QuickReplyPage /></RequireRole>} />
         <Route path="/settings/extensions" element={<RequireRole minRole="end_user"><ExtensionsPage /></RequireRole>} />
         <Route path="/settings/databank" element={<RequireRole minRole="end_user"><DataBankPage /></RequireRole>} />
+        <Route path="/settings/gallery" element={<RequireRole minRole="end_user"><GalleryPage /></RequireRole>} />
         <Route path="/invite/:token" element={<InviteAcceptPage />} />
         <Route path="/" element={<MainLayout />}>
           <Route index element={<ChatView />} />

--- a/src/api/imageGenApi.ts
+++ b/src/api/imageGenApi.ts
@@ -1,12 +1,67 @@
 import { apiRequest } from './client';
+import { api } from './client';
+import { useSettingsStore } from '../stores/settingsStore';
 
-export type ImageGenBackend = 'pollinations' | 'sdwebui';
+export type ImageGenBackend = 'pollinations' | 'sdwebui' | 'dalle';
 
 export interface ImageGenResult {
   /** Raw base64 string — no data URI prefix. */
   base64: string;
   format: string;
 }
+
+// ---------------------------------------------------------------------------
+// SSE stream helper (same pattern as summarizeStore)
+// ---------------------------------------------------------------------------
+
+async function collectStream(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  let result = '';
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop() || '';
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed === 'data: [DONE]') continue;
+        if (trimmed.startsWith('data: ')) {
+          const data = trimmed.slice(6);
+          if (!data || data === '[DONE]') continue;
+          try {
+            const json = JSON.parse(data);
+            const content =
+              json.choices?.[0]?.delta?.content ||
+              json.choices?.[0]?.text ||
+              json.delta?.text ||
+              (json.type === 'content_block_delta' ? json.delta?.text : null) ||
+              json.content ||
+              json.message?.content?.[0]?.text ||
+              '';
+            if (content) result += content;
+          } catch {
+            if (data.length > 0 && data !== 'undefined') result += data;
+          }
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  return result.trim();
+}
+
+// ---------------------------------------------------------------------------
+// API methods
+// ---------------------------------------------------------------------------
 
 export const imageGenApi = {
   async pingSdWebui(url: string, auth?: string): Promise<boolean> {
@@ -70,5 +125,94 @@ export const imageGenApi = {
       throw new Error('No images returned from SD WebUI');
     }
     return { base64: result.images[0], format: 'png' };
+  },
+
+  /**
+   * Generate an image using OpenAI DALL-E (2 or 3).
+   * Calls the SillyTavern backend at POST /api/openai/generate-image,
+   * which forwards to https://api.openai.com/v1/images/generations.
+   */
+  async generateDalle(opts: {
+    prompt: string;
+    model?: 'dall-e-3' | 'dall-e-2';
+    size?: string;
+    quality?: 'standard' | 'hd';
+  }): Promise<ImageGenResult> {
+    const model = opts.model ?? 'dall-e-3';
+    const body: Record<string, unknown> = {
+      prompt: opts.prompt,
+      model,
+      size: opts.size ?? '1024x1024',
+      response_format: 'b64_json',
+      n: 1,
+    };
+    // Quality is only supported by DALL-E 3
+    if (model === 'dall-e-3') {
+      body.quality = opts.quality ?? 'standard';
+    }
+
+    const result = await apiRequest<{
+      data: { b64_json?: string; url?: string; revised_prompt?: string }[];
+    }>('/api/openai/generate-image', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    });
+
+    const img = result.data?.[0];
+    if (!img?.b64_json) {
+      throw new Error('No image data returned from DALL-E');
+    }
+    return { base64: img.b64_json, format: 'png' };
+  },
+
+  /**
+   * Generate an image prompt from recent chat context using the active LLM.
+   * Returns a detailed visual description suitable for image generation.
+   */
+  async generatePromptFromContext(
+    messages: { name: string; isUser: boolean; isSystem: boolean; content: string }[],
+    characterName: string
+  ): Promise<string> {
+    const { activeProvider, activeModel } = useSettingsStore.getState();
+
+    // Take last 10 non-system messages for context
+    const recent = messages
+      .filter((m) => !m.isSystem)
+      .slice(-10);
+
+    if (recent.length === 0) {
+      throw new Error('No messages to generate a prompt from');
+    }
+
+    const transcript = recent
+      .map((m) => `${m.isUser ? 'User' : characterName}: ${m.content}`)
+      .join('\n');
+
+    const context: { role: 'user' | 'assistant' | 'system'; content: string }[] = [
+      {
+        role: 'system',
+        content:
+          'You are a creative art director. Based on the conversation below, write a detailed visual description for an image generation AI that captures the current scene. ' +
+          'Focus on: character appearance, setting, mood, lighting, and composition. ' +
+          'Output ONLY the image prompt — no explanations, no preamble, no quotes.',
+      },
+      {
+        role: 'user',
+        content: `Write an image generation prompt for this scene:\n\n${transcript}`,
+      },
+    ];
+
+    const stream = await api.generateMessage(
+      context,
+      characterName,
+      activeProvider,
+      activeModel,
+    );
+
+    if (!stream) {
+      throw new Error('No response from LLM');
+    }
+
+    return collectStream(stream);
   },
 };

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -1217,6 +1217,8 @@ export function ChatView() {
           isOpen={isImageGenOpen}
           onClose={() => setIsImageGenOpen(false)}
           initialPrompt={selectedCharacter.name}
+          messages={messages}
+          characterName={selectedCharacter.name}
           onInsert={async (dataUrl, prompt) => {
             await insertImageMessage(
               dataUrl,

--- a/src/components/chat/ImageGenModal.tsx
+++ b/src/components/chat/ImageGenModal.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect } from 'react';
-import { X, Image, Settings2, ChevronDown, ChevronUp, Loader2, RefreshCw } from 'lucide-react';
+import { X, Image, Settings2, ChevronDown, ChevronUp, Loader2, RefreshCw, Sparkles } from 'lucide-react';
 import { useImageGenStore } from '../../stores/imageGenStore';
+import { imageGenApi } from '../../api/imageGenApi';
 import { Button } from '../ui';
 import type { ImageGenBackend } from '../../api/imageGenApi';
 
@@ -11,6 +12,10 @@ interface ImageGenModalProps {
   onInsert: (dataUrl: string, prompt: string) => void;
   /** Optional prompt pre-fill (e.g. character name). */
   initialPrompt?: string;
+  /** Current chat messages — used for context-aware prompt generation. */
+  messages?: { name: string; isUser: boolean; isSystem: boolean; content: string }[];
+  /** Character name for context-aware prompt generation. */
+  characterName?: string;
 }
 
 const POLLINATIONS_MODELS = [
@@ -23,20 +28,41 @@ const POLLINATIONS_MODELS = [
 ];
 
 const SIZE_PRESETS = [
-  { label: 'Square 1024×1024', width: 1024, height: 1024 },
-  { label: 'Portrait 768×1024', width: 768, height: 1024 },
-  { label: 'Landscape 1024×768', width: 1024, height: 768 },
-  { label: 'SD Square 512×512', width: 512, height: 512 },
-  { label: 'SD Portrait 512×768', width: 512, height: 768 },
-  { label: 'SD Landscape 768×512', width: 768, height: 512 },
+  { label: 'Square 1024\u00d71024', width: 1024, height: 1024 },
+  { label: 'Portrait 768\u00d71024', width: 768, height: 1024 },
+  { label: 'Landscape 1024\u00d7768', width: 1024, height: 768 },
+  { label: 'SD Square 512\u00d7512', width: 512, height: 512 },
+  { label: 'SD Portrait 512\u00d7768', width: 512, height: 768 },
+  { label: 'SD Landscape 768\u00d7512', width: 768, height: 512 },
 ];
 
-export function ImageGenModal({ isOpen, onClose, onInsert, initialPrompt = '' }: ImageGenModalProps) {
+const DALLE3_SIZE_PRESETS = [
+  { label: 'Square 1024\u00d71024', width: 1024, height: 1024 },
+  { label: 'Landscape 1792\u00d71024', width: 1792, height: 1024 },
+  { label: 'Portrait 1024\u00d71792', width: 1024, height: 1792 },
+];
+
+const DALLE2_SIZE_PRESETS = [
+  { label: 'Small 256\u00d7256', width: 256, height: 256 },
+  { label: 'Medium 512\u00d7512', width: 512, height: 512 },
+  { label: 'Large 1024\u00d71024', width: 1024, height: 1024 },
+];
+
+export function ImageGenModal({
+  isOpen,
+  onClose,
+  onInsert,
+  initialPrompt = '',
+  messages,
+  characterName,
+}: ImageGenModalProps) {
   const {
     backend,
     sdUrl,
     sdAuth,
     pollinationsModel,
+    dalleModel,
+    dalleQuality,
     width,
     height,
     steps,
@@ -53,6 +79,7 @@ export function ImageGenModal({ isOpen, onClose, onInsert, initialPrompt = '' }:
   const [showNeg, setShowNeg] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
   const [result, setResult] = useState<string | null>(null);
+  const [isGeneratingPrompt, setIsGeneratingPrompt] = useState(false);
   const promptRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {
@@ -60,7 +87,6 @@ export function ImageGenModal({ isOpen, onClose, onInsert, initialPrompt = '' }:
       setPrompt(initialPrompt);
       setResult(null);
       clearError();
-      // Delay focus so the animation doesn't fight autofocus.
       const t = setTimeout(() => promptRef.current?.focus(), 60);
       return () => clearTimeout(t);
     }
@@ -83,6 +109,24 @@ export function ImageGenModal({ isOpen, onClose, onInsert, initialPrompt = '' }:
     onClose();
   };
 
+  const handleGeneratePrompt = async () => {
+    if (!messages || messages.length === 0 || isGeneratingPrompt) return;
+    setIsGeneratingPrompt(true);
+    try {
+      const generatedPrompt = await imageGenApi.generatePromptFromContext(
+        messages,
+        characterName || 'Character'
+      );
+      if (generatedPrompt) {
+        setPrompt(generatedPrompt);
+      }
+    } catch (err) {
+      console.error('Failed to generate prompt from context:', err);
+    } finally {
+      setIsGeneratingPrompt(false);
+    }
+  };
+
   const handleModalKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Escape') onClose();
   };
@@ -94,7 +138,17 @@ export function ImageGenModal({ isOpen, onClose, onInsert, initialPrompt = '' }:
     }
   };
 
+  // Choose size presets based on backend
+  const activeSizePresets =
+    backend === 'dalle'
+      ? dalleModel === 'dall-e-3'
+        ? DALLE3_SIZE_PRESETS
+        : DALLE2_SIZE_PRESETS
+      : SIZE_PRESETS;
+
   const sizeKey = `${width}x${height}`;
+
+  const hasContext = messages && messages.some((m) => !m.isSystem);
 
   return (
     <div
@@ -131,37 +185,59 @@ export function ImageGenModal({ isOpen, onClose, onInsert, initialPrompt = '' }:
 
           {/* Prompt */}
           <div>
-            <label className="block text-xs font-medium text-[var(--color-text-secondary)] mb-1">
-              Prompt <span className="text-zinc-500 font-normal">(Ctrl+Enter to generate)</span>
-            </label>
+            <div className="flex items-center justify-between mb-1">
+              <label className="text-xs font-medium text-[var(--color-text-secondary)]">
+                Prompt <span className="text-zinc-500 font-normal">(Ctrl+Enter to generate)</span>
+              </label>
+              {hasContext && (
+                <button
+                  type="button"
+                  onClick={handleGeneratePrompt}
+                  disabled={isGeneratingPrompt || isGenerating}
+                  className="flex items-center gap-1 text-xs text-[var(--color-primary)] hover:text-[var(--color-primary)]/80 transition-colors disabled:opacity-50"
+                  title="Generate prompt from chat context"
+                >
+                  {isGeneratingPrompt ? (
+                    <Loader2 size={13} className="animate-spin" />
+                  ) : (
+                    <Sparkles size={13} />
+                  )}
+                  From chat
+                </button>
+              )}
+            </div>
             <textarea
               ref={promptRef}
               value={prompt}
               onChange={(e) => setPrompt(e.target.value)}
               onKeyDown={handlePromptKeyDown}
-              placeholder="Describe the image you want to generate…"
+              placeholder="Describe the image you want to generate..."
               rows={3}
               className="w-full bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] rounded-xl px-3 py-2 text-sm text-[var(--color-text-primary)] placeholder-zinc-500 resize-none focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]/40"
             />
           </div>
 
           {/* Negative prompt toggle */}
-          <button
-            type="button"
-            onClick={() => setShowNeg((v) => !v)}
-            className="flex items-center gap-1 text-xs text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors"
-          >
-            {showNeg ? <ChevronUp size={13} /> : <ChevronDown size={13} />}
-            Negative prompt
-          </button>
-          {showNeg && (
-            <textarea
-              value={negativePrompt}
-              onChange={(e) => setNegativePrompt(e.target.value)}
-              placeholder="Things to exclude from the image…"
-              rows={2}
-              className="w-full bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] rounded-xl px-3 py-2 text-sm text-[var(--color-text-primary)] placeholder-zinc-500 resize-none focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]/40"
-            />
+          {backend !== 'dalle' && (
+            <>
+              <button
+                type="button"
+                onClick={() => setShowNeg((v) => !v)}
+                className="flex items-center gap-1 text-xs text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors"
+              >
+                {showNeg ? <ChevronUp size={13} /> : <ChevronDown size={13} />}
+                Negative prompt
+              </button>
+              {showNeg && (
+                <textarea
+                  value={negativePrompt}
+                  onChange={(e) => setNegativePrompt(e.target.value)}
+                  placeholder="Things to exclude from the image..."
+                  rows={2}
+                  className="w-full bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] rounded-xl px-3 py-2 text-sm text-[var(--color-text-primary)] placeholder-zinc-500 resize-none focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]/40"
+                />
+              )}
+            </>
           )}
 
           {/* Settings toggle */}
@@ -190,6 +266,7 @@ export function ImageGenModal({ isOpen, onClose, onInsert, initialPrompt = '' }:
                 >
                   <option value="pollinations">Pollinations (free, no setup)</option>
                   <option value="sdwebui">SD WebUI (local)</option>
+                  <option value="dalle">OpenAI DALL-E (requires API key)</option>
                 </select>
               </div>
 
@@ -209,6 +286,40 @@ export function ImageGenModal({ isOpen, onClose, onInsert, initialPrompt = '' }:
                     ))}
                   </select>
                 </div>
+              )}
+
+              {/* DALL-E settings */}
+              {backend === 'dalle' && (
+                <>
+                  <div>
+                    <label className="block text-xs font-medium text-[var(--color-text-secondary)] mb-1">
+                      Model
+                    </label>
+                    <select
+                      value={dalleModel}
+                      onChange={(e) => setConfig({ dalleModel: e.target.value as 'dall-e-3' | 'dall-e-2' })}
+                      className="w-full bg-[var(--color-bg-secondary)] border border-[var(--color-border)] rounded-lg px-2 py-1.5 text-sm text-[var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]/40"
+                    >
+                      <option value="dall-e-3">DALL-E 3 (highest quality)</option>
+                      <option value="dall-e-2">DALL-E 2 (faster, cheaper)</option>
+                    </select>
+                  </div>
+                  {dalleModel === 'dall-e-3' && (
+                    <div>
+                      <label className="block text-xs font-medium text-[var(--color-text-secondary)] mb-1">
+                        Quality
+                      </label>
+                      <select
+                        value={dalleQuality}
+                        onChange={(e) => setConfig({ dalleQuality: e.target.value as 'standard' | 'hd' })}
+                        className="w-full bg-[var(--color-bg-secondary)] border border-[var(--color-border)] rounded-lg px-2 py-1.5 text-sm text-[var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]/40"
+                      >
+                        <option value="standard">Standard</option>
+                        <option value="hd">HD (higher detail, slower)</option>
+                      </select>
+                    </div>
+                  )}
+                </>
               )}
 
               {/* SD WebUI fields */}
@@ -282,12 +393,12 @@ export function ImageGenModal({ isOpen, onClose, onInsert, initialPrompt = '' }:
                 <select
                   value={sizeKey}
                   onChange={(e) => {
-                    const preset = SIZE_PRESETS.find((p) => `${p.width}x${p.height}` === e.target.value);
+                    const preset = activeSizePresets.find((p) => `${p.width}x${p.height}` === e.target.value);
                     if (preset) setConfig({ width: preset.width, height: preset.height });
                   }}
                   className="w-full bg-[var(--color-bg-secondary)] border border-[var(--color-border)] rounded-lg px-2 py-1.5 text-sm text-[var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]/40"
                 >
-                  {SIZE_PRESETS.map((p) => {
+                  {activeSizePresets.map((p) => {
                     const key = `${p.width}x${p.height}`;
                     return (
                       <option key={key} value={key}>
@@ -295,8 +406,8 @@ export function ImageGenModal({ isOpen, onClose, onInsert, initialPrompt = '' }:
                       </option>
                     );
                   })}
-                  {!SIZE_PRESETS.find((p) => p.width === width && p.height === height) && (
-                    <option value={sizeKey}>Custom {width}×{height}</option>
+                  {!activeSizePresets.find((p) => p.width === width && p.height === height) && (
+                    <option value={sizeKey}>Custom {width}\u00d7{height}</option>
                   )}
                 </select>
               </div>
@@ -356,7 +467,7 @@ export function ImageGenModal({ isOpen, onClose, onInsert, initialPrompt = '' }:
               {isGenerating ? (
                 <>
                   <Loader2 size={15} className="animate-spin" />
-                  Generating…
+                  Generating...
                 </>
               ) : (
                 <>

--- a/src/components/settings/ExtensionsPage.tsx
+++ b/src/components/settings/ExtensionsPage.tsx
@@ -1,47 +1,32 @@
 import { useState } from 'react';
-import {
-  ArrowLeft,
-  Volume2,
-  Image,
-  Languages,
-  FileText,
-  ChevronDown,
-  ChevronUp,
-  Loader2,
-} from 'lucide-react';
+import { ArrowLeft, ChevronDown, ChevronUp } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
-import { useExtensionStore, type ExtensionId } from '../../stores/extensionStore';
-import { useSummarizeStore } from '../../stores/summarizeStore';
+import { useExtensionStore } from '../../stores/extensionStore';
+import { extensionRegistry } from '../../extensions/registry';
+import type { ExtensionManifest } from '../../extensions/types';
 
-interface ExtensionCardProps {
-  id: ExtensionId;
-  icon: React.ReactNode;
-  name: string;
-  description: string;
-  settingsHint?: string;
-  children?: React.ReactNode;
-}
-
-function ExtensionCard({ id, icon, name, description, settingsHint, children }: ExtensionCardProps) {
+function ExtensionCard({ ext }: { ext: ExtensionManifest }) {
   const [showSettings, setShowSettings] = useState(false);
-  const enabled = useExtensionStore((s) => s.enabled[id]);
+  const enabled = useExtensionStore((s) => s.enabled[ext.id] ?? false);
   const setEnabled = useExtensionStore((s) => s.setEnabled);
+  const Icon = ext.icon;
+  const SettingsPanel = ext.settingsPanel;
 
   return (
     <div className="bg-[var(--color-bg-secondary)] rounded-lg overflow-hidden">
       <div className="flex items-center gap-3 p-4">
         <div className="w-10 h-10 rounded-lg bg-[var(--color-primary)]/20 flex items-center justify-center flex-shrink-0">
-          {icon}
+          <Icon size={20} className="text-[var(--color-primary)]" />
         </div>
         <div className="flex-1 min-w-0">
-          <p className="text-sm font-medium text-[var(--color-text-primary)]">{name}</p>
-          <p className="text-xs text-[var(--color-text-secondary)] mt-0.5">{description}</p>
+          <p className="text-sm font-medium text-[var(--color-text-primary)]">{ext.displayName}</p>
+          <p className="text-xs text-[var(--color-text-secondary)] mt-0.5">{ext.description}</p>
         </div>
         <button
           type="button"
           role="switch"
           aria-checked={enabled}
-          onClick={() => setEnabled(id, !enabled)}
+          onClick={() => setEnabled(ext.id, !enabled)}
           className={`relative w-11 h-6 rounded-full transition-colors flex-shrink-0 ${
             enabled ? 'bg-[var(--color-primary)]' : 'bg-[var(--color-bg-tertiary)]'
           }`}
@@ -54,19 +39,19 @@ function ExtensionCard({ id, icon, name, description, settingsHint, children }: 
         </button>
       </div>
 
-      {children && enabled && (
+      {SettingsPanel && enabled && (
         <>
           <button
             type="button"
             onClick={() => setShowSettings((v) => !v)}
             className="w-full flex items-center gap-2 px-4 py-2 text-xs text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-tertiary)] transition-colors border-t border-[var(--color-border)]"
           >
-            <span className="flex-1 text-left">{settingsHint ?? 'Settings'}</span>
+            <span className="flex-1 text-left">Settings</span>
             {showSettings ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
           </button>
           {showSettings && (
             <div className="px-4 pb-4 pt-2 border-t border-[var(--color-border)] bg-[var(--color-bg-primary)]/40">
-              {children}
+              <SettingsPanel />
             </div>
           )}
         </>
@@ -75,100 +60,9 @@ function ExtensionCard({ id, icon, name, description, settingsHint, children }: 
   );
 }
 
-function SummarizeSettings() {
-  const autoSummarize = useSummarizeStore((s) => s.autoSummarize);
-  const autoTriggerEvery = useSummarizeStore((s) => s.autoTriggerEvery);
-  const injectionDepth = useSummarizeStore((s) => s.injectionDepth);
-  const injectionRole = useSummarizeStore((s) => s.injectionRole);
-  const isGenerating = useSummarizeStore((s) => s.isGenerating);
-  const setAutoSummarize = useSummarizeStore((s) => s.setAutoSummarize);
-  const setAutoTriggerEvery = useSummarizeStore((s) => s.setAutoTriggerEvery);
-  const setInjectionDepth = useSummarizeStore((s) => s.setInjectionDepth);
-  const setInjectionRole = useSummarizeStore((s) => s.setInjectionRole);
-
-  const inputClass =
-    'px-2 py-1 text-xs rounded border border-[var(--color-border)] bg-[var(--color-bg-primary)] text-[var(--color-text-primary)] focus:outline-none focus:ring-1 focus:ring-[var(--color-primary)]';
-  const labelClass = 'flex items-center justify-between text-xs text-[var(--color-text-secondary)] mb-2';
-
-  return (
-    <div className="space-y-3">
-      {/* Auto-summarize toggle */}
-      <div className={labelClass}>
-        <span>Auto-summarize</span>
-        <button
-          type="button"
-          role="switch"
-          aria-checked={autoSummarize}
-          onClick={() => setAutoSummarize(!autoSummarize)}
-          disabled={isGenerating}
-          className={`relative w-9 h-5 rounded-full transition-colors ${
-            autoSummarize ? 'bg-[var(--color-primary)]' : 'bg-[var(--color-bg-tertiary)]'
-          }`}
-        >
-          <span
-            className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform ${
-              autoSummarize ? 'translate-x-4' : 'translate-x-0'
-            }`}
-          />
-        </button>
-      </div>
-
-      {/* Trigger interval */}
-      <div className={labelClass}>
-        <span>Trigger every N messages</span>
-        <input
-          type="number"
-          min={5}
-          max={100}
-          value={autoTriggerEvery}
-          onChange={(e) => setAutoTriggerEvery(parseInt(e.target.value, 10))}
-          className={`${inputClass} w-16 text-center`}
-        />
-      </div>
-
-      {/* Injection depth */}
-      <div className={labelClass}>
-        <span>
-          Injection depth
-          <span className="block text-[10px] text-[var(--color-text-secondary)]/60">
-            Messages from end (999 = before all history)
-          </span>
-        </span>
-        <input
-          type="number"
-          min={0}
-          max={999}
-          value={injectionDepth}
-          onChange={(e) => setInjectionDepth(parseInt(e.target.value, 10))}
-          className={`${inputClass} w-16 text-center`}
-        />
-      </div>
-
-      {/* Injection role */}
-      <div className={labelClass}>
-        <span>Injection role</span>
-        <select
-          value={injectionRole}
-          onChange={(e) => setInjectionRole(e.target.value as 'system' | 'user')}
-          className={inputClass}
-        >
-          <option value="system">System</option>
-          <option value="user">User</option>
-        </select>
-      </div>
-
-      {isGenerating && (
-        <div className="flex items-center gap-2 text-xs text-[var(--color-text-secondary)]">
-          <Loader2 size={12} className="animate-spin" />
-          <span>Generating summary…</span>
-        </div>
-      )}
-    </div>
-  );
-}
-
 export function ExtensionsPage() {
   const navigate = useNavigate();
+  const extensions = extensionRegistry.getAll();
 
   return (
     <div className="min-h-screen bg-[var(--color-bg-primary)]">
@@ -191,39 +85,11 @@ export function ExtensionsPage() {
       <div className="p-4 space-y-3 max-w-xl mx-auto">
         <p className="text-xs text-[var(--color-text-secondary)] pb-1">
           Toggle built-in extensions on or off. Disabled extensions are hidden throughout the app.
-          Configure TTS voices and translation providers in the main Settings page.
         </p>
 
-        <ExtensionCard
-          id="tts"
-          icon={<Volume2 size={20} className="text-[var(--color-primary)]" />}
-          name="Text-to-Speech"
-          description="Read AI messages aloud using your device's speech engine. Supports auto-read on new messages."
-        />
-
-        <ExtensionCard
-          id="imageGen"
-          icon={<Image size={20} className="text-[var(--color-primary)]" />}
-          name="Image Generation"
-          description="Generate images from prompts using Pollinations or a local Stable Diffusion WebUI. Images are inserted inline in chat."
-        />
-
-        <ExtensionCard
-          id="translate"
-          icon={<Languages size={20} className="text-[var(--color-primary)]" />}
-          name="Translation"
-          description="Translate AI messages to your preferred language. Tap the globe icon on any message. Configure provider and language in Settings."
-        />
-
-        <ExtensionCard
-          id="summarize"
-          icon={<FileText size={20} className="text-[var(--color-primary)]" />}
-          name="Summarization"
-          description="Condense long conversations into a summary injected into the AI's context, preventing memory loss over long chats."
-          settingsHint="Configure auto-summarize and injection"
-        >
-          <SummarizeSettings />
-        </ExtensionCard>
+        {extensions.map((ext) => (
+          <ExtensionCard key={ext.id} ext={ext} />
+        ))}
       </div>
     </div>
   );

--- a/src/components/settings/GalleryPage.tsx
+++ b/src/components/settings/GalleryPage.tsx
@@ -1,0 +1,157 @@
+import { useState } from 'react';
+import { ArrowLeft, Trash2, X } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { useImageGenStore, type GalleryEntry } from '../../stores/imageGenStore';
+
+function formatDate(ts: number): string {
+  const d = new Date(ts);
+  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) +
+    ' ' +
+    d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+}
+
+function backendLabel(backend: string): string {
+  switch (backend) {
+    case 'pollinations': return 'Pollinations';
+    case 'sdwebui': return 'SD WebUI';
+    case 'dalle': return 'DALL-E';
+    default: return backend;
+  }
+}
+
+function Lightbox({ entry, onClose }: { entry: GalleryEntry; onClose: () => void }) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm">
+      <button
+        onClick={onClose}
+        className="absolute top-4 right-4 p-2 rounded-full bg-black/50 text-white hover:bg-black/70 transition-colors z-10"
+        aria-label="Close"
+      >
+        <X size={20} />
+      </button>
+      <div className="max-w-[90vw] max-h-[90vh] flex flex-col items-center gap-3">
+        <img
+          src={entry.dataUrl}
+          alt={entry.prompt}
+          className="max-w-full max-h-[80vh] object-contain rounded-lg"
+        />
+        <p className="text-sm text-zinc-300 text-center max-w-lg px-4 line-clamp-3">
+          {entry.prompt}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export function GalleryPage() {
+  const navigate = useNavigate();
+  const gallery = useImageGenStore((s) => s.gallery);
+  const removeFromGallery = useImageGenStore((s) => s.removeFromGallery);
+  const clearGallery = useImageGenStore((s) => s.clearGallery);
+  const [selectedEntry, setSelectedEntry] = useState<GalleryEntry | null>(null);
+  const [confirmClear, setConfirmClear] = useState(false);
+
+  return (
+    <div className="min-h-screen bg-[var(--color-bg-primary)]">
+      {/* Header */}
+      <div className="sticky top-0 z-10 bg-[var(--color-bg-primary)] border-b border-[var(--color-border)] px-4 py-3 flex items-center gap-3">
+        <button
+          type="button"
+          onClick={() => navigate('/settings')}
+          className="p-2 -ml-2 rounded-lg hover:bg-[var(--color-bg-secondary)] transition-colors"
+          aria-label="Back"
+        >
+          <ArrowLeft size={20} className="text-[var(--color-text-primary)]" />
+        </button>
+        <div className="flex-1">
+          <h1 className="text-base font-semibold text-[var(--color-text-primary)]">Image Gallery</h1>
+          <p className="text-xs text-[var(--color-text-secondary)]">
+            {gallery.length} image{gallery.length !== 1 ? 's' : ''} saved
+          </p>
+        </div>
+        {gallery.length > 0 && (
+          <button
+            type="button"
+            onClick={() => {
+              if (confirmClear) {
+                clearGallery();
+                setConfirmClear(false);
+              } else {
+                setConfirmClear(true);
+                setTimeout(() => setConfirmClear(false), 3000);
+              }
+            }}
+            className={`text-xs px-3 py-1.5 rounded-lg transition-colors ${
+              confirmClear
+                ? 'bg-red-500/20 text-red-400 border border-red-500/40'
+                : 'text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-secondary)]'
+            }`}
+          >
+            {confirmClear ? 'Tap to confirm' : 'Clear all'}
+          </button>
+        )}
+      </div>
+
+      {gallery.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-20 px-6 text-center">
+          <p className="text-sm text-[var(--color-text-secondary)]">
+            No images generated yet. Use the image generation button in chat to create images.
+          </p>
+        </div>
+      ) : (
+        <div className="p-3 grid grid-cols-2 sm:grid-cols-3 gap-3">
+          {gallery.map((entry) => (
+            <div
+              key={entry.id}
+              className="bg-[var(--color-bg-secondary)] rounded-xl overflow-hidden border border-[var(--color-border)] group"
+            >
+              {/* Thumbnail */}
+              <button
+                type="button"
+                onClick={() => setSelectedEntry(entry)}
+                className="block w-full aspect-square overflow-hidden"
+              >
+                <img
+                  src={entry.dataUrl}
+                  alt={entry.prompt}
+                  className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-200"
+                  loading="lazy"
+                />
+              </button>
+
+              {/* Info */}
+              <div className="p-2">
+                <p className="text-xs text-[var(--color-text-primary)] line-clamp-2 leading-tight mb-1.5">
+                  {entry.prompt}
+                </p>
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-1.5">
+                    <span className="text-[10px] px-1.5 py-0.5 rounded bg-[var(--color-primary)]/15 text-[var(--color-primary)] font-medium">
+                      {backendLabel(entry.backend)}
+                    </span>
+                    <span className="text-[10px] text-[var(--color-text-secondary)]">
+                      {formatDate(entry.timestamp)}
+                    </span>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => removeFromGallery(entry.id)}
+                    className="p-1 rounded text-[var(--color-text-secondary)] hover:text-red-400 hover:bg-red-500/10 transition-colors opacity-0 group-hover:opacity-100"
+                    aria-label="Delete image"
+                  >
+                    <Trash2 size={12} />
+                  </button>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Lightbox */}
+      {selectedEntry && (
+        <Lightbox entry={selectedEntry} onClose={() => setSelectedEntry(null)} />
+      )}
+    </div>
+  );
+}

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { ArrowLeft, BookOpen, Check, ChevronRight, Database, Eye, EyeOff, Globe, Key, Languages, Loader2, MessageSquare, Mic, Palette, Plug, Replace, Sliders, Trash2, UserPlus, Users, Volume2, Zap } from 'lucide-react';
+import { ArrowLeft, BookOpen, Check, ChevronRight, Database, Eye, EyeOff, Globe, Image, Key, Languages, Loader2, MessageSquare, Mic, Palette, Plug, Replace, Sliders, Trash2, UserPlus, Users, Volume2, Zap } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useSettingsStore } from '../../stores/settingsStore';
 import { PROVIDERS, type SecretState } from '../../api/client';
@@ -655,6 +655,25 @@ export function SettingsPage() {
                   <p className="text-sm font-medium text-[var(--color-text-primary)]">Extensions</p>
                   <p className="text-xs text-[var(--color-text-secondary)] mt-0.5">
                     TTS, image gen, translation, summarization
+                  </p>
+                </div>
+                <ChevronRight size={20} className="text-[var(--color-text-secondary)]" />
+              </button>
+            </section>
+
+            {/* Image Gallery (Phase 7.3) */}
+            <section className="bg-[var(--color-bg-secondary)] rounded-lg overflow-hidden">
+              <button
+                onClick={() => navigate('/settings/gallery')}
+                className="w-full flex items-center gap-3 p-4 hover:bg-[var(--color-bg-tertiary)] transition-colors text-left"
+              >
+                <div className="w-10 h-10 rounded-lg bg-[var(--color-primary)]/20 flex items-center justify-center">
+                  <Image size={20} className="text-[var(--color-primary)]" />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium text-[var(--color-text-primary)]">Image Gallery</p>
+                  <p className="text-xs text-[var(--color-text-secondary)] mt-0.5">
+                    Browse previously generated images
                   </p>
                 </div>
                 <ChevronRight size={20} className="text-[var(--color-text-secondary)]" />

--- a/src/components/settings/index.ts
+++ b/src/components/settings/index.ts
@@ -5,3 +5,4 @@ export { UserManagementPage } from './UserManagementPage';
 export { QuickReplyPage } from './QuickReplyPage';
 export { ExtensionsPage } from './ExtensionsPage';
 export { DataBankPage } from './DataBankPage';
+export { GalleryPage } from './GalleryPage';

--- a/src/extensions/builtins/imageGen.ts
+++ b/src/extensions/builtins/imageGen.ts
@@ -1,0 +1,15 @@
+import { Image } from 'lucide-react';
+import { extensionRegistry } from '../registry';
+import type { ExtensionManifest } from '../types';
+
+const manifest: ExtensionManifest = {
+  id: 'imageGen',
+  displayName: 'Image Generation',
+  description:
+    'Generate images from prompts using Pollinations or a local Stable Diffusion WebUI. Images are inserted inline in chat.',
+  version: '1.0.0',
+  icon: Image,
+  defaultEnabled: true,
+};
+
+extensionRegistry.register(manifest);

--- a/src/extensions/builtins/summarize.tsx
+++ b/src/extensions/builtins/summarize.tsx
@@ -1,0 +1,135 @@
+import { FileText, Loader2 } from 'lucide-react';
+import { extensionRegistry } from '../registry';
+import { useSummarizeStore } from '../../stores/summarizeStore';
+import type { ExtensionManifest, ContextBuildEvent, ContextContribution } from '../types';
+
+// ---------------------------------------------------------------------------
+// Settings panel (rendered inside the extension card)
+// ---------------------------------------------------------------------------
+
+function SummarizeSettings() {
+  const autoSummarize = useSummarizeStore((s) => s.autoSummarize);
+  const autoTriggerEvery = useSummarizeStore((s) => s.autoTriggerEvery);
+  const injectionDepth = useSummarizeStore((s) => s.injectionDepth);
+  const injectionRole = useSummarizeStore((s) => s.injectionRole);
+  const isGenerating = useSummarizeStore((s) => s.isGenerating);
+  const setAutoSummarize = useSummarizeStore((s) => s.setAutoSummarize);
+  const setAutoTriggerEvery = useSummarizeStore((s) => s.setAutoTriggerEvery);
+  const setInjectionDepth = useSummarizeStore((s) => s.setInjectionDepth);
+  const setInjectionRole = useSummarizeStore((s) => s.setInjectionRole);
+
+  const inputClass =
+    'px-2 py-1 text-xs rounded border border-[var(--color-border)] bg-[var(--color-bg-primary)] text-[var(--color-text-primary)] focus:outline-none focus:ring-1 focus:ring-[var(--color-primary)]';
+  const labelClass =
+    'flex items-center justify-between text-xs text-[var(--color-text-secondary)] mb-2';
+
+  return (
+    <div className="space-y-3">
+      <div className={labelClass}>
+        <span>Auto-summarize</span>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={autoSummarize}
+          onClick={() => setAutoSummarize(!autoSummarize)}
+          disabled={isGenerating}
+          className={`relative w-9 h-5 rounded-full transition-colors ${
+            autoSummarize ? 'bg-[var(--color-primary)]' : 'bg-[var(--color-bg-tertiary)]'
+          }`}
+        >
+          <span
+            className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform ${
+              autoSummarize ? 'translate-x-4' : 'translate-x-0'
+            }`}
+          />
+        </button>
+      </div>
+
+      <div className={labelClass}>
+        <span>Trigger every N messages</span>
+        <input
+          type="number"
+          min={5}
+          max={100}
+          value={autoTriggerEvery}
+          onChange={(e) => setAutoTriggerEvery(parseInt(e.target.value, 10))}
+          className={`${inputClass} w-16 text-center`}
+        />
+      </div>
+
+      <div className={labelClass}>
+        <span>
+          Injection depth
+          <span className="block text-[10px] text-[var(--color-text-secondary)]/60">
+            Messages from end (999 = before all history)
+          </span>
+        </span>
+        <input
+          type="number"
+          min={0}
+          max={999}
+          value={injectionDepth}
+          onChange={(e) => setInjectionDepth(parseInt(e.target.value, 10))}
+          className={`${inputClass} w-16 text-center`}
+        />
+      </div>
+
+      <div className={labelClass}>
+        <span>Injection role</span>
+        <select
+          value={injectionRole}
+          onChange={(e) => setInjectionRole(e.target.value as 'system' | 'user')}
+          className={inputClass}
+        >
+          <option value="system">System</option>
+          <option value="user">User</option>
+        </select>
+      </div>
+
+      {isGenerating && (
+        <div className="flex items-center gap-2 text-xs text-[var(--color-text-secondary)]">
+          <Loader2 size={12} className="animate-spin" />
+          <span>Generating summary...</span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Context hook — injects the cached summary into the prompt
+// ---------------------------------------------------------------------------
+
+function onBuildContext(event: ContextBuildEvent): ContextContribution[] {
+  const { injectionDepth, injectionRole, getSummary } = useSummarizeStore.getState();
+  const summary = getSummary(event.currentChatFile);
+  if (!summary?.text) return [];
+
+  return [
+    {
+      content: `[Summary of previous events: ${summary.text}]`,
+      role: injectionRole,
+      position: 'at_depth',
+      depth: injectionDepth,
+      order: 50, // before other at_depth contributions
+    },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Manifest
+// ---------------------------------------------------------------------------
+
+const manifest: ExtensionManifest = {
+  id: 'summarize',
+  displayName: 'Summarization',
+  description:
+    'Condense long conversations into a summary injected into the AI\'s context, preventing memory loss over long chats.',
+  version: '1.0.0',
+  icon: FileText,
+  defaultEnabled: false,
+  onBuildContext,
+  settingsPanel: SummarizeSettings,
+};
+
+extensionRegistry.register(manifest);

--- a/src/extensions/builtins/translate.ts
+++ b/src/extensions/builtins/translate.ts
@@ -1,0 +1,15 @@
+import { Languages } from 'lucide-react';
+import { extensionRegistry } from '../registry';
+import type { ExtensionManifest } from '../types';
+
+const manifest: ExtensionManifest = {
+  id: 'translate',
+  displayName: 'Translation',
+  description:
+    'Translate AI messages to your preferred language. Tap the globe icon on any message.',
+  version: '1.0.0',
+  icon: Languages,
+  defaultEnabled: true,
+};
+
+extensionRegistry.register(manifest);

--- a/src/extensions/builtins/tts.ts
+++ b/src/extensions/builtins/tts.ts
@@ -1,0 +1,15 @@
+import { Volume2 } from 'lucide-react';
+import { extensionRegistry } from '../registry';
+import type { ExtensionManifest } from '../types';
+
+const manifest: ExtensionManifest = {
+  id: 'tts',
+  displayName: 'Text-to-Speech',
+  description:
+    'Read AI messages aloud using your device\'s speech engine. Supports auto-read on new messages.',
+  version: '1.0.0',
+  icon: Volume2,
+  defaultEnabled: true,
+};
+
+extensionRegistry.register(manifest);

--- a/src/extensions/index.ts
+++ b/src/extensions/index.ts
@@ -1,0 +1,16 @@
+// Register all built-in extensions.
+// Import order determines registration order (and thus display order).
+import './builtins/tts';
+import './builtins/imageGen';
+import './builtins/translate';
+import './builtins/summarize';
+
+// Re-export for external consumption.
+export { extensionRegistry } from './registry';
+export type {
+  ExtensionManifest,
+  ContextBuildEvent,
+  ContextContribution,
+  MessageActionSlotProps,
+  ChatInputSlotProps,
+} from './types';

--- a/src/extensions/registry.ts
+++ b/src/extensions/registry.ts
@@ -1,0 +1,120 @@
+import { useExtensionStore } from '../stores/extensionStore';
+import type {
+  ExtensionManifest,
+  ContextBuildEvent,
+  ContextContribution,
+} from './types';
+
+// ---------------------------------------------------------------------------
+// Extension Registry — singleton that all built-in extensions register with
+// ---------------------------------------------------------------------------
+
+const extensions = new Map<string, ExtensionManifest>();
+const initialized = new Set<string>();
+
+export const extensionRegistry = {
+  /** Register a built-in extension. Called once at module import time. */
+  register(manifest: ExtensionManifest): void {
+    if (extensions.has(manifest.id)) {
+      console.warn(`[ExtensionRegistry] duplicate id "${manifest.id}", skipping`);
+      return;
+    }
+    extensions.set(manifest.id, manifest);
+
+    // Seed the store's enabled map with the default if the user hasn't toggled it.
+    const store = useExtensionStore.getState();
+    if (!(manifest.id in store.enabled)) {
+      store.setEnabled(manifest.id, manifest.defaultEnabled ?? true);
+    }
+  },
+
+  /** Look up a single extension by ID. */
+  get(id: string): ExtensionManifest | undefined {
+    return extensions.get(id);
+  },
+
+  /** All registered extensions, in registration order. */
+  getAll(): ExtensionManifest[] {
+    return Array.from(extensions.values());
+  },
+
+  /** Whether the user has this extension enabled. */
+  isEnabled(id: string): boolean {
+    return useExtensionStore.getState().enabled[id] ?? false;
+  },
+
+  // -----------------------------------------------------------------------
+  // Lifecycle
+  // -----------------------------------------------------------------------
+
+  /** Call onInit for all enabled extensions that haven't been initialized yet. */
+  initAll(): void {
+    for (const ext of extensions.values()) {
+      if (this.isEnabled(ext.id) && !initialized.has(ext.id)) {
+        ext.onInit?.();
+        initialized.add(ext.id);
+      }
+    }
+  },
+
+  /** Call onDestroy for an extension and mark it uninitialized. */
+  destroy(id: string): void {
+    if (initialized.has(id)) {
+      extensions.get(id)?.onDestroy?.();
+      initialized.delete(id);
+    }
+  },
+
+  // -----------------------------------------------------------------------
+  // Context hooks — called by buildConversationContext in chatStore
+  // -----------------------------------------------------------------------
+
+  /** Collect ContextContributions from all enabled extensions. */
+  runContextHooks(event: ContextBuildEvent): ContextContribution[] {
+    const contributions: ContextContribution[] = [];
+    for (const ext of extensions.values()) {
+      if (!this.isEnabled(ext.id) || !ext.onBuildContext) continue;
+      try {
+        const items = ext.onBuildContext(event);
+        for (const item of items) {
+          contributions.push({ ...item, order: item.order ?? 100 });
+        }
+      } catch (err) {
+        console.error(`[ExtensionRegistry] onBuildContext error in "${ext.id}":`, err);
+      }
+    }
+    return contributions.sort((a, b) => (a.order ?? 100) - (b.order ?? 100));
+  },
+
+  // -----------------------------------------------------------------------
+  // Message pipeline hooks
+  // -----------------------------------------------------------------------
+
+  /** Chain onBeforeUserMessage through all enabled extensions. */
+  runBeforeUserMessage(text: string, charAvatar: string): string {
+    let result = text;
+    for (const ext of extensions.values()) {
+      if (!this.isEnabled(ext.id) || !ext.onBeforeUserMessage) continue;
+      try {
+        result = ext.onBeforeUserMessage(result, charAvatar);
+      } catch (err) {
+        console.error(`[ExtensionRegistry] onBeforeUserMessage error in "${ext.id}":`, err);
+      }
+    }
+    return result;
+  },
+
+  /** Chain onAfterAIMessage through all enabled extensions. */
+  runAfterAIMessage(text: string, charAvatar: string): string {
+    let result = text;
+    for (const ext of extensions.values()) {
+      if (!this.isEnabled(ext.id) || !ext.onAfterAIMessage) continue;
+      try {
+        result = ext.onAfterAIMessage(result, charAvatar);
+      } catch (err) {
+        console.error(`[ExtensionRegistry] onAfterAIMessage error in "${ext.id}":`, err);
+      }
+    }
+    return result;
+  },
+};

--- a/src/extensions/types.ts
+++ b/src/extensions/types.ts
@@ -1,0 +1,79 @@
+import type { ComponentType } from 'react';
+import type { LucideIcon } from 'lucide-react';
+
+// ---------------------------------------------------------------------------
+// Context injection types — extensions contribute prompt content via these
+// ---------------------------------------------------------------------------
+
+/** Passed to every enabled extension's `onBuildContext` hook. */
+export interface ContextBuildEvent {
+  messages: { name: string; isUser: boolean; isSystem: boolean; content: string }[];
+  characterName: string;
+  characterAvatar: string;
+  currentChatFile: string;
+}
+
+/** A single piece of content an extension wants injected into the prompt. */
+export interface ContextContribution {
+  content: string;
+  role: 'system' | 'user';
+  position: 'before_char' | 'after_char' | 'before_an' | 'after_an' | 'at_depth';
+  /** Required when position is 'at_depth'. Distance from the end of history. */
+  depth?: number;
+  /** Sort priority within the same position (lower = earlier). Default 100. */
+  order?: number;
+}
+
+// ---------------------------------------------------------------------------
+// UI slot props — extensions can provide React components for these slots
+// ---------------------------------------------------------------------------
+
+export interface MessageActionSlotProps {
+  messageId: string;
+  content: string;
+  isUser: boolean;
+  isSystem: boolean;
+  characterAvatar?: string;
+}
+
+export interface ChatInputSlotProps {
+  characterName: string;
+  characterAvatar: string;
+}
+
+// ---------------------------------------------------------------------------
+// Extension manifest — the complete interface an extension implements
+// ---------------------------------------------------------------------------
+
+export interface ExtensionManifest {
+  /** Unique ID, e.g. 'tts', 'summarize'. */
+  id: string;
+  displayName: string;
+  description: string;
+  version: string;
+  icon: LucideIcon;
+  /** Default enabled state when the user has never toggled this extension. */
+  defaultEnabled?: boolean;
+
+  // -- Lifecycle --
+  onInit?(): void;
+  onDestroy?(): void;
+
+  // -- Context injection --
+  /** Return prompt contributions. Called synchronously during context build. */
+  onBuildContext?(event: ContextBuildEvent): ContextContribution[];
+
+  // -- Message pipeline hooks --
+  /** Transform user text before it's stored. Return the (possibly modified) text. */
+  onBeforeUserMessage?(text: string, charAvatar: string): string;
+  /** Transform AI text after generation finishes. Return the (possibly modified) text. */
+  onAfterAIMessage?(text: string, charAvatar: string): string;
+
+  // -- UI slots --
+  /** Settings panel rendered inside the extension card on ExtensionsPage. */
+  settingsPanel?: ComponentType;
+  /** Buttons/icons rendered next to each AI message (TTS, translate, etc.). */
+  messageActions?: ComponentType<MessageActionSlotProps>;
+  /** Buttons/icons rendered in or near the chat input area. */
+  chatInputActions?: ComponentType<ChatInputSlotProps>;
+}

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -29,6 +29,8 @@ import { getInstructTemplate, formatInstructPrompt } from '../utils/instructTemp
 import { useRegexScriptStore } from './regexScriptStore';
 import { applyRegexScripts, getActiveScripts } from '../utils/regexScripts';
 import { useDataBankStore } from './dataBankStore';
+import { extensionRegistry } from '../extensions/registry';
+import type { ContextContribution } from '../extensions/types';
 
 export interface ChatMessage {
   id: string;
@@ -622,6 +624,35 @@ function buildConversationContext(
       .filter((c) => c.trim().length > 0)
       .join('\n\n');
 
+  // Phase 7.1: Extension context contributions
+  const { currentChatFile: ctxChatFile } = useChatStore.getState();
+  const extContributions = extensionRegistry.runContextHooks({
+    messages: messages.map((m) => ({
+      name: m.name,
+      isUser: m.isUser,
+      isSystem: m.isSystem,
+      content: m.content,
+    })),
+    characterName: character.name,
+    characterAvatar: character.avatar || '',
+    currentChatFile: ctxChatFile || '',
+  });
+  const extByPosition: Record<string, ContextContribution[]> = {
+    before_char: [],
+    after_char: [],
+    before_an: [],
+    after_an: [],
+    at_depth: [],
+  };
+  for (const c of extContributions) {
+    (extByPosition[c.position] ??= []).push(c);
+  }
+  const joinExt = (list: ContextContribution[]): string =>
+    list
+      .map((c) => c.content)
+      .filter((c) => c.trim().length > 0)
+      .join('\n\n');
+
   const description = sub(getCharacterField(character, 'description'));
   const personality = sub(getCharacterField(character, 'personality'));
   const scenario = sub(getCharacterField(character, 'scenario'));
@@ -687,6 +718,8 @@ Choose the emotion that best matches how ${character.name} would feel based on t
   if (wiBeforeChar) {
     systemParts.push(wiBeforeChar);
   }
+  const extBeforeChar = joinExt(extByPosition.before_char);
+  if (extBeforeChar) systemParts.push(extBeforeChar);
   if (charInfoBlock) {
     systemParts.push(charInfoBlock);
   }
@@ -694,6 +727,8 @@ Choose the emotion that best matches how ${character.name} would feel based on t
   if (wiAfterChar) {
     systemParts.push(wiAfterChar);
   }
+  const extAfterChar = joinExt(extByPosition.after_char);
+  if (extAfterChar) systemParts.push(extAfterChar);
   if (persona && persona.descriptionPosition === 'after_char' && personaDescription) {
     systemParts.push(`[The user you're talking to is ${personaName}. ${personaDescription}]`);
   }
@@ -705,6 +740,8 @@ Choose the emotion that best matches how ${character.name} would feel based on t
   if (wiBeforeAn) {
     systemParts.push(wiBeforeAn);
   }
+  const extBeforeAn = joinExt(extByPosition.before_an);
+  if (extBeforeAn) systemParts.push(extBeforeAn);
   if (userJailbreak) {
     systemParts.push(userJailbreak);
   }
@@ -732,9 +769,8 @@ Choose the emotion that best matches how ${character.name} would feel based on t
   const depthPromptContent = depthPrompt ? sub(depthPrompt.prompt) : '';
 
   // Phase 8.1: Author's Note — per-chat persistent instruction injected at depth
-  const { currentChatFile } = useChatStore.getState();
-  const authorNote = currentChatFile
-    ? useChatStore.getState().getAuthorNote(currentChatFile)
+  const authorNote = ctxChatFile
+    ? useChatStore.getState().getAuthorNote(ctxChatFile)
     : null;
 
   // Persona @ depth
@@ -759,6 +795,14 @@ Choose the emotion that best matches how ${character.name} would feel based on t
     const d = Math.max(0, Math.floor(m.entry.depth));
     if (!wiAtDepthByDepth[d]) wiAtDepthByDepth[d] = [];
     wiAtDepthByDepth[d].push(m);
+  }
+
+  // Phase 7.1: Group extension at-depth contributions by their depth value.
+  const extAtDepthByDepth: Record<number, ContextContribution[]> = {};
+  for (const c of extByPosition.at_depth) {
+    const d = Math.max(0, Math.floor(c.depth ?? 0));
+    if (!extAtDepthByDepth[d]) extAtDepthByDepth[d] = [];
+    extAtDepthByDepth[d].push(c);
   }
 
   for (let i = 0; i < recentMessages.length; i++) {
@@ -791,6 +835,15 @@ Choose the emotion that best matches how ${character.name} would feel based on t
       const content = joinWi(wiHere);
       if (content) {
         historyWithInsertions.push({ role: 'system', content });
+      }
+    }
+    // Phase 7.1: Extension at-depth contributions
+    const extHere = extAtDepthByDepth[depthFromEnd];
+    if (extHere && extHere.length > 0) {
+      for (const c of extHere) {
+        if (c.content.trim()) {
+          historyWithInsertions.push({ role: c.role, content: c.content });
+        }
       }
     }
 
@@ -833,6 +886,17 @@ Choose the emotion that best matches how ${character.name} would feel based on t
       }
     }
   }
+  // Phase 7.1: Extension at-depth overflow — prepend if depth > history length.
+  for (const depthKey of Object.keys(extAtDepthByDepth)) {
+    const d = parseInt(depthKey, 10);
+    if (d > recentMessages.length) {
+      for (const c of extAtDepthByDepth[d]) {
+        if (c.content.trim()) {
+          historyWithInsertions.unshift({ role: c.role, content: c.content });
+        }
+      }
+    }
+  }
 
   // Token-aware trimming: keep system prompts, drop oldest history that exceeds budget
   if (ctxConfig.tokenAware) {
@@ -862,6 +926,10 @@ Choose the emotion that best matches how ${character.name} would feel based on t
   const wiAfterAn = joinWi(wiByPosition.after_an);
   if (wiAfterAn) {
     context.push({ role: 'system', content: wiAfterAn });
+  }
+  const extAfterAn = joinExt(extByPosition.after_an);
+  if (extAfterAn) {
+    context.push({ role: 'system', content: extAfterAn });
   }
 
   // If not token-aware, still estimate tokens for the UI badge

--- a/src/stores/extensionStore.ts
+++ b/src/stores/extensionStore.ts
@@ -1,24 +1,16 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
-export type ExtensionId = 'tts' | 'imageGen' | 'translate' | 'summarize';
-
 interface ExtensionState {
-  enabled: Record<ExtensionId, boolean>;
-  setEnabled: (id: ExtensionId, on: boolean) => void;
+  /** Per-extension enabled state. Keys are extension IDs (e.g. 'tts', 'summarize'). */
+  enabled: Record<string, boolean>;
+  setEnabled: (id: string, on: boolean) => void;
 }
-
-const DEFAULTS: Record<ExtensionId, boolean> = {
-  tts: true,
-  imageGen: true,
-  translate: true,
-  summarize: false,
-};
 
 export const useExtensionStore = create<ExtensionState>()(
   persist(
     (set) => ({
-      enabled: { ...DEFAULTS },
+      enabled: {},
       setEnabled: (id, on) =>
         set((s) => ({ enabled: { ...s.enabled, [id]: on } })),
     }),

--- a/src/stores/imageGenStore.ts
+++ b/src/stores/imageGenStore.ts
@@ -1,13 +1,32 @@
 import { create } from 'zustand';
 import { imageGenApi, type ImageGenBackend } from '../api/imageGenApi';
 
+// ---------------------------------------------------------------------------
+// Gallery entry — persisted alongside config
+// ---------------------------------------------------------------------------
+
+export interface GalleryEntry {
+  id: string;
+  dataUrl: string;
+  prompt: string;
+  backend: ImageGenBackend;
+  timestamp: number;
+}
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
 const STORAGE_KEY = 'sillytavern_imagegen_config';
+const GALLERY_KEY = 'sillytavern_imagegen_gallery';
 
 interface ImageGenConfig {
   backend: ImageGenBackend;
   sdUrl: string;
   sdAuth: string;
   pollinationsModel: string;
+  dalleModel: 'dall-e-3' | 'dall-e-2';
+  dalleQuality: 'standard' | 'hd';
   width: number;
   height: number;
   steps: number;
@@ -19,6 +38,8 @@ const DEFAULT_CONFIG: ImageGenConfig = {
   sdUrl: 'http://localhost:7860',
   sdAuth: '',
   pollinationsModel: 'flux',
+  dalleModel: 'dall-e-3',
+  dalleQuality: 'standard',
   width: 1024,
   height: 1024,
   steps: 20,
@@ -37,20 +58,69 @@ function saveConfig(config: ImageGenConfig) {
   localStorage.setItem(STORAGE_KEY, JSON.stringify(config));
 }
 
+function loadGallery(): GalleryEntry[] {
+  try {
+    const stored = localStorage.getItem(GALLERY_KEY);
+    if (stored) return JSON.parse(stored);
+  } catch { /* ignore */ }
+  return [];
+}
+
+function saveGallery(gallery: GalleryEntry[]) {
+  localStorage.setItem(GALLERY_KEY, JSON.stringify(gallery));
+}
+
+// ---------------------------------------------------------------------------
+// DALL-E size helpers
+// ---------------------------------------------------------------------------
+
+const DALLE3_SIZES = ['1024x1024', '1792x1024', '1024x1792'] as const;
+const DALLE2_SIZES = ['256x256', '512x512', '1024x1024'] as const;
+
+/** Map arbitrary w/h to the nearest valid DALL-E size string. */
+function nearestDalleSize(
+  w: number,
+  h: number,
+  model: 'dall-e-3' | 'dall-e-2'
+): string {
+  const sizes = model === 'dall-e-3' ? DALLE3_SIZES : DALLE2_SIZES;
+  const aspect = w / h;
+  let best = sizes[0];
+  let bestDiff = Infinity;
+  for (const s of sizes) {
+    const [sw, sh] = s.split('x').map(Number);
+    const diff = Math.abs(sw / sh - aspect);
+    if (diff < bestDiff) {
+      bestDiff = diff;
+      best = s;
+    }
+  }
+  return best;
+}
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
 interface ImageGenState extends ImageGenConfig {
   isGenerating: boolean;
   error: string | null;
+  gallery: GalleryEntry[];
 
   setConfig: (patch: Partial<ImageGenConfig>) => void;
   /** Generate an image and return its data URI, or null on failure. */
   generate: (prompt: string, negativePrompt?: string) => Promise<string | null>;
   clearError: () => void;
+  addToGallery: (entry: GalleryEntry) => void;
+  removeFromGallery: (id: string) => void;
+  clearGallery: () => void;
 }
 
 export const useImageGenStore = create<ImageGenState>((set, get) => ({
   ...loadConfig(),
   isGenerating: false,
   error: null,
+  gallery: loadGallery(),
 
   setConfig: (patch) => {
     set((s) => {
@@ -60,6 +130,8 @@ export const useImageGenStore = create<ImageGenState>((set, get) => ({
         sdUrl: next.sdUrl,
         sdAuth: next.sdAuth,
         pollinationsModel: next.pollinationsModel,
+        dalleModel: next.dalleModel,
+        dalleQuality: next.dalleQuality,
         width: next.width,
         height: next.height,
         steps: next.steps,
@@ -71,7 +143,10 @@ export const useImageGenStore = create<ImageGenState>((set, get) => ({
   },
 
   generate: async (prompt, negativePrompt) => {
-    const { backend, sdUrl, sdAuth, pollinationsModel, width, height, steps, cfgScale } = get();
+    const {
+      backend, sdUrl, sdAuth, pollinationsModel,
+      dalleModel, dalleQuality, width, height, steps, cfgScale,
+    } = get();
     set({ isGenerating: true, error: null });
     try {
       let result;
@@ -86,6 +161,14 @@ export const useImageGenStore = create<ImageGenState>((set, get) => ({
           steps,
           cfgScale,
         });
+      } else if (backend === 'dalle') {
+        const size = nearestDalleSize(width, height, dalleModel);
+        result = await imageGenApi.generateDalle({
+          prompt,
+          model: dalleModel,
+          size,
+          quality: dalleQuality,
+        });
       } else {
         result = await imageGenApi.generatePollinations({
           prompt,
@@ -95,8 +178,21 @@ export const useImageGenStore = create<ImageGenState>((set, get) => ({
           height,
         });
       }
+
+      const dataUrl = `data:image/${result.format};base64,${result.base64}`;
+
+      // Auto-save to gallery
+      const entry: GalleryEntry = {
+        id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        dataUrl,
+        prompt,
+        backend,
+        timestamp: Date.now(),
+      };
+      get().addToGallery(entry);
+
       set({ isGenerating: false });
-      return `data:image/${result.format};base64,${result.base64}`;
+      return dataUrl;
     } catch (e) {
       set({ isGenerating: false, error: e instanceof Error ? e.message : 'Generation failed' });
       return null;
@@ -104,4 +200,25 @@ export const useImageGenStore = create<ImageGenState>((set, get) => ({
   },
 
   clearError: () => set({ error: null }),
+
+  addToGallery: (entry) => {
+    set((s) => {
+      const gallery = [entry, ...s.gallery];
+      saveGallery(gallery);
+      return { gallery };
+    });
+  },
+
+  removeFromGallery: (id) => {
+    set((s) => {
+      const gallery = s.gallery.filter((e) => e.id !== id);
+      saveGallery(gallery);
+      return { gallery };
+    });
+  },
+
+  clearGallery: () => {
+    saveGallery([]);
+    set({ gallery: [] });
+  },
 }));


### PR DESCRIPTION
## Summary

- **Phase 7.1 — Extension System Architecture**: Built a registry-based extension system (`src/extensions/`) where each extension registers a manifest with lifecycle hooks, context injection, and UI slots. Migrated TTS, image gen, translation, and summarization. Extensions page is now fully registry-driven. Summarization's `onBuildContext` hook now actually injects summaries into the prompt at the configured depth.

- **Phase 7.3 — Image Generation Completion**: Added OpenAI DALL-E as a third backend (DALL-E 2/3, quality/size selection). Added context-aware prompt generation ("From chat" button uses the active LLM to write an art prompt from recent messages). Added an image gallery page that auto-saves every generated image with lightbox view and delete.

## Test plan

- [ ] Navigate to Settings > Extensions — all 4 extensions render with toggles
- [ ] Toggle summarization on — settings panel expands with auto-summarize config
- [ ] Toggle TTS off — TTS button disappears from chat messages
- [ ] Open image gen modal — DALL-E appears as third backend option
- [ ] Select DALL-E — model (2/3), quality (standard/HD), and DALL-E sizes render
- [ ] Click "From chat" sparkle button — LLM generates art prompt from conversation
- [ ] Generate an image (any backend) — verify it appears in Settings > Image Gallery
- [ ] Gallery lightbox, delete, clear all work
- [ ] `npx tsc --noEmit` passes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)