### PR TITLE
fix: widen nearestDalleSize return type to fix tsc -b build error

### DIFF
--- a/src/stores/imageGenStore.ts
+++ b/src/stores/imageGenStore.ts
@@ -85,7 +85,7 @@ function nearestDalleSize(
 ): string {
   const sizes = model === 'dall-e-3' ? DALLE3_SIZES : DALLE2_SIZES;
   const aspect = w / h;
-  let best = sizes[0];
+  let best: string = sizes[0];
   let bestDiff = Infinity;
   for (const s of sizes) {
     const [sw, sh] = s.split('x').map(Number);


### PR DESCRIPTION
The readonly tuple types from DALLE3_SIZES/DALLE2_SIZES created an incompatible union for the `best` variable assignment.