### PR TITLE
feat: add cyberpunk neon rainbow theme

### DIFF
--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -422,7 +422,7 @@ export function ChatMessage({
               className={`
                 px-4 py-2 rounded-2xl
                 ${isUser
-                  ? 'bg-[var(--color-primary)] text-white rounded-br-md'
+                  ? 'bg-[var(--color-primary)] text-white rounded-br-md cyberpunk-user-bubble'
                   : 'bg-[var(--color-bg-tertiary)] text-[var(--color-text-primary)] rounded-bl-md'}
                 ${isEditing ? 'w-full' : ''}
                 ${!isEditing && onEdit ? 'cursor-text select-text' : ''}

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -754,7 +754,11 @@ export function SettingsPage() {
                         ? 'ring-2 ring-offset-2 ring-offset-[var(--color-bg-secondary)] ring-[var(--color-primary)] scale-110'
                         : 'hover:scale-110'
                     }`}
-                    style={{ backgroundColor: PRESET_SWATCHES[preset] }}
+                    style={{
+                      ...(PRESET_SWATCHES[preset].includes('gradient')
+                        ? { background: PRESET_SWATCHES[preset] }
+                        : { backgroundColor: PRESET_SWATCHES[preset] }),
+                    }}
                     title={preset.charAt(0).toUpperCase() + preset.slice(1)}
                     aria-label={`${preset} theme`}
                   />

--- a/src/hooks/themePreferences.ts
+++ b/src/hooks/themePreferences.ts
@@ -13,7 +13,7 @@
 // ---------------------------------------------------------------------------
 
 export type ThemeMode = 'light' | 'dark' | 'auto';
-export type ThemePreset = 'purple' | 'blue' | 'green' | 'red' | 'amber';
+export type ThemePreset = 'purple' | 'blue' | 'green' | 'red' | 'amber' | 'cyberpunk';
 
 interface ThemeColors {
   primary: string;
@@ -56,6 +56,11 @@ const DARK_THEMES: Record<ThemePreset, ThemeColors> = {
     bgPrimary: '#0f0f0f', bgSecondary: '#1a1a1a', bgTertiary: '#262626',
     textPrimary: '#ffffff', textSecondary: '#a1a1aa', border: '#3f3f46',
   },
+  cyberpunk: {
+    primary: '#e040fb', primaryHover: '#ea80fc',
+    bgPrimary: '#0a0a0f', bgSecondary: '#12121a', bgTertiary: '#1a1a28',
+    textPrimary: '#f0e6ff', textSecondary: '#9a8fad', border: '#2a2540',
+  },
 };
 
 const LIGHT_THEMES: Record<ThemePreset, ThemeColors> = {
@@ -84,6 +89,12 @@ const LIGHT_THEMES: Record<ThemePreset, ThemeColors> = {
     bgPrimary: '#ffffff', bgSecondary: '#f4f4f5', bgTertiary: '#e4e4e7',
     textPrimary: '#18181b', textSecondary: '#71717a', border: '#d4d4d8',
   },
+  cyberpunk: {
+    // Light mode still uses the neon palette but softened for readability.
+    primary: '#c026d3', primaryHover: '#a21caf',
+    bgPrimary: '#faf5ff', bgSecondary: '#f3e8ff', bgTertiary: '#e9d5ff',
+    textPrimary: '#1a0a2e', textSecondary: '#6b21a8', border: '#d8b4fe',
+  },
 };
 
 /** Accent swatch colors shown in the settings picker (always the dark variant). */
@@ -93,9 +104,10 @@ export const PRESET_SWATCHES: Record<ThemePreset, string> = {
   green: '#22c55e',
   red: '#ef4444',
   amber: '#f59e0b',
+  cyberpunk: 'conic-gradient(#8b5cf6, #3b82f6, #22c55e, #ef4444, #f59e0b, #8b5cf6)',
 };
 
-export const THEME_PRESETS: ThemePreset[] = ['purple', 'blue', 'green', 'red', 'amber'];
+export const THEME_PRESETS: ThemePreset[] = ['purple', 'blue', 'green', 'red', 'amber', 'cyberpunk'];
 
 // ---------------------------------------------------------------------------
 // localStorage persistence
@@ -169,6 +181,19 @@ export function applyTheme(): void {
   root.style.setProperty('--color-text-primary', colors.textPrimary);
   root.style.setProperty('--color-text-secondary', colors.textSecondary);
   root.style.setProperty('--color-border', colors.border);
+
+  // Cyberpunk preset: set a data attribute so CSS can target special effects.
+  // Also inject the rainbow gradient as a CSS variable for borders/glows.
+  if (preset === 'cyberpunk') {
+    root.setAttribute('data-theme', 'cyberpunk');
+    root.style.setProperty(
+      '--rainbow-gradient',
+      'linear-gradient(135deg, #8b5cf6, #3b82f6, #22c55e, #f59e0b, #ef4444, #e040fb, #8b5cf6)'
+    );
+  } else {
+    root.removeAttribute('data-theme');
+    root.style.removeProperty('--rainbow-gradient');
+  }
 
   // Native form controls and scrollbars respect color-scheme
   root.style.colorScheme = resolved;

--- a/src/index.css
+++ b/src/index.css
@@ -267,3 +267,146 @@ body {
    chat width are all driven by inline Tailwind classes + inline styles
    in ChatMessage.tsx.  No additional CSS needed here.
    =================================================================== */
+
+/* ===================================================================
+   Cyberpunk / Neon Rainbow Theme
+   Active when data-theme="cyberpunk" is set on <html>.
+   Gradient borders with slow parallax, soft neon glow.
+   =================================================================== */
+
+/* Animated rainbow gradient — shifts slowly for parallax effect. */
+@property --rainbow-angle {
+  syntax: '<angle>';
+  initial-value: 0deg;
+  inherits: false;
+}
+
+@keyframes rainbow-spin {
+  to { --rainbow-angle: 360deg; }
+}
+
+/* Cards, sections, modals — rainbow border + glow */
+[data-theme="cyberpunk"] section,
+[data-theme="cyberpunk"] .bg-\[var\(--color-bg-secondary\)\] {
+  position: relative;
+  border: 1px solid transparent;
+  background-clip: padding-box;
+  background-origin: border-box;
+}
+
+[data-theme="cyberpunk"] section::before,
+[data-theme="cyberpunk"] .bg-\[var\(--color-bg-secondary\)\]::before {
+  content: '';
+  position: absolute;
+  inset: -1px;
+  border-radius: inherit;
+  padding: 1px;
+  background: conic-gradient(
+    from var(--rainbow-angle, 0deg),
+    #8b5cf6, #3b82f6, #22c55e, #f59e0b, #ef4444, #e040fb, #8b5cf6
+  );
+  mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  mask-composite: exclude;
+  -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  animation: rainbow-spin 8s linear infinite;
+  pointer-events: none;
+  z-index: 0;
+  opacity: 0.5;
+  transition: opacity 0.3s;
+}
+
+/* Brighten on hover */
+[data-theme="cyberpunk"] section:hover::before,
+[data-theme="cyberpunk"] .bg-\[var\(--color-bg-secondary\)\]:hover::before {
+  opacity: 0.85;
+}
+
+/* Soft glow under cards */
+[data-theme="cyberpunk"] section,
+[data-theme="cyberpunk"] .bg-\[var\(--color-bg-secondary\)\] {
+  box-shadow: 0 0 12px -3px rgba(139, 92, 246, 0.15),
+              0 0 12px -3px rgba(59, 130, 246, 0.15),
+              0 0 12px -3px rgba(34, 197, 94, 0.15);
+}
+
+/* Buttons — thin rainbow border + subtle glow */
+[data-theme="cyberpunk"] button[class*="bg-[var(--color-primary)]"],
+[data-theme="cyberpunk"] button[class*="bg-\[var\(--color-primary\)\]"] {
+  box-shadow: 0 0 10px -2px rgba(224, 64, 251, 0.4),
+              0 0 20px -4px rgba(139, 92, 246, 0.2);
+}
+
+/* Toggle switches — neon glow when active */
+[data-theme="cyberpunk"] button[role="switch"][aria-checked="true"] {
+  box-shadow: 0 0 8px 1px rgba(224, 64, 251, 0.5);
+}
+
+/* Scrollbar — neon accent */
+[data-theme="cyberpunk"] ::-webkit-scrollbar-thumb {
+  background: linear-gradient(180deg, #8b5cf6, #e040fb);
+  border-radius: 9999px;
+}
+
+[data-theme="cyberpunk"] ::-webkit-scrollbar-thumb:hover {
+  background: linear-gradient(180deg, #a78bfa, #ea80fc);
+}
+
+/* Streaming cursor — rainbow pulse */
+[data-theme="cyberpunk"] .streaming-cursor {
+  background: linear-gradient(180deg, #8b5cf6, #3b82f6, #22c55e);
+  background-size: 100% 300%;
+  animation: cursor-blink 0.8s step-end infinite,
+             rainbow-cursor-shift 3s ease infinite;
+}
+
+@keyframes rainbow-cursor-shift {
+  0%, 100% { background-position: 0% 0%; }
+  50% { background-position: 0% 100%; }
+}
+
+/* Blockquote accent — rainbow left border */
+[data-theme="cyberpunk"] .markdown-content .md-segment blockquote {
+  border-image: linear-gradient(180deg, #8b5cf6, #3b82f6, #22c55e, #f59e0b, #ef4444) 1;
+}
+
+/* Links — neon glow on hover */
+[data-theme="cyberpunk"] .markdown-content .md-segment a:hover {
+  text-shadow: 0 0 6px rgba(224, 64, 251, 0.5);
+}
+
+/* Code blocks — subtle border glow */
+[data-theme="cyberpunk"] .code-block-wrapper {
+  box-shadow: 0 0 8px -2px rgba(139, 92, 246, 0.2),
+              0 0 8px -2px rgba(59, 130, 246, 0.2);
+}
+
+/* User chat bubbles — dark bg with animated rainbow border + glow */
+[data-theme="cyberpunk"] .cyberpunk-user-bubble {
+  background: var(--color-bg-tertiary) !important;
+  color: var(--color-text-primary) !important;
+  position: relative;
+  overflow: visible;
+  box-shadow: 0 0 10px -2px rgba(139, 92, 246, 0.25),
+              0 0 10px -2px rgba(59, 130, 246, 0.2),
+              0 0 10px -2px rgba(224, 64, 251, 0.2);
+}
+
+[data-theme="cyberpunk"] .cyberpunk-user-bubble::before {
+  content: '';
+  position: absolute;
+  inset: -1.5px;
+  border-radius: inherit;
+  padding: 1.5px;
+  background: conic-gradient(
+    from var(--rainbow-angle, 0deg),
+    #8b5cf6, #3b82f6, #22c55e, #f59e0b, #ef4444, #e040fb, #8b5cf6
+  );
+  mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  mask-composite: exclude;
+  -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  animation: rainbow-spin 8s linear infinite;
+  pointer-events: none;
+  z-index: -1;
+}


### PR DESCRIPTION
New 'cyberpunk' preset in the theme picker — deep purple-black backgrounds with animated rainbow gradient borders on cards, sections, and user chat bubbles. Slow 8s parallax spin on the conic-gradient, soft multi-color neon glow, rainbow scrollbar, and neon accents throughout.

The swatch in settings renders as a conic-gradient circle using all five accent colors. All cyberpunk CSS is scoped to [data-theme="cyberpunk"] so other themes are unaffected.