### PR TITLE
fix: replace mask-composite with padding-box/border-box for rainbow b…

### DIFF
--- a/src/components/settings/ExtensionsPage.tsx
+++ b/src/components/settings/ExtensionsPage.tsx
@@ -13,7 +13,7 @@ function ExtensionCard({ ext }: { ext: ExtensionManifest }) {
   const SettingsPanel = ext.settingsPanel;
 
   return (
-    <div className="bg-[var(--color-bg-secondary)] rounded-lg overflow-hidden">
+    <div className="bg-[var(--color-bg-secondary)] rounded-lg overflow-hidden cyberpunk-card">
       <div className="flex items-center gap-3 p-4">
         <div className="w-10 h-10 rounded-lg bg-[var(--color-primary)]/20 flex items-center justify-center flex-shrink-0">
           <Icon size={20} className="text-[var(--color-primary)]" />

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -196,7 +196,7 @@ export function SettingsPage() {
         ) : (
           <>
             {/* Active Provider Selection */}
-            <section className="bg-[var(--color-bg-secondary)] rounded-lg p-4">
+            <section className="bg-[var(--color-bg-secondary)] rounded-lg p-4 cyberpunk-card">
               <h2 className="text-sm font-semibold text-[var(--color-text-primary)] mb-3">
                 Active Provider
               </h2>
@@ -301,7 +301,7 @@ export function SettingsPage() {
 
             {/* Model Selection */}
             {currentProvider && activeProvider !== 'custom' && (
-              <section className="bg-[var(--color-bg-secondary)] rounded-lg p-4">
+              <section className="bg-[var(--color-bg-secondary)] rounded-lg p-4 cyberpunk-card">
                 <h2 className="text-sm font-semibold text-[var(--color-text-primary)] mb-3">
                   Model
                 </h2>
@@ -321,7 +321,7 @@ export function SettingsPage() {
             )}
 
             {/* Phase 8.4: Connection Profiles */}
-            <section className="bg-[var(--color-bg-secondary)] rounded-lg p-4">
+            <section className="bg-[var(--color-bg-secondary)] rounded-lg p-4 cyberpunk-card">
               <div className="flex items-center gap-2 mb-3">
                 <Plug size={16} className="text-[var(--color-text-secondary)]" />
                 <h2 className="text-sm font-semibold text-[var(--color-text-primary)]">
@@ -430,7 +430,7 @@ export function SettingsPage() {
             </section>
 
             {/* API Keys Configuration */}
-            <section className="bg-[var(--color-bg-secondary)] rounded-lg p-4">
+            <section className="bg-[var(--color-bg-secondary)] rounded-lg p-4 cyberpunk-card">
               <h2 className="text-sm font-semibold text-[var(--color-text-primary)] mb-3">
                 API Keys
               </h2>
@@ -519,7 +519,7 @@ export function SettingsPage() {
             </section>
 
             {/* Generation Settings Link */}
-            <section className="bg-[var(--color-bg-secondary)] rounded-lg overflow-hidden">
+            <section className="bg-[var(--color-bg-secondary)] rounded-lg overflow-hidden cyberpunk-card">
               <button
                 onClick={() => navigate('/settings/generation')}
                 className="w-full flex items-center gap-3 p-4 hover:bg-[var(--color-bg-tertiary)] transition-colors text-left"
@@ -540,7 +540,7 @@ export function SettingsPage() {
             </section>
 
             {/* World Info Link */}
-            <section className="bg-[var(--color-bg-secondary)] rounded-lg overflow-hidden">
+            <section className="bg-[var(--color-bg-secondary)] rounded-lg overflow-hidden cyberpunk-card">
               <button
                 onClick={() => navigate('/settings/worldinfo')}
                 className="w-full flex items-center gap-3 p-4 hover:bg-[var(--color-bg-tertiary)] transition-colors text-left"
@@ -561,7 +561,7 @@ export function SettingsPage() {
             </section>
 
             {/* Regex Scripts Link (Phase 8.2) */}
-            <section className="bg-[var(--color-bg-secondary)] rounded-lg overflow-hidden">
+            <section className="bg-[var(--color-bg-secondary)] rounded-lg overflow-hidden cyberpunk-card">
               <button
                 onClick={() => navigate('/settings/regex')}
                 className="w-full flex items-center gap-3 p-4 hover:bg-[var(--color-bg-tertiary)] transition-colors text-left"
@@ -582,7 +582,7 @@ export function SettingsPage() {
             </section>
 
             {/* Invitations */}
-            <section className="bg-[var(--color-bg-secondary)] rounded-lg overflow-hidden">
+            <section className="bg-[var(--color-bg-secondary)] rounded-lg overflow-hidden cyberpunk-card">
               <button
                 onClick={() => navigate('/settings/invitations')}
                 className="w-full flex items-center gap-3 p-4 hover:bg-[var(--color-bg-tertiary)] transition-colors text-left"
@@ -603,7 +603,7 @@ export function SettingsPage() {
             </section>
 
             {/* Users (Phase 3.1) */}
-            <section className="bg-[var(--color-bg-secondary)] rounded-lg overflow-hidden">
+            <section className="bg-[var(--color-bg-secondary)] rounded-lg overflow-hidden cyberpunk-card">
               <button
                 onClick={() => navigate('/settings/users')}
                 className="w-full flex items-center gap-3 p-4 hover:bg-[var(--color-bg-tertiary)] transition-colors text-left"
@@ -624,7 +624,7 @@ export function SettingsPage() {
             </section>
 
             {/* Quick Replies (Phase 10.2) */}
-            <section className="bg-[var(--color-bg-secondary)] rounded-lg overflow-hidden">
+            <section className="bg-[var(--color-bg-secondary)] rounded-lg overflow-hidden cyberpunk-card">
               <button
                 onClick={() => navigate('/settings/quickreplies')}
                 className="w-full flex items-center gap-3 p-4 hover:bg-[var(--color-bg-tertiary)] transition-colors text-left"
@@ -643,7 +643,7 @@ export function SettingsPage() {
             </section>
 
             {/* Extensions (Phase 7.1) */}
-            <section className="bg-[var(--color-bg-secondary)] rounded-lg overflow-hidden">
+            <section className="bg-[var(--color-bg-secondary)] rounded-lg overflow-hidden cyberpunk-card">
               <button
                 onClick={() => navigate('/settings/extensions')}
                 className="w-full flex items-center gap-3 p-4 hover:bg-[var(--color-bg-tertiary)] transition-colors text-left"
@@ -662,7 +662,7 @@ export function SettingsPage() {
             </section>
 
             {/* Image Gallery (Phase 7.3) */}
-            <section className="bg-[var(--color-bg-secondary)] rounded-lg overflow-hidden">
+            <section className="bg-[var(--color-bg-secondary)] rounded-lg overflow-hidden cyberpunk-card">
               <button
                 onClick={() => navigate('/settings/gallery')}
                 className="w-full flex items-center gap-3 p-4 hover:bg-[var(--color-bg-tertiary)] transition-colors text-left"
@@ -681,7 +681,7 @@ export function SettingsPage() {
             </section>
 
             {/* Data Bank (Phase 8.5) */}
-            <section className="bg-[var(--color-bg-secondary)] rounded-lg overflow-hidden">
+            <section className="bg-[var(--color-bg-secondary)] rounded-lg overflow-hidden cyberpunk-card">
               <button
                 onClick={() => navigate('/settings/databank')}
                 className="w-full flex items-center gap-3 p-4 hover:bg-[var(--color-bg-tertiary)] transition-colors text-left"
@@ -700,7 +700,7 @@ export function SettingsPage() {
             </section>
 
             {/* Appearance (Phase 7.4) */}
-            <section className="bg-[var(--color-bg-secondary)] rounded-lg p-4">
+            <section className="bg-[var(--color-bg-secondary)] rounded-lg p-4 cyberpunk-card">
               <div className="flex items-center gap-2 mb-3">
                 <Palette size={16} className="text-[var(--color-text-secondary)]" />
                 <h2 className="text-sm font-semibold text-[var(--color-text-primary)]">
@@ -767,7 +767,7 @@ export function SettingsPage() {
             </section>
 
             {/* Chat Display (Phase 7.3) */}
-            <section className="bg-[var(--color-bg-secondary)] rounded-lg p-4">
+            <section className="bg-[var(--color-bg-secondary)] rounded-lg p-4 cyberpunk-card">
               <div className="flex items-center gap-2 mb-3">
                 <MessageSquare size={16} className="text-[var(--color-text-secondary)]" />
                 <h2 className="text-sm font-semibold text-[var(--color-text-primary)]">
@@ -904,7 +904,7 @@ export function SettingsPage() {
 
             {/* Voice Input Language */}
             {isSpeechSupported && (
-              <section className="bg-[var(--color-bg-secondary)] rounded-lg p-4">
+              <section className="bg-[var(--color-bg-secondary)] rounded-lg p-4 cyberpunk-card">
                 <div className="flex items-center gap-2 mb-2">
                   <Mic size={16} className="text-[var(--color-text-secondary)]" />
                   <h2 className="text-sm font-semibold text-[var(--color-text-primary)]">
@@ -937,7 +937,7 @@ export function SettingsPage() {
 
             {/* Text-to-Speech (Phase 6.3) */}
             {isTtsSupported && (
-              <section className="bg-[var(--color-bg-secondary)] rounded-lg p-4">
+              <section className="bg-[var(--color-bg-secondary)] rounded-lg p-4 cyberpunk-card">
                 <div className="flex items-center gap-2 mb-2">
                   <Volume2 size={16} className="text-[var(--color-text-secondary)]" />
                   <h2 className="text-sm font-semibold text-[var(--color-text-primary)]">
@@ -1037,7 +1037,7 @@ export function SettingsPage() {
             )}
 
             {/* Translation (Phase 7.2) */}
-            <section className="bg-[var(--color-bg-secondary)] rounded-lg p-4">
+            <section className="bg-[var(--color-bg-secondary)] rounded-lg p-4 cyberpunk-card">
               <div className="flex items-center gap-2 mb-3">
                 <Languages size={16} className="text-[var(--color-text-secondary)]" />
                 <h2 className="text-sm font-semibold text-[var(--color-text-primary)]">

--- a/src/index.css
+++ b/src/index.css
@@ -272,6 +272,7 @@ body {
    Cyberpunk / Neon Rainbow Theme
    Active when data-theme="cyberpunk" is set on <html>.
    Gradient borders with slow parallax, soft neon glow.
+   Uses the background padding-box/border-box technique (no mask-composite).
    =================================================================== */
 
 /* Animated rainbow gradient — shifts slowly for parallax effect. */
@@ -285,56 +286,44 @@ body {
   to { --rainbow-angle: 360deg; }
 }
 
-/* Cards, sections, modals — rainbow border + glow */
-[data-theme="cyberpunk"] section,
-[data-theme="cyberpunk"] .bg-\[var\(--color-bg-secondary\)\] {
-  position: relative;
+/*
+ * Cards and sections — rainbow border via the .cyberpunk-card class.
+ * Technique: transparent border + two backgrounds:
+ *   1) solid dark fill clipped to padding-box
+ *   2) animated conic-gradient clipped to border-box (shows through the border)
+ */
+[data-theme="cyberpunk"] .cyberpunk-card {
   border: 1px solid transparent;
-  background-clip: padding-box;
-  background-origin: border-box;
-}
-
-[data-theme="cyberpunk"] section::before,
-[data-theme="cyberpunk"] .bg-\[var\(--color-bg-secondary\)\]::before {
-  content: '';
-  position: absolute;
-  inset: -1px;
-  border-radius: inherit;
-  padding: 1px;
-  background: conic-gradient(
-    from var(--rainbow-angle, 0deg),
-    #8b5cf6, #3b82f6, #22c55e, #f59e0b, #ef4444, #e040fb, #8b5cf6
-  );
-  mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
-  mask-composite: exclude;
-  -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
-  -webkit-mask-composite: xor;
+  background:
+    var(--color-bg-secondary) padding-box,
+    conic-gradient(
+      from var(--rainbow-angle, 0deg),
+      rgba(139, 92, 246, 0.5),
+      rgba(59, 130, 246, 0.5),
+      rgba(34, 197, 94, 0.5),
+      rgba(245, 158, 11, 0.5),
+      rgba(239, 68, 68, 0.5),
+      rgba(224, 64, 251, 0.5),
+      rgba(139, 92, 246, 0.5)
+    ) border-box;
   animation: rainbow-spin 8s linear infinite;
-  pointer-events: none;
-  z-index: 0;
-  opacity: 0.5;
-  transition: opacity 0.3s;
-}
-
-/* Brighten on hover */
-[data-theme="cyberpunk"] section:hover::before,
-[data-theme="cyberpunk"] .bg-\[var\(--color-bg-secondary\)\]:hover::before {
-  opacity: 0.85;
-}
-
-/* Soft glow under cards */
-[data-theme="cyberpunk"] section,
-[data-theme="cyberpunk"] .bg-\[var\(--color-bg-secondary\)\] {
   box-shadow: 0 0 12px -3px rgba(139, 92, 246, 0.15),
               0 0 12px -3px rgba(59, 130, 246, 0.15),
               0 0 12px -3px rgba(34, 197, 94, 0.15);
+  transition: box-shadow 0.3s;
 }
 
-/* Buttons — thin rainbow border + subtle glow */
-[data-theme="cyberpunk"] button[class*="bg-[var(--color-primary)]"],
-[data-theme="cyberpunk"] button[class*="bg-\[var\(--color-primary\)\]"] {
-  box-shadow: 0 0 10px -2px rgba(224, 64, 251, 0.4),
-              0 0 20px -4px rgba(139, 92, 246, 0.2);
+[data-theme="cyberpunk"] .cyberpunk-card:hover {
+  border-color: transparent;
+  background:
+    var(--color-bg-secondary) padding-box,
+    conic-gradient(
+      from var(--rainbow-angle, 0deg),
+      #8b5cf6, #3b82f6, #22c55e, #f59e0b, #ef4444, #e040fb, #8b5cf6
+    ) border-box;
+  box-shadow: 0 0 16px -2px rgba(139, 92, 246, 0.25),
+              0 0 16px -2px rgba(59, 130, 246, 0.25),
+              0 0 16px -2px rgba(34, 197, 94, 0.25);
 }
 
 /* Toggle switches — neon glow when active */
@@ -383,30 +372,16 @@ body {
 
 /* User chat bubbles — dark bg with animated rainbow border + glow */
 [data-theme="cyberpunk"] .cyberpunk-user-bubble {
-  background: var(--color-bg-tertiary) !important;
+  background:
+    var(--color-bg-tertiary) padding-box,
+    conic-gradient(
+      from var(--rainbow-angle, 0deg),
+      #8b5cf6, #3b82f6, #22c55e, #f59e0b, #ef4444, #e040fb, #8b5cf6
+    ) border-box !important;
   color: var(--color-text-primary) !important;
-  position: relative;
-  overflow: visible;
+  border: 1.5px solid transparent !important;
+  animation: rainbow-spin 8s linear infinite;
   box-shadow: 0 0 10px -2px rgba(139, 92, 246, 0.25),
               0 0 10px -2px rgba(59, 130, 246, 0.2),
               0 0 10px -2px rgba(224, 64, 251, 0.2);
-}
-
-[data-theme="cyberpunk"] .cyberpunk-user-bubble::before {
-  content: '';
-  position: absolute;
-  inset: -1.5px;
-  border-radius: inherit;
-  padding: 1.5px;
-  background: conic-gradient(
-    from var(--rainbow-angle, 0deg),
-    #8b5cf6, #3b82f6, #22c55e, #f59e0b, #ef4444, #e040fb, #8b5cf6
-  );
-  mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
-  mask-composite: exclude;
-  -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
-  -webkit-mask-composite: xor;
-  animation: rainbow-spin 8s linear infinite;
-  pointer-events: none;
-  z-index: -1;
 }


### PR DESCRIPTION
…orders

The mask-composite: exclude technique broke in the production build, causing rainbow gradients to fill entire cards. Replaced with the reliable background padding-box/border-box approach: transparent border with a solid bg clipped to padding-box and a conic-gradient clipped to border-box. Added .cyberpunk-card class to settings sections instead of targeting escaped Tailwind class names.