### PR TITLE
feat: Phase 9 — Prompt Manager, Templates, and Full Macro System

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import { ProfilePage } from './components/auth/ProfilePage';
 import { RequireRole } from './components/auth/RequireRole';
 import { MainLayout } from './components/layout/MainLayout';
 import { ChatView } from './components/chat/ChatView';
-import { SettingsPage, GenerationSettingsPage, InvitationManager, UserManagementPage, QuickReplyPage, ExtensionsPage, DataBankPage, GalleryPage } from './components/settings';
+import { SettingsPage, GenerationSettingsPage, InvitationManager, UserManagementPage, QuickReplyPage, ExtensionsPage, DataBankPage, GalleryPage, PromptTemplatesPage } from './components/settings';
 import { WorldInfoPage } from './components/worldinfo';
 import { RegexScriptPage } from './components/regexscripts';
 import { InviteAcceptPage } from './components/auth/InviteAcceptPage';
@@ -22,6 +22,7 @@ function App() {
         <Route path="/profile" element={<RequireRole minRole="end_user"><ProfilePage /></RequireRole>} />
         <Route path="/settings" element={<RequireRole minRole="admin"><SettingsPage /></RequireRole>} />
         <Route path="/settings/generation" element={<RequireRole minRole="admin"><GenerationSettingsPage /></RequireRole>} />
+        <Route path="/settings/prompts" element={<RequireRole minRole="admin"><PromptTemplatesPage /></RequireRole>} />
         <Route path="/settings/worldinfo" element={<RequireRole minRole="admin"><WorldInfoPage /></RequireRole>} />
         <Route path="/settings/regex" element={<RequireRole minRole="admin"><RegexScriptPage /></RequireRole>} />
         <Route path="/settings/invitations" element={<RequireRole minRole="admin"><InvitationManager /></RequireRole>} />

--- a/src/components/settings/GenerationSettingsPage.tsx
+++ b/src/components/settings/GenerationSettingsPage.tsx
@@ -6,12 +6,14 @@ import { useSettingsStore } from '../../stores/settingsStore';
 import { getDefaultContextSize } from '../../utils/tokenizer';
 import { INSTRUCT_TEMPLATES } from '../../utils/instructTemplates';
 import { Button, Input, TextArea } from '../ui';
+import { PromptOrderEditor } from './PromptOrderEditor';
 
-type TabId = 'samplers' | 'prompts' | 'context' | 'instruct';
+type TabId = 'samplers' | 'prompts' | 'order' | 'context' | 'instruct';
 
 const TABS: { id: TabId; label: string }[] = [
   { id: 'samplers', label: 'Samplers' },
   { id: 'prompts', label: 'Prompts' },
+  { id: 'order', label: 'Order' },
   { id: 'context', label: 'Context' },
   { id: 'instruct', label: 'Instruct' },
 ];
@@ -400,6 +402,8 @@ export function GenerationSettingsPage() {
             </div>
           </section>
         )}
+
+        {tab === 'order' && <PromptOrderEditor />}
 
         {tab === 'context' && (
           <section className="bg-[var(--color-bg-secondary)] rounded-lg p-4 space-y-4">

--- a/src/components/settings/PromptOrderEditor.tsx
+++ b/src/components/settings/PromptOrderEditor.tsx
@@ -1,0 +1,119 @@
+import { ChevronDown, ChevronUp, RotateCcw } from 'lucide-react';
+import {
+  useGenerationStore,
+  PROMPT_SECTION_LABELS,
+  PROMPT_SECTION_DESCRIPTIONS,
+  POST_HISTORY_SECTIONS,
+} from '../../stores/generationStore';
+import { Button } from '../ui';
+
+/**
+ * Phase 9.1 — Prompt Order Editor.
+ *
+ * Renders the user's prompt-section order as a reorderable list. Each row
+ * shows the section label + description, an enable checkbox, and up/down
+ * arrow buttons. Follows the QuickReplyPage arrow-button reorder pattern to
+ * avoid pulling in a DnD library.
+ */
+export function PromptOrderEditor() {
+  const { promptOrder, movePromptSection, togglePromptSection, resetPromptOrder } =
+    useGenerationStore();
+
+  return (
+    <section className="bg-[var(--color-bg-secondary)] rounded-lg p-4">
+      <div className="flex items-center justify-between mb-2">
+        <h2 className="text-sm font-semibold text-[var(--color-text-primary)]">
+          Prompt Order
+        </h2>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={resetPromptOrder}
+          className="text-xs"
+          aria-label="Reset to defaults"
+        >
+          <RotateCcw size={14} className="mr-1" />
+          Reset
+        </Button>
+      </div>
+      <p className="text-xs text-[var(--color-text-secondary)] mb-4 leading-relaxed">
+        Reorder or disable prompt sections. Sections marked <em>post-history</em>{' '}
+        are placed after the chat history. At-depth injections (author's note,
+        depth prompts) are not reorderable here — they're controlled by their
+        own depth settings.
+      </p>
+
+      <ul className="space-y-2">
+        {promptOrder.map((entry, idx) => {
+          const label = PROMPT_SECTION_LABELS[entry.id];
+          const description = PROMPT_SECTION_DESCRIPTIONS[entry.id];
+          const isPostHistory = POST_HISTORY_SECTIONS.has(entry.id);
+          const atTop = idx === 0;
+          const atBottom = idx === promptOrder.length - 1;
+          return (
+            <li
+              key={entry.id}
+              className={`
+                bg-[var(--color-bg-tertiary)] rounded-lg border border-[var(--color-border)]
+                ${entry.enabled ? '' : 'opacity-50'}
+              `}
+            >
+              <div className="flex items-start gap-2 p-3">
+                {/* Order + enable controls */}
+                <div className="flex flex-col items-center gap-1 pt-0.5">
+                  <button
+                    type="button"
+                    onClick={() => movePromptSection(entry.id, 'up')}
+                    disabled={atTop}
+                    className="p-1 rounded hover:bg-[var(--color-bg-secondary)] disabled:opacity-30 disabled:cursor-not-allowed text-[var(--color-text-primary)]"
+                    aria-label={`Move ${label} up`}
+                  >
+                    <ChevronUp size={16} />
+                  </button>
+                  <span className="text-xs text-[var(--color-text-secondary)] tabular-nums">
+                    {idx + 1}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => movePromptSection(entry.id, 'down')}
+                    disabled={atBottom}
+                    className="p-1 rounded hover:bg-[var(--color-bg-secondary)] disabled:opacity-30 disabled:cursor-not-allowed text-[var(--color-text-primary)]"
+                    aria-label={`Move ${label} down`}
+                  >
+                    <ChevronDown size={16} />
+                  </button>
+                </div>
+
+                {/* Label + description */}
+                <label className="flex-1 min-w-0 cursor-pointer flex items-start gap-2">
+                  <input
+                    type="checkbox"
+                    checked={entry.enabled}
+                    onChange={() => togglePromptSection(entry.id)}
+                    className="mt-1 accent-[var(--color-primary)]"
+                    aria-label={`Enable ${label}`}
+                  />
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span className="text-sm font-medium text-[var(--color-text-primary)]">
+                        {label}
+                      </span>
+                      {isPostHistory && (
+                        <span className="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded bg-[var(--color-bg-primary)] text-[var(--color-text-secondary)] border border-[var(--color-border)]">
+                          post-history
+                        </span>
+                      )}
+                    </div>
+                    <p className="text-xs text-[var(--color-text-secondary)] mt-1 leading-relaxed">
+                      {description}
+                    </p>
+                  </div>
+                </label>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/src/components/settings/PromptTemplatesPage.tsx
+++ b/src/components/settings/PromptTemplatesPage.tsx
@@ -1,0 +1,336 @@
+import { useRef, useState } from 'react';
+import {
+  ArrowLeft,
+  Check,
+  Download,
+  Pencil,
+  Plus,
+  Trash2,
+  Upload,
+  X,
+} from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { usePromptTemplateStore } from '../../stores/promptTemplateStore';
+import { Button, Input, ConfirmDialog } from '../ui';
+
+/**
+ * Phase 9.2 — Prompt Templates & Presets.
+ *
+ * Lets users save the current generation-store state as a named template,
+ * load it back, rename, delete, and import/export as JSON. Mirrors the
+ * regex-script page import/export pattern.
+ */
+export function PromptTemplatesPage() {
+  const navigate = useNavigate();
+  const {
+    templates,
+    activeTemplateId,
+    saveTemplate,
+    loadTemplate,
+    deleteTemplate,
+    renameTemplate,
+    importTemplates,
+    exportTemplates,
+  } = usePromptTemplateStore();
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const [name, setName] = useState('');
+  const [includeSampler, setIncludeSampler] = useState(false);
+  const [justLoadedId, setJustLoadedId] = useState<string | null>(null);
+
+  const [renamingId, setRenamingId] = useState<string | null>(null);
+  const [renameDraft, setRenameDraft] = useState('');
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  const handleSave = () => {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    saveTemplate(trimmed, includeSampler);
+    setName('');
+    setIncludeSampler(false);
+  };
+
+  const handleLoad = (id: string) => {
+    loadTemplate(id);
+    setJustLoadedId(id);
+    setTimeout(() => setJustLoadedId((curr) => (curr === id ? null : curr)), 1500);
+  };
+
+  const startRename = (id: string, currentName: string) => {
+    setRenamingId(id);
+    setRenameDraft(currentName);
+  };
+
+  const commitRename = () => {
+    if (renamingId && renameDraft.trim()) {
+      renameTemplate(renamingId, renameDraft.trim());
+    }
+    setRenamingId(null);
+    setRenameDraft('');
+  };
+
+  const handleExport = () => {
+    const json = exportTemplates();
+    const blob = new Blob([json], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'prompt_templates.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleImportClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = importTemplates(reader.result as string);
+      if (result.imported === 0) {
+        alert('No valid templates found in file.');
+      } else if (result.errors > 0) {
+        alert(`Imported ${result.imported} templates (${result.errors} skipped).`);
+      }
+    };
+    reader.readAsText(file);
+    e.target.value = '';
+  };
+
+  const templateToDelete = deletingId
+    ? templates.find((t) => t.id === deletingId) ?? null
+    : null;
+
+  return (
+    <div className="min-h-screen bg-[var(--color-bg-primary)]">
+      {/* Header */}
+      <header className="h-14 bg-[var(--color-bg-secondary)] border-b border-[var(--color-border)] flex items-center px-4 gap-3 safe-top">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => navigate('/settings')}
+          className="p-2"
+          aria-label="Back"
+        >
+          <ArrowLeft size={24} />
+        </Button>
+        <h1 className="text-lg font-semibold text-[var(--color-text-primary)] flex-1">
+          Prompt Templates
+        </h1>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={handleImportClick}
+            className="p-1.5 rounded-lg hover:bg-[var(--color-bg-tertiary)] text-[var(--color-text-secondary)]"
+            title="Import templates"
+            aria-label="Import templates"
+          >
+            <Upload size={18} />
+          </button>
+          <button
+            type="button"
+            onClick={handleExport}
+            disabled={templates.length === 0}
+            className="p-1.5 rounded-lg hover:bg-[var(--color-bg-tertiary)] text-[var(--color-text-secondary)] disabled:opacity-40"
+            title="Export templates"
+            aria-label="Export templates"
+          >
+            <Download size={18} />
+          </button>
+        </div>
+      </header>
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".json"
+        onChange={handleFileChange}
+        className="hidden"
+      />
+
+      <div className="max-w-2xl mx-auto p-4 space-y-6">
+        {/* Save current */}
+        <section className="bg-[var(--color-bg-secondary)] rounded-lg p-4 space-y-3">
+          <h2 className="text-sm font-semibold text-[var(--color-text-primary)]">
+            Save Current Setup
+          </h2>
+          <p className="text-xs text-[var(--color-text-secondary)]">
+            Captures your current main prompt, jailbreak, post-history instructions,
+            context size, instruct mode, and prompt order. Samplers are optional.
+          </p>
+          <Input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Template name"
+            aria-label="Template name"
+          />
+          <label className="flex items-center gap-2 text-sm text-[var(--color-text-primary)] cursor-pointer">
+            <input
+              type="checkbox"
+              checked={includeSampler}
+              onChange={(e) => setIncludeSampler(e.target.checked)}
+              className="accent-[var(--color-primary)]"
+            />
+            Include sampler parameters (temperature, topP, etc.)
+          </label>
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={handleSave}
+            disabled={!name.trim()}
+            className="w-full"
+          >
+            <Plus size={16} className="mr-1" />
+            Save as Template
+          </Button>
+        </section>
+
+        {/* Template list */}
+        <section className="bg-[var(--color-bg-secondary)] rounded-lg p-4">
+          <h2 className="text-sm font-semibold text-[var(--color-text-primary)] mb-3">
+            Saved Templates {templates.length > 0 && `(${templates.length})`}
+          </h2>
+
+          {templates.length === 0 ? (
+            <p className="text-sm text-[var(--color-text-secondary)] text-center py-6">
+              No templates yet. Save one above or import from a JSON file.
+            </p>
+          ) : (
+            <ul className="space-y-2">
+              {templates.map((template) => {
+                const isActive = activeTemplateId === template.id;
+                const isRenaming = renamingId === template.id;
+                const justLoaded = justLoadedId === template.id;
+                return (
+                  <li
+                    key={template.id}
+                    className={`
+                      p-3 rounded-lg border
+                      ${
+                        isActive
+                          ? 'bg-[var(--color-bg-tertiary)] border-[var(--color-primary)]'
+                          : 'bg-[var(--color-bg-tertiary)] border-[var(--color-border)]'
+                      }
+                    `}
+                  >
+                    {isRenaming ? (
+                      <div className="flex items-center gap-2">
+                        <Input
+                          value={renameDraft}
+                          onChange={(e) => setRenameDraft(e.target.value)}
+                          autoFocus
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter') commitRename();
+                            if (e.key === 'Escape') {
+                              setRenamingId(null);
+                              setRenameDraft('');
+                            }
+                          }}
+                          className="flex-1"
+                          aria-label="Rename template"
+                        />
+                        <button
+                          type="button"
+                          onClick={commitRename}
+                          className="p-1.5 rounded-lg hover:bg-[var(--color-bg-primary)] text-[var(--color-primary)]"
+                          aria-label="Confirm rename"
+                        >
+                          <Check size={16} />
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setRenamingId(null);
+                            setRenameDraft('');
+                          }}
+                          className="p-1.5 rounded-lg hover:bg-[var(--color-bg-primary)] text-[var(--color-text-secondary)]"
+                          aria-label="Cancel rename"
+                        >
+                          <X size={16} />
+                        </button>
+                      </div>
+                    ) : (
+                      <div className="flex items-start justify-between gap-2">
+                        <div className="flex-1 min-w-0">
+                          <div className="flex items-center gap-2 flex-wrap">
+                            <h3 className="text-sm font-medium text-[var(--color-text-primary)] truncate">
+                              {template.name}
+                            </h3>
+                            {template.sampler && (
+                              <span className="text-[10px] px-1.5 py-0.5 rounded bg-[var(--color-primary)]/15 text-[var(--color-primary)]">
+                                +sampler
+                              </span>
+                            )}
+                            {isActive && (
+                              <span className="text-[10px] px-1.5 py-0.5 rounded bg-[var(--color-primary)]/15 text-[var(--color-primary)]">
+                                active
+                              </span>
+                            )}
+                            {justLoaded && (
+                              <span className="text-[10px] px-1.5 py-0.5 rounded bg-green-500/15 text-green-400">
+                                loaded
+                              </span>
+                            )}
+                          </div>
+                          <p className="text-[11px] text-[var(--color-text-secondary)] mt-0.5">
+                            Saved {new Date(template.createdAt).toLocaleString()}
+                          </p>
+                        </div>
+                        <div className="flex items-center gap-0.5 flex-shrink-0">
+                          <Button
+                            variant="primary"
+                            size="sm"
+                            onClick={() => handleLoad(template.id)}
+                            className="text-xs"
+                          >
+                            Load
+                          </Button>
+                          <button
+                            type="button"
+                            onClick={() => startRename(template.id, template.name)}
+                            className="p-1.5 rounded-lg hover:bg-[var(--color-bg-primary)] text-[var(--color-text-secondary)]"
+                            aria-label={`Rename ${template.name}`}
+                          >
+                            <Pencil size={16} />
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => setDeletingId(template.id)}
+                            className="p-1.5 rounded-lg hover:bg-[var(--color-bg-primary)] text-red-400"
+                            aria-label={`Delete ${template.name}`}
+                          >
+                            <Trash2 size={16} />
+                          </button>
+                        </div>
+                      </div>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </section>
+      </div>
+
+      <ConfirmDialog
+        isOpen={deletingId !== null}
+        title="Delete template?"
+        message={
+          templateToDelete
+            ? `"${templateToDelete.name}" will be removed. This cannot be undone.`
+            : ''
+        }
+        confirmLabel="Delete"
+        danger
+        onConfirm={() => {
+          if (deletingId) deleteTemplate(deletingId);
+        }}
+        onClose={() => setDeletingId(null)}
+      />
+    </div>
+  );
+}

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { ArrowLeft, BookOpen, Check, ChevronRight, Database, Eye, EyeOff, Globe, Image, Key, Languages, Loader2, MessageSquare, Mic, Palette, Plug, Replace, Sliders, Trash2, UserPlus, Users, Volume2, Zap } from 'lucide-react';
+import { ArrowLeft, BookOpen, Check, ChevronRight, Database, Eye, EyeOff, FileText, Globe, Image, Key, Languages, Loader2, MessageSquare, Mic, Palette, Plug, Replace, Sliders, Trash2, UserPlus, Users, Volume2, Zap } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useSettingsStore } from '../../stores/settingsStore';
 import { PROVIDERS, type SecretState } from '../../api/client';
@@ -533,6 +533,27 @@ export function SettingsPage() {
                   </h3>
                   <p className="text-xs text-[var(--color-text-secondary)]">
                     Samplers, prompts, context, and instruct mode
+                  </p>
+                </div>
+                <ChevronRight size={20} className="text-[var(--color-text-secondary)]" />
+              </button>
+            </section>
+
+            {/* Prompt Templates Link */}
+            <section className="bg-[var(--color-bg-secondary)] rounded-lg overflow-hidden cyberpunk-card">
+              <button
+                onClick={() => navigate('/settings/prompts')}
+                className="w-full flex items-center gap-3 p-4 hover:bg-[var(--color-bg-tertiary)] transition-colors text-left"
+              >
+                <div className="w-10 h-10 rounded-lg bg-[var(--color-primary)]/20 flex items-center justify-center">
+                  <FileText size={20} className="text-[var(--color-primary)]" />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <h3 className="text-sm font-semibold text-[var(--color-text-primary)]">
+                    Prompt Templates
+                  </h3>
+                  <p className="text-xs text-[var(--color-text-secondary)]">
+                    Save and share full prompt setups
                   </p>
                 </div>
                 <ChevronRight size={20} className="text-[var(--color-text-secondary)]" />

--- a/src/components/settings/index.ts
+++ b/src/components/settings/index.ts
@@ -6,3 +6,4 @@ export { QuickReplyPage } from './QuickReplyPage';
 export { ExtensionsPage } from './ExtensionsPage';
 export { DataBankPage } from './DataBankPage';
 export { GalleryPage } from './GalleryPage';
+export { PromptTemplatesPage } from './PromptTemplatesPage';

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -7,7 +7,11 @@ import {
 } from '../api/client';
 import { useSettingsStore } from './settingsStore';
 import { usePersonaStore } from './personaStore';
-import { useGenerationStore } from './generationStore';
+import {
+  useGenerationStore,
+  POST_HISTORY_SECTIONS,
+  type PromptSectionId,
+} from './generationStore';
 import { useCharacterStore } from './characterStore';
 import {
   useWorldInfoStore,
@@ -121,6 +125,33 @@ function loadAuthorNotesFromStorage(): Record<string, AuthorNote> {
 
 function saveAuthorNotesToStorage(notes: Record<string, AuthorNote>) {
   localStorage.setItem(AUTHOR_NOTES_KEY, JSON.stringify(notes));
+}
+
+/**
+ * Phase 9.3: per-chat variable storage. Keyed by chat file name, each value is
+ * a flat map of variable-name → string value. Populated and mutated by the
+ * `{{setvar}}` / `{{addvar}}` / `{{incvar}}` / `{{decvar}}` macros.
+ */
+const CHAT_VARIABLES_KEY = 'stm:chat-vars';
+
+function loadChatVariablesFromStorage(): Record<string, Record<string, string>> {
+  try {
+    const stored = localStorage.getItem(CHAT_VARIABLES_KEY);
+    if (!stored) return {};
+    const parsed = JSON.parse(stored);
+    if (!parsed || typeof parsed !== 'object') return {};
+    return parsed;
+  } catch {
+    return {};
+  }
+}
+
+function saveChatVariablesToStorage(vars: Record<string, Record<string, string>>) {
+  try {
+    localStorage.setItem(CHAT_VARIABLES_KEY, JSON.stringify(vars));
+  } catch {
+    // ignore quota
+  }
 }
 
 const GROUP_CHATS_KEY = 'sillytavern_group_chats';
@@ -373,6 +404,11 @@ interface ChatState {
   getAuthorNote: (fileName: string) => AuthorNote | null;
   setAuthorNote: (fileName: string, note: Partial<AuthorNote>) => void;
 
+  // Phase 9.3: per-chat variables consumed by the macro system
+  chatVariables: Record<string, Record<string, string>>;
+  getChatVariables: (fileName: string) => Record<string, string>;
+  setChatVariables: (fileName: string, vars: Record<string, string>) => void;
+
   // Phase 8.6: load a branch snapshot into memory (does not save to disk)
   loadBranchMessages: (messages: ChatMessage[]) => void;
 
@@ -507,7 +543,8 @@ function buildMacroContext(
   personaName: string,
   personaDescription: string,
   messages: ChatMessage[],
-  model: string
+  model: string,
+  variables?: Record<string, string>
 ): MacroContext {
   const nonSystem = messages.filter((m) => !m.isSystem);
   const lastMessage = nonSystem[nonSystem.length - 1]?.content || '';
@@ -524,10 +561,13 @@ function buildMacroContext(
     characterPersonality:
       character.personality || character.data?.personality || '',
     characterScenario: character.scenario || character.data?.scenario || '',
+    characterExampleMessages:
+      character.mes_example || character.data?.mes_example || '',
     lastMessage,
     lastUserMessage: lastUser,
     lastCharMessage: lastChar,
     model,
+    variables,
   };
 }
 
@@ -573,12 +613,23 @@ function buildConversationContext(
   const genState = useGenerationStore.getState();
   const { activeModel, activeProvider } = useSettingsStore.getState();
 
+  // Phase 9.3: clone the chat's variables into a mutable map that macros
+  // will read from and write to during processing. After the whole context
+  // is built, the snapshot is persisted back to the store via
+  // `setChatVariables` so `{{setvar}}` calls survive between turns.
+  const chatStoreState = useChatStore.getState();
+  const ctxChatFile = chatStoreState.currentChatFile;
+  const variables: Record<string, string> = ctxChatFile
+    ? { ...chatStoreState.getChatVariables(ctxChatFile) }
+    : {};
+
   const macroCtx = buildMacroContext(
     character,
     personaName,
     personaDescription,
     messages,
-    activeModel
+    activeModel,
+    variables
   );
   const sub = (text: string) => (text ? processMacros(text, macroCtx) : '');
 
@@ -625,7 +676,6 @@ function buildConversationContext(
       .join('\n\n');
 
   // Phase 7.1: Extension context contributions
-  const { currentChatFile: ctxChatFile } = useChatStore.getState();
   const extContributions = extensionRegistry.runContextHooks({
     messages: messages.map((m) => ({
       name: m.name,
@@ -709,47 +759,55 @@ Choose the emotion that best matches how ${character.name} would feel based on t
     }
   }
 
-  // Assemble system prompt parts in order
-  const systemParts: string[] = [mainPrompt];
-  if (persona && persona.descriptionPosition === 'before_char' && personaBlock) {
-    systemParts.push(personaBlock);
-  }
+  // Phase 9.1: Compute every reorderable section's content into a keyed map.
+  // Order + enabled flags come from `genState.promptOrder`; assembly below
+  // iterates that array instead of pushing in a hard-coded sequence.
   const wiBeforeChar = joinWi(wiByPosition.before_char);
-  if (wiBeforeChar) {
-    systemParts.push(wiBeforeChar);
-  }
   const extBeforeChar = joinExt(extByPosition.before_char);
-  if (extBeforeChar) systemParts.push(extBeforeChar);
-  if (charInfoBlock) {
-    systemParts.push(charInfoBlock);
-  }
   const wiAfterChar = joinWi(wiByPosition.after_char);
-  if (wiAfterChar) {
-    systemParts.push(wiAfterChar);
-  }
   const extAfterChar = joinExt(extByPosition.after_char);
-  if (extAfterChar) systemParts.push(extAfterChar);
-  if (persona && persona.descriptionPosition === 'after_char' && personaDescription) {
-    systemParts.push(`[The user you're talking to is ${personaName}. ${personaDescription}]`);
-  }
-  if (persona && persona.descriptionPosition === 'in_prompt' && personaDescription) {
-    // Only add it once; if not added as before_char
-    // Already added as before_char, so only add if not already
-  }
   const wiBeforeAn = joinWi(wiByPosition.before_an);
-  if (wiBeforeAn) {
-    systemParts.push(wiBeforeAn);
-  }
   const extBeforeAn = joinExt(extByPosition.before_an);
-  if (extBeforeAn) systemParts.push(extBeforeAn);
-  if (userJailbreak) {
-    systemParts.push(userJailbreak);
-  }
-  systemParts.push(emotionInstruction);
+  const wiAfterAn = joinWi(wiByPosition.after_an);
+  const extAfterAn = joinExt(extByPosition.after_an);
 
-  // Phase 8.5 — RAG: inject retrieved chunks from the Data Bank
-  if (ragContext) {
-    systemParts.push(`[Relevant background information]\n${ragContext}`);
+  const sectionContent: Partial<Record<PromptSectionId, string>> = {
+    main_prompt: mainPrompt,
+    persona_before_char:
+      persona && persona.descriptionPosition === 'before_char' && personaBlock
+        ? personaBlock
+        : '',
+    wi_before_char: wiBeforeChar,
+    ext_before_char: extBeforeChar,
+    char_info_block: charInfoBlock,
+    wi_after_char: wiAfterChar,
+    ext_after_char: extAfterChar,
+    persona_after_char:
+      persona && persona.descriptionPosition === 'after_char' && personaDescription
+        ? `[The user you're talking to is ${personaName}. ${personaDescription}]`
+        : '',
+    wi_before_an: wiBeforeAn,
+    ext_before_an: extBeforeAn,
+    jailbreak: userJailbreak,
+    emotion_instruction: emotionInstruction,
+    rag_context: ragContext
+      ? `[Relevant background information]\n${ragContext}`
+      : '',
+    char_phi: charPostHistoryInstructions,
+    user_phi: userPHI,
+    wi_after_an: wiAfterAn,
+    ext_after_an: extAfterAn,
+  };
+
+  const promptOrder = genState.promptOrder;
+
+  // Pre-history stage: everything that lives in the leading system block.
+  const systemParts: string[] = [];
+  for (const entry of promptOrder) {
+    if (!entry.enabled) continue;
+    if (POST_HISTORY_SECTIONS.has(entry.id)) continue;
+    const content = sectionContent[entry.id];
+    if (content && content.trim()) systemParts.push(content);
   }
 
   context.push({
@@ -914,22 +972,14 @@ Choose the emotion that best matches how ${character.name} would feel based on t
     context.push(...historyWithInsertions);
   }
 
-  // Post-history instructions: character's PHI, then user PHI
-  if (charPostHistoryInstructions) {
-    context.push({ role: 'system', content: charPostHistoryInstructions });
-  }
-  if (userPHI) {
-    context.push({ role: 'system', content: userPHI });
-  }
-
-  // World info 'after_an' entries go after post-history instructions
-  const wiAfterAn = joinWi(wiByPosition.after_an);
-  if (wiAfterAn) {
-    context.push({ role: 'system', content: wiAfterAn });
-  }
-  const extAfterAn = joinExt(extByPosition.after_an);
-  if (extAfterAn) {
-    context.push({ role: 'system', content: extAfterAn });
+  // Phase 9.1: Post-history stage — char PHI, user PHI, wi_after_an, ext_after_an
+  // emit in user-defined order (same map computed above).
+  for (const entry of promptOrder) {
+    if (!entry.enabled) continue;
+    if (!POST_HISTORY_SECTIONS.has(entry.id)) continue;
+    const content = sectionContent[entry.id];
+    if (!content || !content.trim()) continue;
+    context.push({ role: 'system', content });
   }
 
   // If not token-aware, still estimate tokens for the UI badge
@@ -937,6 +987,12 @@ Choose the emotion that best matches how ${character.name} would feel based on t
     genState.setLastTokenEstimate(
       estimateConversationTokens(context, tokenProfile)
     );
+  }
+
+  // Phase 9.3: persist any `{{setvar}}`/`{{addvar}}`/`{{incvar}}`/`{{decvar}}`
+  // writes that happened during macro processing back to the chat's store.
+  if (ctxChatFile) {
+    chatStoreState.setChatVariables(ctxChatFile, variables);
   }
 
   return context;
@@ -1444,6 +1500,20 @@ export const useChatStore = create<ChatState>((set, get) => ({
     };
     saveAuthorNotesToStorage(updated);
     set({ authorNotes: updated });
+  },
+
+  // Phase 9.3: Chat variables (consumed by macro system)
+  chatVariables: loadChatVariablesFromStorage(),
+
+  getChatVariables: (fileName: string) => {
+    return get().chatVariables[fileName] ?? {};
+  },
+
+  setChatVariables: (fileName: string, vars: Record<string, string>) => {
+    const { chatVariables } = get();
+    const updated = { ...chatVariables, [fileName]: { ...vars } };
+    saveChatVariablesToStorage(updated);
+    set({ chatVariables: updated });
   },
 
   refreshGroupChats: () => {

--- a/src/stores/generationStore.ts
+++ b/src/stores/generationStore.ts
@@ -87,6 +87,99 @@ export const DEFAULT_INSTRUCT_CONFIG: InstructConfig = {
   extraStopStrings: [],
 };
 
+/** Phase 9.1: stable IDs for every reorderable prompt section. */
+export type PromptSectionId =
+  | 'main_prompt'
+  | 'persona_before_char'
+  | 'wi_before_char'
+  | 'ext_before_char'
+  | 'char_info_block'
+  | 'wi_after_char'
+  | 'ext_after_char'
+  | 'persona_after_char'
+  | 'wi_before_an'
+  | 'ext_before_an'
+  | 'jailbreak'
+  | 'emotion_instruction'
+  | 'rag_context'
+  | 'char_phi'
+  | 'user_phi'
+  | 'wi_after_an'
+  | 'ext_after_an';
+
+export interface PromptSectionEntry {
+  id: PromptSectionId;
+  enabled: boolean;
+}
+
+export const DEFAULT_PROMPT_ORDER: PromptSectionEntry[] = [
+  { id: 'main_prompt', enabled: true },
+  { id: 'persona_before_char', enabled: true },
+  { id: 'wi_before_char', enabled: true },
+  { id: 'ext_before_char', enabled: true },
+  { id: 'char_info_block', enabled: true },
+  { id: 'wi_after_char', enabled: true },
+  { id: 'ext_after_char', enabled: true },
+  { id: 'persona_after_char', enabled: true },
+  { id: 'wi_before_an', enabled: true },
+  { id: 'ext_before_an', enabled: true },
+  { id: 'jailbreak', enabled: true },
+  { id: 'emotion_instruction', enabled: true },
+  { id: 'rag_context', enabled: true },
+  { id: 'char_phi', enabled: true },
+  { id: 'user_phi', enabled: true },
+  { id: 'wi_after_an', enabled: true },
+  { id: 'ext_after_an', enabled: true },
+];
+
+/** Sections emitted AFTER the chat history (post-history stage). */
+export const POST_HISTORY_SECTIONS: ReadonlySet<PromptSectionId> = new Set<PromptSectionId>([
+  'char_phi',
+  'user_phi',
+  'wi_after_an',
+  'ext_after_an',
+]);
+
+export const PROMPT_SECTION_LABELS: Record<PromptSectionId, string> = {
+  main_prompt: 'Main / System Prompt',
+  persona_before_char: 'Persona (before character)',
+  wi_before_char: 'World Info — Before Char',
+  ext_before_char: 'Extensions — Before Char',
+  char_info_block: 'Character Info (desc / personality / scenario / examples)',
+  wi_after_char: 'World Info — After Char',
+  ext_after_char: 'Extensions — After Char',
+  persona_after_char: 'Persona (after character)',
+  wi_before_an: 'World Info — Before Author Note',
+  ext_before_an: 'Extensions — Before Author Note',
+  jailbreak: 'Jailbreak / Auxiliary Prompt',
+  emotion_instruction: 'Emotion Tag Instruction',
+  rag_context: 'Data Bank / RAG Context',
+  char_phi: 'Character Post-History Instructions',
+  user_phi: 'User Post-History Instructions',
+  wi_after_an: 'World Info — After Author Note',
+  ext_after_an: 'Extensions — After Author Note',
+};
+
+export const PROMPT_SECTION_DESCRIPTIONS: Record<PromptSectionId, string> = {
+  main_prompt: 'The top-level system instruction. Character card overrides win when respected.',
+  persona_before_char: 'Your persona description, when positioned before the character block.',
+  wi_before_char: 'World Info entries marked "before character".',
+  ext_before_char: 'Extension-injected context marked "before character".',
+  char_info_block: 'Description + personality + scenario + example dialogue.',
+  wi_after_char: 'World Info entries marked "after character".',
+  ext_after_char: 'Extension-injected context marked "after character".',
+  persona_after_char: 'Your persona description, when positioned after the character block.',
+  wi_before_an: 'World Info entries marked "before author note".',
+  ext_before_an: 'Extension-injected context marked "before author note".',
+  jailbreak: 'User-level jailbreak / auxiliary system prompt.',
+  emotion_instruction: 'Instructs the AI to prefix each reply with an [emotion:TAG] tag.',
+  rag_context: 'Semantic chunks retrieved from the Data Bank for the current message.',
+  char_phi: "Character card's post-history instructions (after chat history).",
+  user_phi: 'User-level post-history instructions (after chat history).',
+  wi_after_an: 'World Info entries marked "after author note" (after chat history).',
+  ext_after_an: 'Extension-injected context marked "after author note" (after chat history).',
+};
+
 interface GenerationState {
   sampler: SamplerParams;
   presets: GenerationPreset[];
@@ -95,6 +188,8 @@ interface GenerationState {
   prompt: PromptConfig;
   context: ContextConfig;
   instruct: InstructConfig;
+  /** Phase 9.1: user-editable prompt section order + enabled flags. */
+  promptOrder: PromptSectionEntry[];
 
   // Cached last-used token estimate for the UI badge
   lastTokenEstimate: number;
@@ -114,6 +209,11 @@ interface GenerationState {
 
   setInstruct: (instruct: Partial<InstructConfig>) => void;
 
+  setPromptOrder: (order: PromptSectionEntry[]) => void;
+  movePromptSection: (id: PromptSectionId, direction: 'up' | 'down') => void;
+  togglePromptSection: (id: PromptSectionId) => void;
+  resetPromptOrder: () => void;
+
   setLastTokenEstimate: (n: number) => void;
 }
 
@@ -126,6 +226,7 @@ interface PersistedShape {
   prompt: PromptConfig;
   context: ContextConfig;
   instruct: InstructConfig;
+  promptOrder?: PromptSectionEntry[];
 }
 
 function loadFromStorage(): Partial<PersistedShape> {
@@ -154,11 +255,41 @@ function persist(state: GenerationState) {
     prompt: state.prompt,
     context: state.context,
     instruct: state.instruct,
+    promptOrder: state.promptOrder,
   });
 }
 
 function generatePresetId(): string {
   return `preset_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/**
+ * Merge a persisted promptOrder with the default. Unknown/legacy IDs are
+ * dropped, and any sections that exist in the default but not in the persisted
+ * array are appended at the end with `enabled: true` (forward-compat).
+ */
+export function mergePromptOrder(
+  persisted: PromptSectionEntry[] | undefined
+): PromptSectionEntry[] {
+  if (!Array.isArray(persisted) || persisted.length === 0) {
+    return DEFAULT_PROMPT_ORDER.map((e) => ({ ...e }));
+  }
+  const knownIds = new Set<PromptSectionId>(DEFAULT_PROMPT_ORDER.map((e) => e.id));
+  const seen = new Set<PromptSectionId>();
+  const result: PromptSectionEntry[] = [];
+  for (const entry of persisted) {
+    if (!entry || typeof entry.id !== 'string') continue;
+    if (!knownIds.has(entry.id as PromptSectionId)) continue;
+    if (seen.has(entry.id as PromptSectionId)) continue;
+    seen.add(entry.id as PromptSectionId);
+    result.push({ id: entry.id as PromptSectionId, enabled: entry.enabled !== false });
+  }
+  for (const def of DEFAULT_PROMPT_ORDER) {
+    if (!seen.has(def.id)) {
+      result.push({ ...def });
+    }
+  }
+  return result;
 }
 
 const initial = loadFromStorage();
@@ -170,6 +301,7 @@ export const useGenerationStore = create<GenerationState>((set, get) => ({
   prompt: { ...DEFAULT_PROMPT_CONFIG, ...(initial.prompt ?? {}) },
   context: { ...DEFAULT_CONTEXT_CONFIG, ...(initial.context ?? {}) },
   instruct: { ...DEFAULT_INSTRUCT_CONFIG, ...(initial.instruct ?? {}) },
+  promptOrder: mergePromptOrder(initial.promptOrder),
   lastTokenEstimate: 0,
 
   setSampler: (patch) => {
@@ -281,6 +413,49 @@ export const useGenerationStore = create<GenerationState>((set, get) => ({
       const next = { ...state, instruct: { ...state.instruct, ...patch } };
       persist(next);
       return { instruct: next.instruct };
+    });
+  },
+
+  setPromptOrder: (order) => {
+    set((state) => {
+      const next = { ...state, promptOrder: mergePromptOrder(order) };
+      persist(next);
+      return { promptOrder: next.promptOrder };
+    });
+  },
+
+  movePromptSection: (id, direction) => {
+    set((state) => {
+      const idx = state.promptOrder.findIndex((e) => e.id === id);
+      if (idx < 0) return {};
+      const target = direction === 'up' ? idx - 1 : idx + 1;
+      if (target < 0 || target >= state.promptOrder.length) return {};
+      const nextOrder = state.promptOrder.slice();
+      const [moved] = nextOrder.splice(idx, 1);
+      nextOrder.splice(target, 0, moved);
+      const next = { ...state, promptOrder: nextOrder };
+      persist(next);
+      return { promptOrder: nextOrder };
+    });
+  },
+
+  togglePromptSection: (id) => {
+    set((state) => {
+      const nextOrder = state.promptOrder.map((e) =>
+        e.id === id ? { ...e, enabled: !e.enabled } : e
+      );
+      const next = { ...state, promptOrder: nextOrder };
+      persist(next);
+      return { promptOrder: nextOrder };
+    });
+  },
+
+  resetPromptOrder: () => {
+    set((state) => {
+      const nextOrder = DEFAULT_PROMPT_ORDER.map((e) => ({ ...e }));
+      const next = { ...state, promptOrder: nextOrder };
+      persist(next);
+      return { promptOrder: nextOrder };
     });
   },
 

--- a/src/stores/promptTemplateStore.ts
+++ b/src/stores/promptTemplateStore.ts
@@ -1,0 +1,219 @@
+import { create } from 'zustand';
+import {
+  useGenerationStore,
+  DEFAULT_PROMPT_CONFIG,
+  DEFAULT_CONTEXT_CONFIG,
+  DEFAULT_INSTRUCT_CONFIG,
+  DEFAULT_SAMPLER,
+  mergePromptOrder,
+  type PromptConfig,
+  type ContextConfig,
+  type InstructConfig,
+  type SamplerParams,
+  type PromptSectionEntry,
+} from './generationStore';
+
+/**
+ * Phase 9.2 — Prompt Templates & Presets.
+ *
+ * A PromptTemplate bundles an entire generation-side configuration so users
+ * can save, load, export, and share a full "persona setup" — not just
+ * samplers (which existing GenerationPreset already covers).
+ */
+export interface PromptTemplate {
+  id: string;
+  name: string;
+  prompt: PromptConfig;
+  context: ContextConfig;
+  instruct: InstructConfig;
+  promptOrder: PromptSectionEntry[];
+  /** Optional — only set when user opts in to "include samplers" on save. */
+  sampler?: SamplerParams;
+  createdAt: number;
+}
+
+interface PromptTemplateState {
+  templates: PromptTemplate[];
+  activeTemplateId: string | null;
+
+  saveTemplate: (name: string, includeSampler: boolean) => void;
+  loadTemplate: (id: string) => void;
+  deleteTemplate: (id: string) => void;
+  renameTemplate: (id: string, name: string) => void;
+  importTemplates: (json: string) => { imported: number; errors: number };
+  exportTemplates: () => string;
+  exportTemplate: (id: string) => string | null;
+}
+
+const STORAGE_KEY = 'stm:prompt-templates';
+
+interface PersistedShape {
+  templates: PromptTemplate[];
+  activeTemplateId: string | null;
+}
+
+function loadFromStorage(): PersistedShape {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { templates: [], activeTemplateId: null };
+    const parsed = JSON.parse(raw) as PersistedShape;
+    return {
+      templates: Array.isArray(parsed.templates) ? parsed.templates : [],
+      activeTemplateId:
+        typeof parsed.activeTemplateId === 'string' ? parsed.activeTemplateId : null,
+    };
+  } catch {
+    return { templates: [], activeTemplateId: null };
+  }
+}
+
+function saveToStorage(state: PersistedShape) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    // ignore quota errors
+  }
+}
+
+function generateId(): string {
+  return `tpl_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function coerceTemplate(raw: unknown): PromptTemplate | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const r = raw as Record<string, unknown>;
+  if (typeof r.name !== 'string' || !r.name.trim()) return null;
+  if (!r.prompt || typeof r.prompt !== 'object') return null;
+  const prompt = { ...DEFAULT_PROMPT_CONFIG, ...(r.prompt as Partial<PromptConfig>) };
+  const context = { ...DEFAULT_CONTEXT_CONFIG, ...((r.context as Partial<ContextConfig>) ?? {}) };
+  const instruct = {
+    ...DEFAULT_INSTRUCT_CONFIG,
+    ...((r.instruct as Partial<InstructConfig>) ?? {}),
+  };
+  const promptOrder = mergePromptOrder(
+    Array.isArray(r.promptOrder) ? (r.promptOrder as PromptSectionEntry[]) : undefined
+  );
+  const sampler =
+    r.sampler && typeof r.sampler === 'object'
+      ? { ...DEFAULT_SAMPLER, ...(r.sampler as Partial<SamplerParams>) }
+      : undefined;
+  return {
+    id: generateId(),
+    name: r.name.trim(),
+    prompt,
+    context,
+    instruct,
+    promptOrder,
+    sampler,
+    createdAt: Date.now(),
+  };
+}
+
+const initial = loadFromStorage();
+
+export const usePromptTemplateStore = create<PromptTemplateState>((set, get) => ({
+  templates: initial.templates,
+  activeTemplateId: initial.activeTemplateId,
+
+  saveTemplate: (name, includeSampler) => {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    const gen = useGenerationStore.getState();
+    const template: PromptTemplate = {
+      id: generateId(),
+      name: trimmed,
+      prompt: { ...gen.prompt },
+      context: { ...gen.context },
+      instruct: { ...gen.instruct },
+      promptOrder: gen.promptOrder.map((e) => ({ ...e })),
+      sampler: includeSampler ? { ...gen.sampler } : undefined,
+      createdAt: Date.now(),
+    };
+    const { templates } = get();
+    const nextTemplates = [...templates, template];
+    saveToStorage({ templates: nextTemplates, activeTemplateId: template.id });
+    set({ templates: nextTemplates, activeTemplateId: template.id });
+  },
+
+  loadTemplate: (id) => {
+    const { templates } = get();
+    const template = templates.find((t) => t.id === id);
+    if (!template) return;
+    const gen = useGenerationStore.getState();
+    gen.setPrompt(template.prompt);
+    gen.setContext(template.context);
+    gen.setInstruct(template.instruct);
+    gen.setPromptOrder(template.promptOrder);
+    if (template.sampler) {
+      gen.setSampler(template.sampler);
+    }
+    saveToStorage({ templates, activeTemplateId: template.id });
+    set({ activeTemplateId: template.id });
+  },
+
+  deleteTemplate: (id) => {
+    const { templates, activeTemplateId } = get();
+    const nextTemplates = templates.filter((t) => t.id !== id);
+    const nextActive = activeTemplateId === id ? null : activeTemplateId;
+    saveToStorage({ templates: nextTemplates, activeTemplateId: nextActive });
+    set({ templates: nextTemplates, activeTemplateId: nextActive });
+  },
+
+  renameTemplate: (id, name) => {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    const { templates, activeTemplateId } = get();
+    const nextTemplates = templates.map((t) =>
+      t.id === id ? { ...t, name: trimmed } : t
+    );
+    saveToStorage({ templates: nextTemplates, activeTemplateId });
+    set({ templates: nextTemplates });
+  },
+
+  importTemplates: (json) => {
+    let imported = 0;
+    let errors = 0;
+    try {
+      const parsed = JSON.parse(json);
+      const arr: unknown[] = Array.isArray(parsed)
+        ? parsed
+        : Array.isArray((parsed as { templates?: unknown[] })?.templates)
+          ? (parsed as { templates: unknown[] }).templates
+          : [];
+
+      if (arr.length === 0) return { imported: 0, errors: 0 };
+
+      const { templates, activeTemplateId } = get();
+      const newTemplates: PromptTemplate[] = [];
+      for (const raw of arr) {
+        const t = coerceTemplate(raw);
+        if (t) {
+          newTemplates.push(t);
+          imported++;
+        } else {
+          errors++;
+        }
+      }
+      if (newTemplates.length === 0) return { imported: 0, errors };
+
+      const nextTemplates = [...templates, ...newTemplates];
+      saveToStorage({ templates: nextTemplates, activeTemplateId });
+      set({ templates: nextTemplates });
+      return { imported, errors };
+    } catch {
+      return { imported: 0, errors: 1 };
+    }
+  },
+
+  exportTemplates: () => {
+    const { templates } = get();
+    return JSON.stringify({ version: 1, templates }, null, 2);
+  },
+
+  exportTemplate: (id) => {
+    const { templates } = get();
+    const t = templates.find((x) => x.id === id);
+    if (!t) return null;
+    return JSON.stringify({ version: 1, templates: [t] }, null, 2);
+  },
+}));

--- a/src/utils/macros.ts
+++ b/src/utils/macros.ts
@@ -1,5 +1,8 @@
 // Macro processor for prompt substitution
-// Supports core ST-style macros like {{char}}, {{user}}, {{time}}, {{random}}, etc.
+// Supports core ST-style macros ({{char}}, {{user}}, {{time}}, {{random}}, …)
+// plus Phase 9.3 extensions: {{if}}/{{else}}/{{/if}} conditionals,
+// {{getvar}}/{{setvar}}/{{addvar}}/{{incvar}}/{{decvar}} chat-scoped variables,
+// {{calc}} safe arithmetic, {{isMobile}}, {{mesExamples}}.
 
 export interface MacroContext {
   charName?: string;
@@ -9,11 +12,18 @@ export interface MacroContext {
   characterDescription?: string;
   characterPersonality?: string;
   characterScenario?: string;
+  characterExampleMessages?: string;
   lastMessage?: string;
   lastUserMessage?: string;
   lastCharMessage?: string;
   model?: string;
   maxPrompt?: number;
+  /**
+   * Phase 9.3: mutable map of chat-scoped variables. `setvar` mutates this
+   * map in place; the caller is responsible for persisting it back to storage
+   * after macro processing completes.
+   */
+  variables?: Record<string, string>;
   // Arbitrary additional values
   extra?: Record<string, string>;
 }
@@ -78,25 +88,242 @@ function splitArgs(raw: string): string[] {
   return [raw.trim()];
 }
 
-/**
- * Process macros in the given text using the supplied context.
- * Replaces {{macro}} and {{macro:args}} patterns.
- * Returns a new string; original is not mutated.
- */
-export function processMacros(text: string, ctx: MacroContext): string {
-  if (!text) return text;
+// ───────── Phase 9.3: Safe arithmetic evaluator ─────────
+//
+// Recursive-descent parser for the grammar:
+//   expression := term (('+' | '-') term)*
+//   term       := factor (('*' | '/' | '%') factor)*
+//   factor     := number | '(' expression ')' | ('-' | '+') factor
+//
+// No `eval`, no `Function`. Unknown characters return an empty string.
 
-  // Replace macros in a single pass using a regex with a callback.
-  // Pattern matches {{name}} and {{name:args}} (args may contain non-brace chars).
+class CalcParser {
+  readonly text: string;
+  pos = 0;
+  constructor(text: string) {
+    this.text = text;
+  }
+  peek(): string {
+    return this.text[this.pos] ?? '';
+  }
+  consume(ch: string): boolean {
+    if (this.peek() === ch) {
+      this.pos++;
+      return true;
+    }
+    return false;
+  }
+  parseExpression(): number {
+    let left = this.parseTerm();
+    while (this.pos < this.text.length) {
+      const op = this.peek();
+      if (op !== '+' && op !== '-') break;
+      this.pos++;
+      const right = this.parseTerm();
+      left = op === '+' ? left + right : left - right;
+    }
+    return left;
+  }
+  parseTerm(): number {
+    let left = this.parseFactor();
+    while (this.pos < this.text.length) {
+      const op = this.peek();
+      if (op !== '*' && op !== '/' && op !== '%') break;
+      this.pos++;
+      const right = this.parseFactor();
+      if (op === '*') left = left * right;
+      else if (op === '/') left = right === 0 ? 0 : left / right;
+      else left = right === 0 ? 0 : left % right;
+    }
+    return left;
+  }
+  parseFactor(): number {
+    if (this.consume('-')) return -this.parseFactor();
+    if (this.consume('+')) return this.parseFactor();
+    if (this.consume('(')) {
+      const v = this.parseExpression();
+      if (!this.consume(')')) throw new Error('unmatched paren');
+      return v;
+    }
+    const start = this.pos;
+    while (this.pos < this.text.length && /[\d.]/.test(this.text[this.pos])) {
+      this.pos++;
+    }
+    if (this.pos === start) throw new Error('expected number');
+    const num = Number(this.text.slice(start, this.pos));
+    if (Number.isNaN(num)) throw new Error('invalid number');
+    return num;
+  }
+}
+
+function evalCalc(expr: string): string {
+  const cleaned = expr.replace(/\s+/g, '');
+  if (!cleaned) return '';
+  if (!/^[-+*/%().\d]+$/.test(cleaned)) return '';
+  try {
+    const parser = new CalcParser(cleaned);
+    const result = parser.parseExpression();
+    if (parser.pos !== cleaned.length) return '';
+    if (!Number.isFinite(result)) return '';
+    return String(result);
+  } catch {
+    return '';
+  }
+}
+
+// ───────── Phase 9.3: Conditional block parser ─────────
+
+const IF_OPEN = '{{if::';
+const IF_CLOSE = '{{/if}}';
+const ELSE_TAG = '{{else}}';
+
+function numCompare(a: string, b: string, fn: (x: number, y: number) => boolean): boolean {
+  const x = Number(a);
+  const y = Number(b);
+  if (Number.isNaN(x) || Number.isNaN(y)) return false;
+  return fn(x, y);
+}
+
+/**
+ * Evaluate a condition string. Supports: contains, ==, !=, <=, >=, <, >.
+ * Operands are trimmed. Numeric operators parse both sides as numbers; if
+ * either fails to parse, the comparison is false. An operator-less condition
+ * is truthy iff the trimmed string is non-empty.
+ */
+function evaluateCondition(cond: string): boolean {
+  const trimmed = cond.trim();
+  if (!trimmed) return false;
+  const patterns: { re: RegExp; fn: (a: string, b: string) => boolean }[] = [
+    { re: /^(.*?)\s+contains\s+(.*)$/, fn: (a, b) => a.includes(b) },
+    { re: /^(.*?)==(.*)$/, fn: (a, b) => a === b },
+    { re: /^(.*?)!=(.*)$/, fn: (a, b) => a !== b },
+    { re: /^(.*?)<=(.*)$/, fn: (a, b) => numCompare(a, b, (x, y) => x <= y) },
+    { re: /^(.*?)>=(.*)$/, fn: (a, b) => numCompare(a, b, (x, y) => x >= y) },
+    { re: /^(.*?)<(.*)$/, fn: (a, b) => numCompare(a, b, (x, y) => x < y) },
+    { re: /^(.*?)>(.*)$/, fn: (a, b) => numCompare(a, b, (x, y) => x > y) },
+  ];
+  for (const { re, fn } of patterns) {
+    const m = trimmed.match(re);
+    if (m) return fn(m[1].trim(), m[2].trim());
+  }
+  return Boolean(trimmed);
+}
+
+/**
+ * Walk `text` looking for `{{if::…}}…{{/if}}` blocks and replace each with
+ * the selected branch. Nested `{{if::}}` blocks are tracked via a depth
+ * counter. The condition is itself run through `processInline` first so
+ * nested macros resolve before comparison.
+ */
+function processBlocks(text: string, ctx: MacroContext): string {
+  let result = '';
+  let i = 0;
+
+  while (i < text.length) {
+    const openIdx = text.indexOf(IF_OPEN, i);
+    if (openIdx === -1) {
+      result += text.slice(i);
+      break;
+    }
+    result += text.slice(i, openIdx);
+
+    // Find the `}}` that closes the {{if::...}} opener, tracking nested {{ }}.
+    const condStart = openIdx + IF_OPEN.length;
+    let condEnd = -1;
+    let braceDepth = 1;
+    let k = condStart;
+    while (k < text.length - 1) {
+      if (text[k] === '{' && text[k + 1] === '{') {
+        braceDepth++;
+        k += 2;
+      } else if (text[k] === '}' && text[k + 1] === '}') {
+        braceDepth--;
+        if (braceDepth === 0) {
+          condEnd = k;
+          break;
+        }
+        k += 2;
+      } else {
+        k++;
+      }
+    }
+    if (condEnd === -1) {
+      // Unclosed {{if}} — bail out and keep the rest of the text as-is.
+      result += text.slice(openIdx);
+      break;
+    }
+    const condition = text.slice(condStart, condEnd);
+    const bodyStart = condEnd + 2;
+
+    // Find the matching {{/if}} respecting nested {{if::...}} blocks.
+    // Track {{else}} at depth 1 (the block we're currently matching).
+    let depth = 1;
+    let bodyEnd = -1;
+    let elseIdx = -1;
+    let j = bodyStart;
+    while (j < text.length) {
+      if (text.startsWith(IF_OPEN, j)) {
+        depth++;
+        j += IF_OPEN.length;
+      } else if (text.startsWith(IF_CLOSE, j)) {
+        depth--;
+        if (depth === 0) {
+          bodyEnd = j;
+          break;
+        }
+        j += IF_CLOSE.length;
+      } else if (depth === 1 && text.startsWith(ELSE_TAG, j)) {
+        if (elseIdx === -1) elseIdx = j;
+        j += ELSE_TAG.length;
+      } else {
+        j++;
+      }
+    }
+    if (bodyEnd === -1) {
+      result += text.slice(openIdx);
+      break;
+    }
+
+    const thenBranch =
+      elseIdx !== -1 ? text.slice(bodyStart, elseIdx) : text.slice(bodyStart, bodyEnd);
+    const elseBranch =
+      elseIdx !== -1 ? text.slice(elseIdx + ELSE_TAG.length, bodyEnd) : '';
+
+    // Resolve macros inside the condition so e.g. `{{getvar::x}}==5` works.
+    const resolvedCond = processInline(condition, ctx);
+    const taken = evaluateCondition(resolvedCond) ? thenBranch : elseBranch;
+    result += taken;
+
+    i = bodyEnd + IF_CLOSE.length;
+  }
+
+  return result;
+}
+
+// ───────── Inline (single-brace) substitution ─────────
+
+/**
+ * Single-pass replacement of `{{name}}` / `{{name:args}}` / `{{name::args}}`.
+ * The regex excludes braces inside the match, so inside-out processing falls
+ * out naturally: innermost macros (which have no nested braces) get resolved
+ * first, the next iteration of the outer loop sees the updated text.
+ */
+function processInline(text: string, ctx: MacroContext): string {
+  if (!text) return text;
   return text.replace(/\{\{([^{}]+?)\}\}/g, (match, inner: string) => {
     const trimmed = inner.trim();
     if (!trimmed) return match;
 
-    // Split on first ':' for name:args form
-    const colonIdx = trimmed.indexOf(':');
+    // Split on first `::` (Phase 9.3 macros) or fall back to `:` (legacy).
+    let sepIdx = trimmed.indexOf('::');
+    let sepLen = 2;
+    if (sepIdx < 0) {
+      sepIdx = trimmed.indexOf(':');
+      sepLen = 1;
+    }
     const name =
-      colonIdx >= 0 ? trimmed.slice(0, colonIdx).trim().toLowerCase() : trimmed.toLowerCase();
-    const args = colonIdx >= 0 ? trimmed.slice(colonIdx + 1) : '';
+      sepIdx >= 0 ? trimmed.slice(0, sepIdx).trim().toLowerCase() : trimmed.toLowerCase();
+    const args = sepIdx >= 0 ? trimmed.slice(sepIdx + sepLen) : '';
 
     switch (name) {
       case 'char':
@@ -112,6 +339,10 @@ export function processMacros(text: string, ctx: MacroContext): string {
         return ctx.characterPersonality || '';
       case 'scenario':
         return ctx.characterScenario || '';
+      case 'mesexamples':
+      case 'mes_examples':
+      case 'mesexample':
+        return ctx.characterExampleMessages || '';
       case 'lastmessage':
       case 'last_message':
         return ctx.lastMessage || '';
@@ -126,6 +357,9 @@ export function processMacros(text: string, ctx: MacroContext): string {
       case 'maxprompt':
       case 'max_prompt':
         return ctx.maxPrompt ? String(ctx.maxPrompt) : '';
+      case 'ismobile':
+      case 'is_mobile':
+        return 'true';
       case 'time':
         return getTimeString();
       case 'date':
@@ -142,18 +376,15 @@ export function processMacros(text: string, ctx: MacroContext): string {
       case 'datetime':
         return new Date().toLocaleString();
       case 'random': {
-        // {{random:a,b,c}} => pick one; {{random}} => 0..1 number
         if (!args) return String(Math.random());
         const options = splitArgs(args);
         return pickRandom(options) ?? '';
       }
       case 'pick': {
-        // {{pick:a,b,c}} => stable pick (seeded by text hash) - fallback to random
         if (!args) return '';
         return pickRandom(splitArgs(args)) ?? '';
       }
       case 'roll': {
-        // {{roll:d6}} => 1..6
         if (!args) return '';
         const m = args.match(/d(\d+)/i);
         if (!m) return '';
@@ -167,15 +398,82 @@ export function processMacros(text: string, ctx: MacroContext): string {
       case 'comment':
         return '';
       case 'extra': {
-        // {{extra:key}} from extra map
         if (!args || !ctx.extra) return '';
         return ctx.extra[args.trim()] || '';
       }
+
+      // ───── Phase 9.3: Variables ─────
+      case 'getvar': {
+        const key = args.trim();
+        if (!key) return '';
+        return ctx.variables?.[key] ?? '';
+      }
+      case 'setvar': {
+        const parts = args.split('::');
+        if (parts.length < 2) return '';
+        const key = parts[0].trim();
+        if (!key) return '';
+        const value = parts.slice(1).join('::');
+        if (ctx.variables) ctx.variables[key] = value;
+        return '';
+      }
+      case 'addvar': {
+        const parts = args.split('::');
+        if (parts.length < 2) return '';
+        const key = parts[0].trim();
+        if (!key) return '';
+        const delta = Number(parts.slice(1).join('::'));
+        if (Number.isNaN(delta)) return '';
+        const current = Number(ctx.variables?.[key] ?? 0);
+        const base = Number.isFinite(current) ? current : 0;
+        const next = String(base + delta);
+        if (ctx.variables) ctx.variables[key] = next;
+        return '';
+      }
+      case 'incvar':
+      case 'decvar': {
+        const key = args.trim();
+        if (!key) return '';
+        const current = Number(ctx.variables?.[key] ?? 0);
+        const base = Number.isFinite(current) ? current : 0;
+        const next = String(base + (name === 'incvar' ? 1 : -1));
+        if (ctx.variables) ctx.variables[key] = next;
+        return next;
+      }
+
+      // ───── Phase 9.3: Math ─────
+      case 'calc': {
+        if (!args) return '';
+        return evalCalc(args);
+      }
+
       default:
-        // Unknown macro – leave original text
+        // Unknown macro – leave original text so it's visible for debugging.
         return match;
     }
   });
+}
+
+/**
+ * Process macros in the given text using the supplied context.
+ *
+ * Runs block (`{{if}}`) and inline passes in a loop until the text stabilizes,
+ * capped at 5 iterations so a pathological input can't spin forever. This lets
+ * nested macros like `{{calc::{{getvar::x}}*2}}` resolve inside-out.
+ *
+ * Returns a new string; the original is not mutated. `ctx.variables`, if
+ * provided, IS mutated in place — the caller is responsible for persisting.
+ */
+export function processMacros(text: string, ctx: MacroContext): string {
+  if (!text) return text;
+  let current = text;
+  for (let i = 0; i < 5; i++) {
+    const afterBlocks = processBlocks(current, ctx);
+    const afterInline = processInline(afterBlocks, ctx);
+    if (afterInline === current) break;
+    current = afterInline;
+  }
+  return current;
 }
 
 /**


### PR DESCRIPTION
## Summary

Phase 9 of the [ROADMAP](ROADMAP.md) — gives users control over how prompts are built, saved, and composed with dynamic logic. All three sub-phases shipped in one PR.

### 9.1 Prompt Manager
`buildConversationContext` in `src/stores/chatStore.ts` refactored from a hard-coded push sequence into a `sectionContent` keyed map iterated per a user-editable `promptOrder`. 17 reorderable sections with enable toggles. New **Order** tab in Generation Settings with arrow-button reordering (no DnD library). Default order matches the previous hard-coded order, so existing users see zero behavior change. At-depth sections (author's note, depth prompts, WI at-depth) intentionally stay in the depth-interleaving loop — they're semantically tied to message depth, not linear order. Group chat (`buildGroupConversationContext`) is out of scope.

### 9.2 Prompt Templates & Presets
New `promptTemplateStore` + `PromptTemplatesPage` at `/settings/prompts`. Captures the full generation-store snapshot: `prompt` + `context` + `instruct` + `promptOrder`, with samplers optional. JSON import/export follows the regex-script pattern with validation and ID regeneration on import.

### 9.3 Full Macro System
`src/utils/macros.ts` rewritten with:
- **Variables (chat-scoped):** `{{getvar::name}}`, `{{setvar::name::value}}`, `{{addvar::name::delta}}`, `{{incvar::name}}`, `{{decvar::name}}`
- **Conditionals:** `{{if::cond}}…{{/if}}` and `{{if::cond}}…{{else}}…{{/if}}` with operators `contains`, `==`, `!=`, `<=`, `>=`, `<`, `>`. Nesting-aware block parser; conditions are recursively macro-expanded before evaluation
- **Math:** `{{calc::expr}}` via a safe recursive-descent parser (`+ - * / % ( ) .`) — no `eval` or `Function`
- `{{isMobile}}` → `true`, `{{mesExamples}}` → character's example dialogue
- **Loop-until-stable runner** (max 5 iterations) handles nested macros like `{{calc::{{getvar::x}}*2}}` inside-out
- Separator handling accepts both `:` and `::`

Variables persist per chat file via a new `chatVariables` state on `chatStore` (localStorage key `stm:chat-vars`), mirroring the author's-note pattern. `buildConversationContext` clones the chat's variables into a mutable map, passes it to macros (which mutate in place via `{{setvar}}`), and flushes the result back to the store after building the full prompt.

## Test plan

- [x] `npx tsc -b` — clean
- [x] `npm run build` (tsc + vite) — clean, 907 kB bundle
- [x] `eslint` on all modified files — clean
- [ ] Manual: Settings → Generation → Order tab. Verify 17 sections appear, all enabled by default. Reorder `jailbreak` above `char_info_block`, disable `emotion_instruction`, send a message, verify the final prompt reflects the change
- [ ] Manual: Reset to defaults, verify order restored. Reload page, verify `promptOrder` persisted
- [ ] Manual: Settings → Prompt Templates. Save a template, tweak settings, load it back, verify values revert. Save one with "include samplers" checked, repeat
- [ ] Manual: Export all templates → download JSON → clear localStorage → reimport → verify round-trip
- [ ] Manual macro test — put this in a character description:
  ```
  {{setvar::count::0}}{{if::{{getvar::count}}==0}}First meeting.{{else}}Meeting number {{getvar::count}}.{{/if}} Math: {{calc::2+3*4}}. Mobile: {{isMobile}}.
  ```
  Verify the `{{if}}` block resolves to `First meeting.`, `{{calc::2+3*4}}` → `14`, `{{isMobile}}` → `true`. Then manually edit `localStorage['stm:chat-vars']` to bump count to 1, send another message, verify the else-branch fires
- [ ] Manual: verify default chat (no edits) produces byte-identical prompt vs pre-PR via `console.log` in `buildConversationContext`
- [ ] Manual: verify group chat still works (separate code path, should be unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)