### PR TITLE
fix: vibrant cyberpunk rainbow borders + dark user bubbles

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -288,42 +288,35 @@ body {
 
 /*
  * Cards and sections — rainbow border via the .cyberpunk-card class.
- * Technique: transparent border + two backgrounds:
- *   1) solid dark fill clipped to padding-box
- *   2) animated conic-gradient clipped to border-box (shows through the border)
+ * Technique: transparent border + two background layers:
+ *   1) solid dark fill, clipped to padding-box
+ *   2) animated conic-gradient, clipped to border-box (shows through the border)
+ *
+ * CRITICAL: the solid fill MUST be wrapped in `linear-gradient(c, c)` —
+ * a bare `<color>` is only valid as the shorthand background-color, which in
+ * multi-layer declarations only applies to the FINAL layer. Using a plain
+ * color in the first layer makes the entire shorthand invalid and the browser
+ * silently drops it, leaving the card transparent.
  */
 [data-theme="cyberpunk"] .cyberpunk-card {
-  border: 1px solid transparent;
+  border: 2px solid transparent;
   background:
-    var(--color-bg-secondary) padding-box,
-    conic-gradient(
-      from var(--rainbow-angle, 0deg),
-      rgba(139, 92, 246, 0.5),
-      rgba(59, 130, 246, 0.5),
-      rgba(34, 197, 94, 0.5),
-      rgba(245, 158, 11, 0.5),
-      rgba(239, 68, 68, 0.5),
-      rgba(224, 64, 251, 0.5),
-      rgba(139, 92, 246, 0.5)
-    ) border-box;
-  animation: rainbow-spin 8s linear infinite;
-  box-shadow: 0 0 12px -3px rgba(139, 92, 246, 0.15),
-              0 0 12px -3px rgba(59, 130, 246, 0.15),
-              0 0 12px -3px rgba(34, 197, 94, 0.15);
-  transition: box-shadow 0.3s;
-}
-
-[data-theme="cyberpunk"] .cyberpunk-card:hover {
-  border-color: transparent;
-  background:
-    var(--color-bg-secondary) padding-box,
+    linear-gradient(var(--color-bg-secondary), var(--color-bg-secondary)) padding-box,
     conic-gradient(
       from var(--rainbow-angle, 0deg),
       #8b5cf6, #3b82f6, #22c55e, #f59e0b, #ef4444, #e040fb, #8b5cf6
     ) border-box;
-  box-shadow: 0 0 16px -2px rgba(139, 92, 246, 0.25),
-              0 0 16px -2px rgba(59, 130, 246, 0.25),
-              0 0 16px -2px rgba(34, 197, 94, 0.25);
+  animation: rainbow-spin 8s linear infinite;
+  box-shadow: 0 0 16px -3px rgba(139, 92, 246, 0.35),
+              0 0 16px -3px rgba(59, 130, 246, 0.3),
+              0 0 16px -3px rgba(224, 64, 251, 0.3);
+  transition: box-shadow 0.3s;
+}
+
+[data-theme="cyberpunk"] .cyberpunk-card:hover {
+  box-shadow: 0 0 24px -2px rgba(139, 92, 246, 0.55),
+              0 0 24px -2px rgba(59, 130, 246, 0.45),
+              0 0 24px -2px rgba(224, 64, 251, 0.45);
 }
 
 /* Toggle switches — neon glow when active */
@@ -370,18 +363,24 @@ body {
               0 0 8px -2px rgba(59, 130, 246, 0.2);
 }
 
-/* User chat bubbles — dark bg with animated rainbow border + glow */
+/*
+ * User chat bubbles — dark fill + animated rainbow border + vibrant glow.
+ * Same `linear-gradient(color, color)` wrapper as .cyberpunk-card above;
+ * without it the background shorthand is invalid and the bubble renders
+ * transparent, letting the Tailwind `bg-[var(--color-primary)]` show through
+ * (or, when the override wins, nothing at all).
+ */
 [data-theme="cyberpunk"] .cyberpunk-user-bubble {
   background:
-    var(--color-bg-tertiary) padding-box,
+    linear-gradient(var(--color-bg-tertiary), var(--color-bg-tertiary)) padding-box,
     conic-gradient(
       from var(--rainbow-angle, 0deg),
       #8b5cf6, #3b82f6, #22c55e, #f59e0b, #ef4444, #e040fb, #8b5cf6
     ) border-box !important;
   color: var(--color-text-primary) !important;
-  border: 1.5px solid transparent !important;
+  border: 2px solid transparent !important;
   animation: rainbow-spin 8s linear infinite;
-  box-shadow: 0 0 10px -2px rgba(139, 92, 246, 0.25),
-              0 0 10px -2px rgba(59, 130, 246, 0.2),
-              0 0 10px -2px rgba(224, 64, 251, 0.2);
+  box-shadow: 0 0 14px -2px rgba(139, 92, 246, 0.5),
+              0 0 14px -2px rgba(59, 130, 246, 0.4),
+              0 0 14px -2px rgba(224, 64, 251, 0.45);
 }


### PR DESCRIPTION
## Summary

- Fixes transparent user chat bubbles and subdued rainbow borders in the cyberpunk theme
- Replaces the invalid `background: <color> padding-box, ...` shorthand with the canonical `linear-gradient(color, color)` wrapper so the two-layer declaration actually parses
- Restores full-opacity gradient colors and thicker borders to bring back the vibrancy of the original cyberpunk theme (pre-PR #54)

## Root cause

The previous CSS in `src/index.css` used this shorthand for cards and user bubbles:

```css
background:
  var(--color-bg-tertiary) padding-box,
  conic-gradient(...) border-box;
```

A bare `<color>` is only a valid `background-color`, and in a multi-layer shorthand `background-color` applies only to the **final** layer. Placing the color in a non-final layer makes the entire declaration invalid — the browser silently drops it, leaving `backgroundImage: none` and `backgroundColor: transparent`. For cards this just meant no rainbow border showed. For user bubbles, the `!important` on the invalid declaration also killed the Tailwind `bg-[var(--color-primary)]` fallback, which is why they rendered fully transparent.

Verified in-browser:

```js
// Before fix
getComputedStyle(testEl)
// => { backgroundImage: "none", backgroundColor: "rgba(0, 0, 0, 0)", backgroundClip: "border-box" }

// After fix
// => { backgroundImage: "linear-gradient(...), conic-gradient(...)", backgroundClip: "padding-box, border-box" }
```

## The fix

Wrap the solid fill layer in a single-stop `linear-gradient`:

```css
background:
  linear-gradient(var(--color-bg-tertiary), var(--color-bg-tertiary)) padding-box,
  conic-gradient(from var(--rainbow-angle, 0deg), #8b5cf6, ...) border-box;
```

A single-stop gradient is a valid `<image>`, so it works in any background-layer position. This is the canonical cross-browser "gradient border" technique and works in every browser that supports `background-clip: padding-box` (Chrome 1+, Firefox 4+, Safari 5+). No vendor prefixes, no `mask-composite`, no production-build fragility.

## Also vibrant-ified

- Gradient colors back to full opacity (were `rgba(..., 0.5)` for cards)
- Card border thickened from 1px → 2px
- User bubble border thickened from 1.5px → 2px
- Glow shadow alpha bumped from ~0.15-0.25 → 0.3-0.5
- Card hover simplified to just brightening the shadow (no redundant background swap)

## Test plan

- [x] Verified in live dev preview at `/settings` — 19 cards render with a vibrant rainbow border spinning on an 8s loop
- [x] Verified in live dev preview at `/` (active chat) — 15 user bubbles render with a dark `--color-bg-tertiary` fill, 2px rainbow border, and neon glow
- [x] Inspected computed styles — `backgroundClip: "padding-box, border-box"`, both layers present in `backgroundImage`
- [x] No console errors after HMR reload
- [ ] Manual: verify in Firefox (animation requires `@property` / registered custom property — Firefox 128+. Older Firefox should show a static but still vibrant rainbow border)
- [ ] Manual: verify in production build (`npm run build && npm run preview`) — this is the fragility that bit PR #54
- [ ] Manual: switch away from and back to cyberpunk theme; verify cards/bubbles reset correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)