### PR TITLE
feat: Phase 8.5 — finish Data Bank / RAG

### DIFF
--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -575,7 +575,10 @@ function buildMacroContext(
  * Phase 8.5 — RAG helper.
  * Extracts the last user message from `messages`, queries the Data Bank for
  * relevant chunks scoped to `characterAvatar`, and returns a formatted string
- * to inject into the system prompt. Returns null when RAG is inactive.
+ * to inject into the system prompt. Each chunk is prefixed with its source
+ * document name (e.g. `[From: ember_lore]`) so the model can cite passages
+ * and users can debug which document a chunk came from. Returns null when
+ * no relevant chunks are found or RAG is inactive.
  */
 async function resolveRagContext(
   messages: ChatMessage[],
@@ -589,7 +592,9 @@ async function resolveRagContext(
     .queryRelevantChunks(lastUser.content, characterAvatar);
 
   if (chunks.length === 0) return null;
-  return chunks.join('\n\n---\n\n');
+  return chunks
+    .map((c) => `[From: ${c.docName}]\n${c.text}`)
+    .join('\n\n---\n\n');
 }
 
 // Build conversation context for AI
@@ -1003,7 +1008,8 @@ function buildGroupConversationContext(
   messages: ChatMessage[],
   characters: CharacterInfo[],
   currentCharacter: CharacterInfo,
-  scenarioOverride?: string
+  scenarioOverride?: string,
+  ragContext?: string
 ): { role: 'user' | 'assistant' | 'system'; content: string }[] {
   const context: { role: 'user' | 'assistant' | 'system'; content: string }[] = [];
 
@@ -1065,7 +1071,15 @@ CONTENT RULES:
 - Stay in character as ${currentCharacter.name} only — do NOT write lines for other characters
 - React naturally to what other characters and the user say`;
 
-  context.push({ role: 'system', content: systemPrompt });
+  // Phase 8.5: append Data Bank / RAG context to the system prompt. Group
+  // chats use a single flat system message (vs. the section-map in solo
+  // chat), so we just concatenate the retrieved chunks at the tail rather
+  // than forking the Phase 9 promptOrder system.
+  const finalSystemPrompt = ragContext
+    ? `${systemPrompt}\n\n[Relevant background information]\n${ragContext}`
+    : systemPrompt;
+
+  context.push({ role: 'system', content: finalSystemPrompt });
 
   // Phase 8.1: Author's Note for group chats
   const { currentChatFile: groupChatFile } = useChatStore.getState();
@@ -1128,11 +1142,16 @@ async function generateGroupTurn(
 
   const { provider, model } = getProviderAndModel();
   const updatedMessages = get().messages;
+  // Phase 8.5: resolve Data Bank / RAG chunks scoped to the current speaker.
+  // In a group turn this means Seraphina's character-scoped docs only fire
+  // on Seraphina's turn, which matches how solo chats scope per-character.
+  const ragCtx = await resolveRagContext(updatedMessages, character.avatar || '');
   const context = buildGroupConversationContext(
     updatedMessages,
     characters,
     character,
-    scenarioOverride
+    scenarioOverride,
+    ragCtx ?? undefined
   );
 
   const finalContext = maybeApplyInstructMode(context);

--- a/src/stores/dataBankStore.ts
+++ b/src/stores/dataBankStore.ts
@@ -77,15 +77,17 @@ interface DataBankState {
    * Find the top-K most relevant chunks for `query` across all in-scope
    * documents (global + those matching `characterAvatar`).
    *
-   * Returns an array of chunk texts sorted by relevance, or [] if no
-   * embedded documents are in scope or the API call fails.
-   * Falls back to `embeddingsApiKey` from the store if `apiKey` is omitted.
+   * Returns an array of {text, docName} objects sorted by relevance, or [] if
+   * no embedded documents are in scope or the API call fails. Each result
+   * carries its parent document's name so callers can attribute the source
+   * when injecting into a prompt. Falls back to `embeddingsApiKey` from the
+   * store if `apiKey` is omitted.
    */
   queryRelevantChunks: (
     query: string,
     characterAvatar?: string,
     topK?: number
-  ) => Promise<string[]>;
+  ) => Promise<Array<{ text: string; docName: string }>>;
 }
 
 // ---------------------------------------------------------------------------
@@ -216,14 +218,20 @@ export const useDataBankStore = create<DataBankState>((set, get) => ({
 
     if (inScope.length === 0) return [];
 
-    const allChunks = inScope.flatMap((d) => d.chunks);
+    // Attach docName from the parent document at flatten time so retrieval
+    // results can be attributed back to their source for provenance.
+    const allChunks = inScope.flatMap((d) =>
+      d.chunks.map((c) => ({ ...c, docName: d.name }))
+    );
     if (allChunks.length === 0) return [];
 
     try {
       const queryEmbedding = await getEmbedding(query, key);
       const results = findTopK(queryEmbedding, allChunks, topK);
       // Only return chunks with at least weak relevance (score > 0.3)
-      return results.filter((r) => r.score > 0.3).map((r) => r.text);
+      return results
+        .filter((r) => r.score > 0.3)
+        .map((r) => ({ text: r.text, docName: r.docName }));
     } catch {
       // Fail silently so generation still proceeds without RAG
       return [];

--- a/src/utils/embeddings.ts
+++ b/src/utils/embeddings.ts
@@ -58,20 +58,28 @@ export function cosineSimilarity(a: number[], b: number[]): number {
 export interface ScoredChunk {
   text: string;
   score: number;
+  /** Name of the parent document — carried through for source provenance in injected chunks. */
+  docName: string;
 }
 
 /**
  * Find the top-K most similar chunks to `queryEmbedding`.
- * Only considers chunks that already have an embedding.
+ * Only considers chunks that already have an embedding. The caller must
+ * attach a `docName` to each input chunk (usually the parent document's name)
+ * so the result carries source provenance back to the caller.
  */
 export function findTopK(
   queryEmbedding: number[],
-  chunks: { text: string; embedding: number[] }[],
+  chunks: { text: string; embedding: number[]; docName: string }[],
   k: number
 ): ScoredChunk[] {
   return chunks
     .filter((c) => c.embedding.length > 0)
-    .map((c) => ({ text: c.text, score: cosineSimilarity(queryEmbedding, c.embedding) }))
+    .map((c) => ({
+      text: c.text,
+      docName: c.docName,
+      score: cosineSimilarity(queryEmbedding, c.embedding),
+    }))
     .sort((a, b) => b.score - a.score)
     .slice(0, k);
 }


### PR DESCRIPTION
## Summary

Finishes the Phase 8.5 Data Bank / RAG stub. The core pipeline (chunking, embedding, cosine similarity retrieval, upload UI) was already working for solo chats — this PR closes two gaps and runs the first end-to-end smoke test.

### Gap 1: Group chat silently skipped RAG

`buildGroupConversationContext` never accepted a `ragContext` parameter and its caller `generateGroupTurn` never called `resolveRagContext` — so group chat users got zero Data Bank retrieval while the feature appeared to work.

**Fix:** `buildGroupConversationContext` accepts an optional `ragContext` and appends it to the single flat system prompt (group chats use one big system message, not the Phase 9 section-map, so no `promptOrder` fork is needed). `generateGroupTurn` calls `resolveRagContext` scoped to the **current speaker's** avatar — so Seraphina's character-scoped docs only fire on Seraphina's turn, matching how solo chat scopes per-character.

### Gap 2: No source provenance on injected chunks

`resolveRagContext` was joining retrieved chunks with `\n\n---\n\n` and the model saw anonymous blobs. Users couldn't debug which document a passage came from, and the model couldn't cite sources.

**Fix:** `ScoredChunk` (in `embeddings.ts`) gains a `docName` field threaded through `findTopK`'s input/output. `queryRelevantChunks` attaches `docName` from the parent document at flatten time — **no on-disk schema change**: `DocumentChunk` stays `{id, text, embedding}` and the doc name is joined at query time from the parent `DataBankDocument.name`. `resolveRagContext` formats each chunk with `[From: docname]\n${text}`.

## Files changed

| File | Change |
|---|---|
| `src/utils/embeddings.ts` | `ScoredChunk` adds `docName`; `findTopK` threads it through input/output |
| `src/stores/dataBankStore.ts` | `queryRelevantChunks` returns `Array<{text, docName}>`; attaches `docName` from parent doc at flatten time |
| `src/stores/chatStore.ts` | (a) `resolveRagContext` formats with `[From: ...]` prefix; (b) `buildGroupConversationContext` accepts+appends `ragContext`; (c) `generateGroupTurn` calls `resolveRagContext` and threads it through |

## Test plan

- [x] `npx tsc -b` — clean
- [x] `npm run build` — clean (tsc + vite, 908 kB bundle)
- [x] `eslint` on all three files — clean
- [x] End-to-end smoke test in live dev preview, stubbing the OpenAI embeddings endpoint with a constant unit vector (`[1/sqrt(1536); 1536]`) so every query matches:
  - [x] Seeded a global `ember_lore` doc + a character-scoped `seraphina_only_lore` doc
  - [x] **Global scope query**: returns only `ember_lore` ✓
  - [x] **Character scope match** (`seraphina.png`): returns both `ember_lore` + `seraphina_only_lore` ✓
  - [x] **Character scope miss** (`doctor.png`): returns only `ember_lore` (seraphina-scoped doc correctly excluded) ✓
  - [x] Verified `resolveRagContext` output format: `[From: ember_lore]\nThe secret password for Ember's vault is CYBERPUNK42. …` ✓
- [x] Grepped production bundle for wiring:
  - `[From: ` appears 1 time (in `resolveRagContext`)
  - `Relevant background information` appears 2 times (in `buildConversationContext` section map AND in `buildGroupConversationContext`'s new finalSystemPrompt)
- [x] Test data + API key cleaned from localStorage before committing
- [ ] Manual: verify with a real OpenAI API key that the full pipeline works end-to-end in both solo and group chats
- [ ] Manual: verify group chat token budget with a large Data Bank doc (known limitation — group chat has no token-aware trimming)

## Known limitations (out of scope — tracked as follow-ups)

- Group chat has no token-aware history trimming (uses `.slice(-30)`), so a very large RAG injection + long history could push shorter-context models over budget
- `queryRelevantChunks` fails silently on API errors (existing behavior preserved)
- No batch embedding optimization — `embedDocument` still makes one API call per chunk in parallel
- No multi-character document linking (a doc can only be global or tied to one character)
- No re-embed on document edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)