### PR TITLE
feat: Phase 10.1 — local model support (frontend UX)

### DIFF
--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -49,6 +49,83 @@ import { TRANSLATE_PROVIDERS, TRANSLATE_LANGUAGES, type TranslateProvider } from
 import { useConnectionProfileStore } from '../../stores/connectionProfileStore';
 import { useGenerationStore } from '../../stores/generationStore';
 
+/**
+ * Phase 10.1 — Local model presets.
+ * One-click buttons that pre-fill the custom endpoint URL (and, for Ollama
+ * only, a default model name) for the five most common local OpenAI-compatible
+ * servers. All five serve the OpenAI `/v1` base; users just need to know the
+ * right host + port, which this table encodes.
+ */
+interface LocalPreset {
+  name: string;
+  url: string;
+  defaultModel?: string;
+}
+
+const LOCAL_PRESETS: LocalPreset[] = [
+  { name: 'Ollama', url: 'http://localhost:11434/v1', defaultModel: 'llama3' },
+  { name: 'LM Studio', url: 'http://localhost:1234/v1' },
+  { name: 'llama.cpp', url: 'http://localhost:8080/v1' },
+  { name: 'KoboldCpp', url: 'http://localhost:5001/v1' },
+  { name: 'Oobabooga', url: 'http://localhost:5000/v1' },
+];
+
+/**
+ * Phase 10.1 — Test a custom OpenAI-compatible endpoint from the browser.
+ *
+ * Fetches `${url}/models` directly (no backend proxy — local endpoints are
+ * reachable from the browser since they're on localhost). On success returns
+ * the list of model IDs so the UI can turn the model field into a dropdown.
+ * On failure returns a human-readable error message with specific hints for
+ * the most common misconfigurations (missing `/v1`, CORS, server not running).
+ */
+async function testLocalEndpoint(
+  url: string
+): Promise<{ ok: true; models: string[] } | { ok: false; error: string }> {
+  const normalized = url.replace(/\/+$/, '');
+  try {
+    const res = await fetch(`${normalized}/models`, {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+    });
+    if (!res.ok) {
+      if (res.status === 404) {
+        return {
+          ok: false,
+          error: "Endpoint returned 404. Did you include '/v1' at the end of the URL?",
+        };
+      }
+      return { ok: false, error: `Endpoint returned HTTP ${res.status}` };
+    }
+    const data = (await res.json().catch(() => null)) as
+      | { data?: Array<{ id?: string }> }
+      | null;
+    const models = Array.isArray(data?.data)
+      ? data.data
+          .map((m) => m.id)
+          .filter((x): x is string => typeof x === 'string')
+      : [];
+    return { ok: true, models };
+  } catch (e) {
+    // Browser fetch throws TypeError for both network failures and CORS
+    // blocks (the response is opaque, so we can't distinguish them). Point
+    // the user at both possibilities in one message.
+    const msg = e instanceof Error ? e.message : String(e);
+    return {
+      ok: false,
+      error:
+        `Couldn't reach the endpoint (${msg}). Is your local server running? ` +
+        'CORS may also block browser access — see help below.',
+    };
+  }
+}
+
+type TestState =
+  | { kind: 'idle' }
+  | { kind: 'pending' }
+  | { kind: 'success'; count: number }
+  | { kind: 'error'; message: string };
+
 export function SettingsPage() {
   const navigate = useNavigate();
   const {
@@ -84,6 +161,9 @@ export function SettingsPage() {
   // Custom endpoint fields — kept as local state and only persisted on Save/blur.
   const [customUrlInput, setCustomUrlInput] = useState('');
   const [customModelInput, setCustomModelInput] = useState('');
+  // Phase 10.1: test-connection state and model-list discovery.
+  const [testState, setTestState] = useState<TestState>({ kind: 'idle' });
+  const [discoveredModels, setDiscoveredModels] = useState<string[]>([]);
   const [speechLang, setSpeechLangState] = useState<string>(() => getSpeechLanguage());
   const { isSupported: isSpeechSupported } = useSpeechRecognition();
 
@@ -127,6 +207,13 @@ export function SettingsPage() {
   // Sync local custom-endpoint inputs from store after fetchSettings resolves.
   useEffect(() => { setCustomUrlInput(customUrl); }, [customUrl]);
   useEffect(() => { setCustomModelInput(activeModel); }, [activeModel]);
+
+  // Phase 10.1: reset test-connection state whenever the URL input changes so
+  // a stale "success" badge doesn't linger after the user edits the URL.
+  useEffect(() => {
+    setTestState({ kind: 'idle' });
+    setDiscoveredModels([]);
+  }, [customUrlInput]);
 
   const handleSaveApiKey = async (providerId: string) => {
     const key = apiKeyInputs[providerId];
@@ -253,6 +340,33 @@ export function SettingsPage() {
                   </h2>
                 </div>
 
+                {/* Phase 10.1: one-click presets for the common local runners. */}
+                <div>
+                  <label className="block text-xs text-[var(--color-text-secondary)] mb-1.5">
+                    Quick presets
+                  </label>
+                  <div className="flex flex-wrap gap-1.5">
+                    {LOCAL_PRESETS.map((preset) => (
+                      <button
+                        key={preset.name}
+                        type="button"
+                        onClick={() => {
+                          setCustomUrlInput(preset.url);
+                          // Only pre-fill the model if a default exists AND the
+                          // current model field is empty — don't clobber a user
+                          // who already picked their own model name.
+                          if (preset.defaultModel && !customModelInput.trim()) {
+                            setCustomModelInput(preset.defaultModel);
+                          }
+                        }}
+                        className="px-3 py-1 rounded-full text-xs font-medium bg-[var(--color-bg-tertiary)] text-[var(--color-text-secondary)] hover:bg-[var(--color-border)] hover:text-[var(--color-text-primary)] transition-colors"
+                      >
+                        {preset.name}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
                 <div>
                   <label className="block text-xs text-[var(--color-text-secondary)] mb-1">
                     Base URL
@@ -266,6 +380,30 @@ export function SettingsPage() {
                       className="flex-1"
                     />
                     <Button
+                      variant="ghost"
+                      onClick={async () => {
+                        const url = customUrlInput.trim();
+                        if (!url) return;
+                        setTestState({ kind: 'pending' });
+                        const result = await testLocalEndpoint(url);
+                        if (result.ok) {
+                          setTestState({ kind: 'success', count: result.models.length });
+                          setDiscoveredModels(result.models);
+                        } else {
+                          setTestState({ kind: 'error', message: result.error });
+                          setDiscoveredModels([]);
+                        }
+                      }}
+                      disabled={testState.kind === 'pending' || !customUrlInput.trim()}
+                      className="shrink-0"
+                    >
+                      {testState.kind === 'pending' ? (
+                        <Loader2 size={16} className="animate-spin" />
+                      ) : (
+                        'Test'
+                      )}
+                    </Button>
+                    <Button
                       onClick={() => setCustomUrl(customUrlInput.trim())}
                       disabled={isSaving || !customUrlInput.trim() || customUrlInput.trim() === customUrl}
                       className="shrink-0"
@@ -273,28 +411,83 @@ export function SettingsPage() {
                       {isSaving ? <Loader2 size={16} className="animate-spin" /> : 'Save'}
                     </Button>
                   </div>
-                  <p className="mt-1 text-xs text-[var(--color-text-secondary)]">
-                    OpenAI-compatible base URL. Examples: Ollama → <code>http://localhost:11434/v1</code>, LM Studio → <code>http://localhost:1234/v1</code>
-                  </p>
+
+                  {/* Phase 10.1: test-connection result badge */}
+                  {testState.kind === 'success' && (
+                    <p className="mt-1.5 text-xs text-green-400 flex items-center gap-1">
+                      <Check size={12} />
+                      Connected. Found {testState.count} model{testState.count !== 1 ? 's' : ''}.
+                    </p>
+                  )}
+                  {testState.kind === 'error' && (
+                    <p className="mt-1.5 text-xs text-red-400">{testState.message}</p>
+                  )}
+
+                  <div className="mt-2 text-xs text-[var(--color-text-secondary)] leading-relaxed">
+                    <p className="mb-1">OpenAI-compatible base URL. Ends in <code>/v1</code> for most tools.</p>
+                    <p className="mb-1">
+                      <strong className="text-[var(--color-text-primary)]">CORS:</strong> your local server must allow browser requests.
+                      Ollama and LM Studio allow it by default;
+                      for <code>llama.cpp</code> run with <code>--cors</code>;
+                      KoboldCpp enables it by default on recent versions.
+                    </p>
+                  </div>
                 </div>
 
                 <div>
                   <label className="block text-xs text-[var(--color-text-secondary)] mb-1">
                     Model name
                   </label>
-                  <Input
-                    value={customModelInput}
-                    onChange={(e) => setCustomModelInput(e.target.value)}
-                    onBlur={() => {
-                      if (customModelInput !== activeModel) {
-                        setActiveModel(customModelInput);
-                      }
-                    }}
-                    placeholder="e.g. llama3, mistral, codellama"
-                  />
-                  <p className="mt-1 text-xs text-[var(--color-text-secondary)]">
-                    Exact model identifier your endpoint expects. Changes are saved on blur.
-                  </p>
+                  {discoveredModels.length > 0 ? (
+                    <>
+                      <select
+                        value={
+                          discoveredModels.includes(customModelInput)
+                            ? customModelInput
+                            : '__custom__'
+                        }
+                        onChange={(e) => {
+                          const value = e.target.value;
+                          if (value === '__custom__') {
+                            // Clear the discovered list so the text input returns
+                            setDiscoveredModels([]);
+                            return;
+                          }
+                          setCustomModelInput(value);
+                          if (value !== activeModel) {
+                            setActiveModel(value);
+                          }
+                        }}
+                        className="w-full text-sm bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] rounded-lg px-3 py-2 text-[var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]"
+                      >
+                        {discoveredModels.map((m) => (
+                          <option key={m} value={m}>
+                            {m}
+                          </option>
+                        ))}
+                        <option value="__custom__">Custom…</option>
+                      </select>
+                      <p className="mt-1 text-xs text-[var(--color-text-secondary)]">
+                        Discovered from <code>{customUrlInput}/models</code>. Select one or choose Custom… to type manually.
+                      </p>
+                    </>
+                  ) : (
+                    <>
+                      <Input
+                        value={customModelInput}
+                        onChange={(e) => setCustomModelInput(e.target.value)}
+                        onBlur={() => {
+                          if (customModelInput !== activeModel) {
+                            setActiveModel(customModelInput);
+                          }
+                        }}
+                        placeholder="e.g. llama3, mistral, codellama"
+                      />
+                      <p className="mt-1 text-xs text-[var(--color-text-secondary)]">
+                        Exact model identifier your endpoint expects. Click Test to discover available models.
+                      </p>
+                    </>
+                  )}
                 </div>
               </section>
             )}


### PR DESCRIPTION
## Summary

Phase 10.1 on the roadmap: support local OpenAI-compatible endpoints (Ollama, LM Studio, llama.cpp server, KoboldCpp, Oobabooga). The **chat-completion path already works** — ST natively handles `chat_completion_source: 'custom'` and reads `oai_settings.custom_url` from server-side storage — but the **frontend UX to get users to a working configuration was missing**. This PR fixes that.

No backend changes. No request-body changes. `settingsStore.setCustomUrl` unchanged.

## What's new

### 1. Five quick-preset pills

One-click buttons that fill the Custom Endpoint URL input with the canonical URL for each runner:

| Preset | URL | Pre-fills model |
|---|---|---|
| Ollama | `http://localhost:11434/v1` | `llama3` (only if model field is empty) |
| LM Studio | `http://localhost:1234/v1` | — |
| llama.cpp | `http://localhost:8080/v1` | — |
| KoboldCpp | `http://localhost:5001/v1` | — |
| Oobabooga | `http://localhost:5000/v1` | — |

Ollama's model pre-fill is only applied when the current model field is empty, so it doesn't clobber a user who already typed their own.

### 2. Test connection button

A `Test` button next to `Save` fetches `\${url}/models` **directly from the browser** (not proxied through the ST backend — it's a localhost endpoint, latency is trivial, and CORS failures surface immediately with actionable messages).

States:
- **Pending**: spinner
- **Success**: green "Connected. Found N models." text + populates a `discoveredModels` list
- **Error**: red text with a specific hint:
  - `HTTP 404` → `"Endpoint returned 404. Did you include '/v1' at the end of the URL?"`
  - Network / CORS (`TypeError`) → `"Couldn't reach the endpoint (<message>). Is your local server running? CORS may also block browser access — see help below."`
  - Other HTTP errors → `"Endpoint returned HTTP <status>"`

### 3. Model field morphs into a dropdown after a successful test

When `discoveredModels.length > 0`, the Model-name text input is replaced with a `<select>` of the discovered model IDs plus a `Custom…` escape-hatch option. Selecting `Custom…` clears `discoveredModels` and returns the plain text input.

Stale state is prevented: editing the URL input triggers a `useEffect` that resets both `testState` and `discoveredModels`, so a prior success badge can't linger when the user starts editing a new URL.

### 4. Richer help text

CORS-aware help replaces the previous one-line caption:

> OpenAI-compatible base URL. Ends in /v1 for most tools.
>
> **CORS:** your local server must allow browser requests. Ollama and LM Studio allow it by default; for llama.cpp run with \`--cors\`; KoboldCpp enables it by default on recent versions.

## Files changed

One file: `src/components/settings/SettingsPage.tsx` (+209/-16). No new files, no new stores, no new routes, no dependencies added.

At module scope the PR adds:
- `LOCAL_PRESETS: LocalPreset[]` — the 5-entry preset table
- `testLocalEndpoint(url)` — the fetch helper with shape-aware parsing
- `TestState` type

Inside the component:
- `testState` + `discoveredModels` local state
- `useEffect` on `[customUrlInput]` to reset test state on URL edit
- Preset pill row above the Base URL input
- Test button next to Save
- Green/red result badge below the URL input
- Dropdown-or-input conditional for the Model field
- Richer help block under the URL input

## Test plan

Verified end-to-end in the live dev preview:

- [x] `npx tsc -b` clean
- [x] `npm run build` clean (911 kB bundle, +3 kB)
- [x] `eslint src/components/settings/SettingsPage.tsx` clean
- [x] Click \"Custom / Local\" provider button → Custom Endpoint section renders with all 5 presets visible
- [x] Click Ollama preset → URL input shows \`http://localhost:11434/v1\`
- [x] Click Test (no real Ollama running) → red text: \"Couldn't reach the endpoint (Failed to fetch). Is your local server running? CORS may also block browser access…\"
- [x] Stub browser \`fetch\` to return a realistic \`{ data: [{ id: 'llama3.1:8b' }, …] }\` → click Test → green \"Connected. Found 5 models.\" badge + Model field morphs into a dropdown with all 5 models + \"Custom…\" option
- [x] Stub \`fetch\` to return 404 → red text: \"Endpoint returned 404. Did you include '/v1' at the end of the URL?\" + dropdown reverts to text input
- [x] Take screenshots confirming visual layout matches spec
- [ ] Manual: run a real Ollama instance, click preset, click Test, select a model, send a chat message end-to-end

## Known limitations (out of scope)

- **CORS dependency.** Test + model-list fetch only work if the local server allows browser requests. Documented in the help text. Fallback is manual text input — no regression.
- **Models endpoint shape.** Assumes OpenAI-compatible \`{ data: [{ id: ... }] }\`. All five target tools conform. Non-conforming responses yield \`discoveredModels: []\` and the text input stays as fallback.
- **Preset URLs hardcoded.** Users running on non-default ports edit the filled-in URL after clicking the preset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)