### PR TITLE
feat: Phase 10.2 — add DeepSeek, Cohere, and Perplexity providers

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -244,7 +244,7 @@ export const api = {
         method: 'POST',
         body: JSON.stringify({ handle: 'default-user', password: '' }),
       });
-    } catch (e) {
+    } catch {
       // If default-user login fails, we can't bootstrap
       throw new Error('Cannot register: Please login as an admin user first');
     }
@@ -785,7 +785,10 @@ export const SECRET_KEYS = {
   MISTRAL: 'api_key_mistralai',
   GROQ: 'api_key_groq',
   OPENROUTER: 'api_key_openrouter',
+  // Phase 10.2
   COHERE: 'api_key_cohere',
+  DEEPSEEK: 'api_key_deepseek',
+  PERPLEXITY: 'api_key_perplexity',
 } as const;
 
 export const PROVIDERS = [
@@ -795,6 +798,12 @@ export const PROVIDERS = [
   { id: 'mistralai', name: 'Mistral AI', secretKey: SECRET_KEYS.MISTRAL, models: ['mistral-large-latest', 'mistral-medium-latest', 'mistral-small-latest'] },
   { id: 'groq', name: 'Groq', secretKey: SECRET_KEYS.GROQ, models: ['llama-3.3-70b-versatile', 'llama-3.1-8b-instant', 'mixtral-8x7b-32768'] },
   { id: 'openrouter', name: 'OpenRouter', secretKey: SECRET_KEYS.OPENROUTER, models: ['openai/gpt-4o', 'anthropic/claude-sonnet-4', 'google/gemini-pro-1.5'] },
+  // Phase 10.2 — additional cloud providers. The SillyTavern backend routes by
+  // `chat_completion_source` matching the `id` below, and the API key is stored
+  // under the corresponding SECRET_KEYS entry. No backend changes required.
+  { id: 'deepseek', name: 'DeepSeek', secretKey: SECRET_KEYS.DEEPSEEK, models: ['deepseek-chat', 'deepseek-reasoner'] },
+  { id: 'cohere', name: 'Cohere', secretKey: SECRET_KEYS.COHERE, models: ['command-r-plus', 'command-r', 'command-r-08-2024'] },
+  { id: 'perplexity', name: 'Perplexity', secretKey: SECRET_KEYS.PERPLEXITY, models: ['sonar', 'sonar-pro', 'llama-3.1-sonar-large-128k-online'] },
   // Custom / local: no secret key required; URL and model are stored directly in oai_settings.
   { id: 'custom', name: 'Custom / Local', secretKey: '', models: [] as readonly string[] },
 ] as const;

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -77,6 +77,12 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
         model = (oaiSettings.google_model as string) || 'gemini-1.5-pro';
       } else if (chatCompletionSource === 'custom') {
         model = (oaiSettings.custom_model as string) || '';
+      } else if (chatCompletionSource === 'deepseek') {
+        model = (oaiSettings.deepseek_model as string) || 'deepseek-chat';
+      } else if (chatCompletionSource === 'cohere') {
+        model = (oaiSettings.cohere_model as string) || 'command-r-plus';
+      } else if (chatCompletionSource === 'perplexity') {
+        model = (oaiSettings.perplexity_model as string) || 'sonar';
       }
 
       const customUrl = (oaiSettings.custom_url as string) || '';
@@ -183,6 +189,12 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
         oaiSettings.claude_model = defaultModel;
       } else if (provider === 'makersuite') {
         oaiSettings.google_model = defaultModel;
+      } else if (provider === 'deepseek') {
+        oaiSettings.deepseek_model = defaultModel;
+      } else if (provider === 'cohere') {
+        oaiSettings.cohere_model = defaultModel;
+      } else if (provider === 'perplexity') {
+        oaiSettings.perplexity_model = defaultModel;
       }
       // 'custom': custom_url / custom_model are managed by setCustomUrl / setActiveModel separately.
 
@@ -232,6 +244,12 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
         oaiSettings.google_model = model;
       } else if (activeProvider === 'custom') {
         oaiSettings.custom_model = model;
+      } else if (activeProvider === 'deepseek') {
+        oaiSettings.deepseek_model = model;
+      } else if (activeProvider === 'cohere') {
+        oaiSettings.cohere_model = model;
+      } else if (activeProvider === 'perplexity') {
+        oaiSettings.perplexity_model = model;
       }
 
       settings.oai_settings = oaiSettings;


### PR DESCRIPTION
## Summary

Phase 10.2 from the roadmap — adds three new cloud providers behind the existing SillyTavern backend chat-completions router: **DeepSeek**, **Cohere**, and **Perplexity**.

No backend changes required. The SillyTavern backend already supports all three via `chat_completion_source: 'deepseek' | 'cohere' | 'perplexity'`, so this PR is a pure frontend change to register the providers in the UI-driven arrays.

## Why it's tiny

The provider grid and API-keys section both auto-render from `PROVIDERS.map(...)` in `SettingsPage.tsx`:

- **Line 204**: `{PROVIDERS.map((provider) => ...)}` — the Active Provider picker grid
- **Line 438**: `{PROVIDERS.filter((p) => p.id !== 'custom').map((provider) => ...)}` — the API Keys section

So adding an entry to the `PROVIDERS` array in `src/api/client.ts` gives each new provider a button in the Active Provider picker **and** an API key input in the API Keys section for free. Happy side effect of the existing architecture.

Also discovered while reading: `SECRET_KEYS.COHERE` was already defined in the file but completely unused — half the work was already done for Cohere.

## Changes

### `src/api/client.ts`
- Add `SECRET_KEYS.DEEPSEEK` = `'api_key_deepseek'`
- Add `SECRET_KEYS.PERPLEXITY` = `'api_key_perplexity'`
- (`SECRET_KEYS.COHERE` already existed)
- Add three PROVIDERS entries with curated model lists:

| Provider | chat_completion_source | Models |
|---|---|---|
| DeepSeek | `deepseek` | `deepseek-chat`, `deepseek-reasoner` |
| Cohere | `cohere` | `command-r-plus`, `command-r`, `command-r-08-2024` |
| Perplexity | `perplexity` | `sonar`, `sonar-pro`, `llama-3.1-sonar-large-128k-online` |

### `src/stores/settingsStore.ts`
Add per-provider model field plumbing to the three spots that switch on `activeProvider`:
1. `fetchSettings` — read back `oai_settings.<provider>_model` on load, with a sensible default per provider
2. `setActiveProvider` — write the provider's default model into `oai_settings.<provider>_model` when switching
3. `setActiveModel` — persist the user's model choice into the right field

Follows the existing `<provider>_model` naming convention used by openai / claude / makersuite.

### Drive-by cleanup
A pre-existing `catch (e) { ... }` at `client.ts:247` had an unused binding that tripped eslint on `npx eslint` runs. Simplified to `catch { ... }`. One-character fix; unrelated to the provider work but I was already touching the file.

## Test plan

Verified live in the dev preview:
- [x] `npx tsc -b` clean
- [x] `npm run build` clean (bundle 908.92 kB, unchanged from main)
- [x] `eslint` clean (including the drive-by fix)
- [x] `dynamic import('/src/api/client.ts')` shows 10 providers in `PROVIDERS`, with `deepseek` / `cohere` / `perplexity` each having the expected `secretKey` and model counts
- [x] Navigate to `/settings` — Active Provider grid renders 10 buttons across 4 rows
- [x] Click DeepSeek → selection persists, Model dropdown auto-populates with `deepseek-chat` (the first model from the provider's list), purple-highlighted active state matches the other providers
- [x] API Keys section auto-renders 9 rows (all providers except Custom/Local), each with the expected provider label and a Save button
- [x] Screenshot confirms visual layout + cyberpunk theme rainbow borders render around every section as expected
- [ ] Manual: enter a real API key for one of the new providers and send a chat message end-to-end against the live SillyTavern backend

## Notes for reviewers

- **Model field names are best-guess.** `oai_settings.deepseek_model` / `cohere_model` / `perplexity_model` follow the convention the existing code uses for openai/claude/makersuite, but I can't verify against the ST backend source from here. If those key names are wrong the provider will still work for the current session (the request body already includes `model: model` directly at `client.ts:522`), but the chosen model won't persist across page reloads. Easy fix in a follow-up if needed.
- **No xAI/Grok.** The user opted out of xAI because its ST backend support status is uncertain. Easy to add later by following the same pattern.
- **Streaming, sampler params, images** all flow through the existing `chat_completion_source` dispatch in `api.generateMessage`, so the new providers pick up full Phase 3/7/9 capabilities for free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)