### PR TITLE
feat: Phase 8.7 — STscript slash command system

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { SettingsPage, GenerationSettingsPage, InvitationManager, UserManagement
 import { WorldInfoPage } from './components/worldinfo';
 import { RegexScriptPage } from './components/regexscripts';
 import { InviteAcceptPage } from './components/auth/InviteAcceptPage';
+import { ToastProvider } from './components/ui/Toast';
 
 // Phase 7.1: Register all built-in extensions at app startup.
 import './extensions';
@@ -16,6 +17,7 @@ import './extensions';
 function App() {
   return (
     <BrowserRouter>
+    <ToastProvider>
       <Routes>
         <Route path="/login" element={<LoginPage />} />
         <Route path="/register" element={<RegisterPage />} />
@@ -38,6 +40,7 @@ function App() {
         </Route>
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
+    </ToastProvider>
     </BrowserRouter>
   );
 }

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -1,5 +1,6 @@
-import { useState, useRef, useEffect, useCallback } from 'react';
+import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
 import { Send, Mic, Paperclip, Square, X, Image } from 'lucide-react';
+import { CommandAutocomplete } from './CommandAutocomplete';
 import { Button } from '../ui';
 import {
   compressImageFiles,
@@ -58,8 +59,20 @@ export function ChatInput({
   const [images, setImages] = useState<string[]>([]);
   const [attachmentError, setAttachmentError] = useState<string | null>(null);
   const [isCompressing, setIsCompressing] = useState(false);
+  const [showAutocomplete, setShowAutocomplete] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Phase 8.7: derive autocomplete prefix from message
+  const autocompletePrefix = useMemo<string | null>(() => {
+    if (!showAutocomplete) return null;
+    const trimmed = message.trimStart();
+    if (!trimmed.startsWith('/')) return null;
+    // Extract text after / up to first space
+    const match = trimmed.match(/^\/(\w*)$/);
+    if (match) return match[1];
+    return null;
+  }, [message, showAutocomplete]);
 
   // Speech-to-text. Snapshot the textarea contents when start() fires so
   // dictation APPENDS rather than replacing. baseTextRef is the only place
@@ -461,11 +474,27 @@ export function ChatInput({
         )}
 
         {/* Input Area */}
-        <div className="flex-1 flex items-end bg-[var(--color-bg-tertiary)] rounded-2xl px-4 py-2">
+        <div className="flex-1 flex items-end bg-[var(--color-bg-tertiary)] rounded-2xl px-4 py-2 relative">
+          {/* Phase 8.7: Slash command autocomplete */}
+          <CommandAutocomplete
+            prefix={autocompletePrefix}
+            onSelect={(name) => {
+              setMessage('/' + name + ' ');
+              setShowAutocomplete(false);
+              textareaRef.current?.focus();
+            }}
+            onDismiss={() => setShowAutocomplete(false)}
+          />
           <textarea
             ref={textareaRef}
             value={message}
-            onChange={(e) => setMessage(e.target.value)}
+            onChange={(e) => {
+              const val = e.target.value;
+              setMessage(val);
+              // Show autocomplete when typing a / command (no spaces yet)
+              const trimmed = val.trimStart();
+              setShowAutocomplete(trimmed.startsWith('/') && !trimmed.includes(' '));
+            }}
             onKeyDown={handleKeyDown}
             placeholder={isListening ? 'Listening…' : placeholder}
             disabled={disabled || isListening}

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useRef, useMemo, useState, useCallback, type CSSProperties } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { MessageSquare, Users, Settings2, Pencil, Square, Search, ChevronUp, ChevronDown, X, Check } from 'lucide-react';
+import { showToastGlobal } from '../ui/Toast';
 import { useCharacterStore } from '../../stores/characterStore';
 import { useChatStore } from '../../stores/chatStore';
 import { ChatMessage } from './ChatMessage';
@@ -45,6 +47,7 @@ import {
 } from '../../hooks/displayPreferences';
 
 export function ChatView() {
+  const routerNavigate = useNavigate();
   const { selectedCharacter, isGroupChatMode, groupChatCharacters, exitGroupChat } = useCharacterStore();
   const {
     messages,
@@ -204,6 +207,39 @@ export function ChatView() {
     const t = setTimeout(() => searchInputRef.current?.focus(), 60);
     return () => clearTimeout(t);
   }, [isSearchOpen]);
+
+  // Phase 8.7: STscript modal state
+  const [stscriptModal, setStscriptModal] = useState<{
+    type: 'popup' | 'input' | 'buttons';
+    message: string;
+    buttons?: string[];
+    defaultValue?: string;
+    resolve: (value: string) => void;
+  } | null>(null);
+
+  // Phase 8.7: Register STscript UI callbacks so slash commands can interact with the UI.
+  useEffect(() => {
+    import('../../utils/stscript').then(({ registerUICallbacks }) => {
+      registerUICallbacks({
+        showToast: (msg, variant) => showToastGlobal(msg, variant),
+        setInputText: (text) => {
+          setPrefillText(text);
+          setPrefillNonce(n => n + 1);
+        },
+        showPopup: (message, buttons) => {
+          return new Promise<string>((resolve) => {
+            setStscriptModal({ type: buttons ? 'buttons' : 'popup', message, buttons, resolve });
+          });
+        },
+        showInputPrompt: (message, defaultValue) => {
+          return new Promise<string | null>((resolve) => {
+            setStscriptModal({ type: 'input', message, defaultValue, resolve: (v) => resolve(v || null) });
+          });
+        },
+        navigate: (path) => routerNavigate(path),
+      });
+    });
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Phase 9.1: auto-navigate to first match when query changes
   useEffect(() => {
@@ -1240,6 +1276,48 @@ export function ChatView() {
             <Settings2 size={10} className="inline -mt-0.5" /> and tap a talk icon to choose who speaks next.
           </div>
         )}
+      {/* Phase 8.7: STscript popup/input/buttons modal */}
+      {stscriptModal && (
+        <div className="fixed inset-0 bg-black/50 z-[100] flex items-center justify-center p-4" onClick={() => { stscriptModal.resolve(''); setStscriptModal(null); }}>
+          <div className="bg-[var(--color-bg-primary)] rounded-lg shadow-xl max-w-md w-full p-4" onClick={(e) => e.stopPropagation()}>
+            <pre className="whitespace-pre-wrap text-sm text-[var(--color-text-primary)] mb-4 max-h-60 overflow-y-auto">{stscriptModal.message}</pre>
+            {stscriptModal.type === 'input' && (
+              <input
+                autoFocus
+                className="w-full px-3 py-2 rounded border border-[var(--color-border)] bg-[var(--color-bg-secondary)] text-[var(--color-text-primary)] mb-3"
+                defaultValue={stscriptModal.defaultValue || ''}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    stscriptModal.resolve((e.target as HTMLInputElement).value);
+                    setStscriptModal(null);
+                  }
+                }}
+                id="stscript-input"
+              />
+            )}
+            <div className="flex gap-2 justify-end">
+              {stscriptModal.type === 'buttons' && stscriptModal.buttons ? (
+                stscriptModal.buttons.map((label) => (
+                  <button key={label} className="px-4 py-2 rounded bg-[var(--color-primary)] text-white text-sm" onClick={() => { stscriptModal.resolve(label); setStscriptModal(null); }}>
+                    {label}
+                  </button>
+                ))
+              ) : stscriptModal.type === 'input' ? (
+                <>
+                  <button className="px-4 py-2 rounded bg-[var(--color-bg-secondary)] text-[var(--color-text-secondary)] text-sm" onClick={() => { stscriptModal.resolve(''); setStscriptModal(null); }}>Cancel</button>
+                  <button className="px-4 py-2 rounded bg-[var(--color-primary)] text-white text-sm" onClick={() => {
+                    const input = document.getElementById('stscript-input') as HTMLInputElement | null;
+                    stscriptModal.resolve(input?.value || '');
+                    setStscriptModal(null);
+                  }}>OK</button>
+                </>
+              ) : (
+                <button className="px-4 py-2 rounded bg-[var(--color-primary)] text-white text-sm" onClick={() => { stscriptModal.resolve('ok'); setStscriptModal(null); }}>OK</button>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
       </div>{/* end VN content wrapper */}
     </div>
   );

--- a/src/components/chat/CommandAutocomplete.tsx
+++ b/src/components/chat/CommandAutocomplete.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useState, useRef } from 'react';
+import type { CommandDefinition } from '../../utils/stscript/types';
+
+interface Props {
+  prefix: string | null;
+  onSelect: (commandName: string) => void;
+  onDismiss: () => void;
+}
+
+const MAX_VISIBLE = 6;
+
+const CATEGORY_BADGES: Record<string, string> = {
+  io: 'I/O',
+  variables: 'Vars',
+  flow: 'Flow',
+  math: 'Math',
+  generation: 'Gen',
+  messages: 'Chat',
+  character: 'Char',
+  quickreply: 'QR',
+  prompt: 'Prompt',
+  text: 'Text',
+  ui: 'UI',
+  system: 'Sys',
+};
+
+export function CommandAutocomplete({ prefix, onSelect, onDismiss }: Props) {
+  const [commands, setCommands] = useState<CommandDefinition[]>([]);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  // Load commands from registry (lazy to avoid eager import)
+  useEffect(() => {
+    if (prefix === null) return;
+    import('../../utils/stscript').then(({ getAllCommands }) => {
+      setCommands(getAllCommands());
+    });
+  }, [prefix !== null]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Reset selection when prefix changes
+  useEffect(() => {
+    setSelectedIndex(0);
+  }, [prefix]);
+
+  if (prefix === null || commands.length === 0) return null;
+
+  const filtered = prefix
+    ? commands.filter(c => c.name.startsWith(prefix.toLowerCase()))
+    : commands;
+
+  if (filtered.length === 0) return null;
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setSelectedIndex(i => Math.min(i + 1, filtered.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setSelectedIndex(i => Math.max(i - 1, 0));
+    } else if (e.key === 'Tab' || e.key === 'Enter') {
+      if (filtered[selectedIndex]) {
+        e.preventDefault();
+        onSelect(filtered[selectedIndex].name);
+      }
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      onDismiss();
+    }
+  };
+
+  return (
+    <AutocompleteKeyHandler onKeyDown={handleKeyDown}>
+      <div
+        ref={listRef}
+        className="absolute bottom-full left-0 right-0 mb-1 bg-[var(--color-bg-secondary)] border border-[var(--color-border)] rounded-lg shadow-lg overflow-hidden z-50"
+        style={{ maxHeight: `${MAX_VISIBLE * 44}px` }}
+      >
+        <div className="overflow-y-auto" style={{ maxHeight: `${MAX_VISIBLE * 44}px` }}>
+          {filtered.slice(0, 20).map((cmd, i) => (
+            <button
+              key={cmd.name}
+              className={`w-full text-left px-3 py-2 flex items-center gap-2 text-sm transition-colors ${
+                i === selectedIndex
+                  ? 'bg-[var(--color-primary)]/15 text-[var(--color-text-primary)]'
+                  : 'text-[var(--color-text-secondary)] hover:bg-[var(--color-primary)]/5'
+              }`}
+              onMouseEnter={() => setSelectedIndex(i)}
+              onClick={() => onSelect(cmd.name)}
+            >
+              <span className="font-mono text-[var(--color-primary)] shrink-0">/{cmd.name}</span>
+              <span className="truncate opacity-70">{cmd.description}</span>
+              <span className="ml-auto text-[10px] px-1.5 py-0.5 rounded bg-[var(--color-bg-primary)] text-[var(--color-text-secondary)] shrink-0">
+                {CATEGORY_BADGES[cmd.category] || cmd.category}
+              </span>
+            </button>
+          ))}
+        </div>
+      </div>
+    </AutocompleteKeyHandler>
+  );
+}
+
+/** Invisible wrapper that captures keyboard events for the autocomplete. */
+function AutocompleteKeyHandler({ onKeyDown, children }: { onKeyDown: (e: KeyboardEvent) => void; children: React.ReactNode }) {
+  useEffect(() => {
+    document.addEventListener('keydown', onKeyDown, true);
+    return () => document.removeEventListener('keydown', onKeyDown, true);
+  }, [onKeyDown]);
+  return <>{children}</>;
+}

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -1,0 +1,76 @@
+import { createContext, useCallback, useContext, useState, useRef, type ReactNode } from 'react';
+
+type ToastVariant = 'info' | 'warning' | 'error' | 'success';
+
+interface ToastItem {
+  id: number;
+  message: string;
+  variant: ToastVariant;
+}
+
+interface ToastContextValue {
+  showToast: (message: string, variant?: ToastVariant) => void;
+}
+
+const ToastContext = createContext<ToastContextValue>({
+  showToast: () => {},
+});
+
+export function useToast() {
+  return useContext(ToastContext);
+}
+
+// Module-level export so non-React code can trigger toasts
+let globalShowToast: (message: string, variant?: ToastVariant) => void = () => {};
+
+export function showToastGlobal(message: string, variant?: ToastVariant) {
+  globalShowToast(message, variant);
+}
+
+const VARIANT_STYLES: Record<ToastVariant, string> = {
+  info: 'bg-blue-600',
+  warning: 'bg-yellow-600',
+  error: 'bg-red-600',
+  success: 'bg-green-600',
+};
+
+const MAX_TOASTS = 3;
+const AUTO_DISMISS_MS = 3000;
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+  const nextId = useRef(0);
+
+  const showToast = useCallback((message: string, variant: ToastVariant = 'info') => {
+    const id = nextId.current++;
+    setToasts(prev => {
+      const next = [...prev, { id, message, variant }];
+      return next.slice(-MAX_TOASTS);
+    });
+    setTimeout(() => {
+      setToasts(prev => prev.filter(t => t.id !== id));
+    }, AUTO_DISMISS_MS);
+  }, []);
+
+  // Register the global handle
+  globalShowToast = showToast;
+
+  return (
+    <ToastContext.Provider value={{ showToast }}>
+      {children}
+      {/* Toast container */}
+      {toasts.length > 0 && (
+        <div className="fixed bottom-20 left-1/2 -translate-x-1/2 z-[200] flex flex-col gap-2 pointer-events-none max-w-sm w-full px-4">
+          {toasts.map(t => (
+            <div
+              key={t.id}
+              className={`${VARIANT_STYLES[t.variant]} text-white px-4 py-2 rounded-lg shadow-lg text-sm animate-fade-in pointer-events-auto`}
+            >
+              {t.message}
+            </div>
+          ))}
+        </div>
+      )}
+    </ToastContext.Provider>
+  );
+}

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -2291,6 +2291,18 @@ export const useChatStore = create<ChatState>((set, get) => ({
     availableEmotions?: string[],
     images?: string[]
   ) => {
+    // Phase 8.7: STscript slash command intercept
+    if (content.trimStart().startsWith('/')) {
+      try {
+        const stscript = await import('../utils/stscript');
+        const ctx = stscript.buildExecutionContext({ originalInput: content.trimStart() });
+        await stscript.executeSlashCommand(content.trimStart(), ctx);
+      } catch (err) {
+        set({ error: err instanceof Error ? err.message : 'Slash command error' });
+      }
+      return;
+    }
+
     const { addMessage } = get();
 
     // Phase 6.1: non-vision model guard. Refuse to send images to a model
@@ -2402,6 +2414,18 @@ export const useChatStore = create<ChatState>((set, get) => ({
     characters: CharacterInfo[],
     images?: string[]
   ) => {
+    // Phase 8.7: STscript slash command intercept (group chat)
+    if (content.trimStart().startsWith('/')) {
+      try {
+        const stscript = await import('../utils/stscript');
+        const ctx = stscript.buildExecutionContext({ originalInput: content.trimStart() });
+        await stscript.executeSlashCommand(content.trimStart(), ctx);
+      } catch (err) {
+        set({ error: err instanceof Error ? err.message : 'Slash command error' });
+      }
+      return;
+    }
+
     const { addMessage, currentChatFile, getGroupChatByFile } = get();
 
     // Phase 6.1: non-vision model guard — same as single-character send.

--- a/src/utils/macros.ts
+++ b/src/utils/macros.ts
@@ -402,6 +402,28 @@ function processInline(text: string, ctx: MacroContext): string {
         return ctx.extra[args.trim()] || '';
       }
 
+      // ───── Phase 8.7: STscript execution macros ─────
+      case 'pipe':
+        return ctx.extra?.['pipe'] ?? '';
+      case 'timesindex':
+      case 'times_index':
+        return ctx.extra?.['timesIndex'] ?? '';
+      case 'input':
+        return ctx.extra?.['input'] ?? '';
+      case 'lastmessageid':
+      case 'last_message_id':
+        return ctx.extra?.['lastMessageId'] ?? '';
+      case 'var': {
+        // Scoped variable access: {{var::name}}
+        if (!args) return '';
+        const scopeVars = ctx.extra?.['__scopeVars'];
+        if (!scopeVars) return '';
+        try {
+          const map: Record<string, string> = JSON.parse(scopeVars);
+          return map[args.trim()] ?? '';
+        } catch { return ''; }
+      }
+
       // ───── Phase 9.3: Variables ─────
       case 'getvar': {
         const key = args.trim();

--- a/src/utils/stscript/commands/character.ts
+++ b/src/utils/stscript/commands/character.ts
@@ -1,0 +1,89 @@
+// Character commands: /go, /persona, /random
+
+import { registerCommand } from '../registry';
+import type { ParsedArg, ExecutionContext } from '../types';
+
+function getUnnamedArgs(args: ParsedArg[]): string {
+  return args.filter(a => !a.key).map(a => a.value).join(' ');
+}
+
+function getNamedArg(args: ParsedArg[], key: string): string | undefined {
+  return args.find(a => a.key === key)?.value;
+}
+
+registerCommand({
+  name: 'go',
+  description: 'Navigate to a character by name',
+  category: 'character',
+  usage: '/go characterName',
+  async handler(args, rawArgs, ctx) {
+    const name = getNamedArg(args, 'name') || getUnnamedArgs(args) || rawArgs || ctx.pipe;
+    if (!name) { ctx.showToast('/go: specify a character name', 'error'); return ''; }
+
+    try {
+      const { useCharacterStore } = await import('../../../stores/characterStore');
+      const chars = useCharacterStore.getState().characters;
+      const match = chars.find(c =>
+        c.name.toLowerCase() === name.toLowerCase() ||
+        c.avatar?.toLowerCase().includes(name.toLowerCase())
+      );
+      if (!match) {
+        ctx.showToast(`/go: character "${name}" not found`, 'error');
+        return '';
+      }
+      useCharacterStore.getState().selectCharacter(match);
+      ctx.navigate(`/chat/${match.avatar}`);
+      return match.name;
+    } catch (err) {
+      ctx.showToast(`/go error: ${err instanceof Error ? err.message : err}`, 'error');
+      return '';
+    }
+  },
+});
+
+registerCommand({
+  name: 'persona',
+  description: 'Switch the active persona',
+  category: 'character',
+  usage: '/persona name',
+  async handler(args, rawArgs, ctx) {
+    const name = getNamedArg(args, 'name') || getUnnamedArgs(args) || rawArgs || ctx.pipe;
+    if (!name) { ctx.showToast('/persona: specify a persona name', 'error'); return ''; }
+
+    try {
+      const { usePersonaStore } = await import('../../../stores/personaStore');
+      const store = usePersonaStore.getState();
+      const match = store.personas.find(p => p.name.toLowerCase() === name.toLowerCase());
+      if (!match) {
+        ctx.showToast(`/persona: "${name}" not found`, 'error');
+        return '';
+      }
+      store.setActivePersona(match.id);
+      return match.name;
+    } catch (err) {
+      ctx.showToast(`/persona error: ${err instanceof Error ? err.message : err}`, 'error');
+      return '';
+    }
+  },
+});
+
+registerCommand({
+  name: 'random',
+  description: 'Open a random character',
+  category: 'character',
+  usage: '/random',
+  async handler(_args, _raw, ctx) {
+    try {
+      const { useCharacterStore } = await import('../../../stores/characterStore');
+      const chars = useCharacterStore.getState().characters;
+      if (chars.length === 0) { ctx.showToast('/random: no characters', 'error'); return ''; }
+      const pick = chars[Math.floor(Math.random() * chars.length)];
+      useCharacterStore.getState().selectCharacter(pick);
+      ctx.navigate(`/chat/${pick.avatar}`);
+      return pick.name;
+    } catch (err) {
+      ctx.showToast(`/random error: ${err instanceof Error ? err.message : err}`, 'error');
+      return '';
+    }
+  },
+});

--- a/src/utils/stscript/commands/chat.ts
+++ b/src/utils/stscript/commands/chat.ts
@@ -1,0 +1,235 @@
+// Chat/message commands: /send, /sendas, /sys, /comment, /del, /messages, /addswipe, /cut, /hide, /unhide
+
+import { registerCommand } from '../registry';
+import type { ParsedArg, ExecutionContext } from '../types';
+
+function getUnnamedArgs(args: ParsedArg[]): string {
+  return args.filter(a => !a.key).map(a => a.value).join(' ');
+}
+
+function getNamedArg(args: ParsedArg[], key: string): string | undefined {
+  return args.find(a => a.key === key)?.value;
+}
+
+async function getChatStore() {
+  const { useChatStore } = await import('../../../stores/chatStore');
+  return useChatStore.getState();
+}
+
+registerCommand({
+  name: 'send',
+  description: 'Post a user message',
+  category: 'messages',
+  usage: '/send [at=index] message',
+  async handler(args, rawArgs, ctx) {
+    const content = getUnnamedArgs(args) || rawArgs || ctx.pipe;
+    if (!content) return '';
+    const state = await getChatStore();
+    state.addMessage({
+      name: 'You',
+      content,
+      isUser: true,
+      timestamp: Date.now(),
+    });
+    return String(state.messages.length - 1);
+  },
+});
+
+registerCommand({
+  name: 'sendas',
+  description: 'Post a message as a specific character',
+  category: 'messages',
+  usage: '/sendas name=CharName message',
+  async handler(args, rawArgs, ctx) {
+    const name = getNamedArg(args, 'name') ?? 'Character';
+    const content = getUnnamedArgs(args) || rawArgs || ctx.pipe;
+    if (!content) return '';
+    const state = await getChatStore();
+    state.addMessage({
+      name,
+      content,
+      isUser: false,
+      timestamp: Date.now(),
+    });
+    return String(state.messages.length - 1);
+  },
+});
+
+registerCommand({
+  name: 'sys',
+  aliases: ['sysmes'],
+  description: 'Post a system narrator message',
+  category: 'messages',
+  usage: '/sys message',
+  async handler(args, rawArgs, ctx) {
+    const content = getUnnamedArgs(args) || rawArgs || ctx.pipe;
+    if (!content) return '';
+    const state = await getChatStore();
+    state.addMessage({
+      name: 'System',
+      content,
+      isUser: false,
+      isSystem: true,
+      timestamp: Date.now(),
+    });
+    return String(state.messages.length - 1);
+  },
+});
+
+registerCommand({
+  name: 'comment',
+  description: 'Add a hidden comment message',
+  category: 'messages',
+  usage: '/comment message',
+  async handler(args, rawArgs, ctx) {
+    const content = getUnnamedArgs(args) || rawArgs || ctx.pipe;
+    if (!content) return '';
+    const state = await getChatStore();
+    state.addMessage({
+      name: 'Comment',
+      content: `[Comment: ${content}]`,
+      isUser: false,
+      isSystem: true,
+      timestamp: Date.now(),
+    });
+    return String(state.messages.length - 1);
+  },
+});
+
+registerCommand({
+  name: 'del',
+  aliases: ['delete'],
+  description: 'Delete the last N messages',
+  category: 'messages',
+  usage: '/del [count]',
+  async handler(args, _raw, ctx) {
+    const count = Math.max(1, Number(args.find(a => !a.key)?.value ?? ctx.pipe ?? 1));
+    const state = await getChatStore();
+    const messages = state.messages;
+    for (let i = 0; i < count && messages.length > 0; i++) {
+      state.deleteMessage(messages.length - 1);
+    }
+    return '';
+  },
+});
+
+registerCommand({
+  name: 'messages',
+  aliases: ['mes'],
+  description: 'Get message content by index range',
+  category: 'messages',
+  usage: '/messages [names=on|off] start[-end]',
+  async handler(args, _raw) {
+    const showNames = getNamedArg(args, 'names') !== 'off';
+    const rangeStr = args.find(a => !a.key)?.value ?? '';
+    const state = await getChatStore();
+    const messages = state.messages;
+
+    let start = 0;
+    let end = messages.length - 1;
+
+    if (rangeStr.includes('-')) {
+      const [s, e] = rangeStr.split('-').map(Number);
+      if (isFinite(s)) start = Math.max(0, s);
+      if (isFinite(e)) end = Math.min(messages.length - 1, e);
+    } else if (rangeStr) {
+      start = end = Math.max(0, Math.min(Number(rangeStr), messages.length - 1));
+    }
+
+    const lines: string[] = [];
+    for (let i = start; i <= end; i++) {
+      const m = messages[i];
+      if (m) {
+        lines.push(showNames ? `${m.name}: ${m.content}` : m.content);
+      }
+    }
+    return lines.join('\n');
+  },
+});
+
+registerCommand({
+  name: 'addswipe',
+  description: 'Add an alternate response to the last AI message',
+  category: 'messages',
+  usage: '/addswipe text',
+  async handler(args, rawArgs, ctx) {
+    const content = getUnnamedArgs(args) || rawArgs || ctx.pipe;
+    if (!content) return '';
+    const state = await getChatStore();
+    const messages = state.messages;
+    const lastAi = [...messages].reverse().find(m => !m.isUser);
+    if (!lastAi) {
+      ctx.showToast('/addswipe: no AI message found', 'error');
+      return '';
+    }
+    const idx = messages.indexOf(lastAi);
+    if (idx >= 0) {
+      const swipes = lastAi.swipes ?? [lastAi.content];
+      state.editMessage(idx, lastAi.content, [...swipes, content]);
+    }
+    return '';
+  },
+});
+
+registerCommand({
+  name: 'cut',
+  description: 'Remove messages in a range',
+  category: 'messages',
+  usage: '/cut from[-to]',
+  async handler(args) {
+    const rangeStr = args.find(a => !a.key)?.value ?? '';
+    if (!rangeStr) return '';
+    const state = await getChatStore();
+    const messages = state.messages;
+
+    let from = 0;
+    let to = messages.length - 1;
+    if (rangeStr.includes('-')) {
+      const [s, e] = rangeStr.split('-').map(Number);
+      if (isFinite(s)) from = Math.max(0, s);
+      if (isFinite(e)) to = Math.min(messages.length - 1, e);
+    } else {
+      from = to = Math.max(0, Number(rangeStr));
+    }
+
+    const removed: string[] = [];
+    // Delete from end to start to preserve indices
+    for (let i = to; i >= from; i--) {
+      if (messages[i]) {
+        removed.unshift(messages[i].content);
+        state.deleteMessage(i);
+      }
+    }
+    return removed.join('\n');
+  },
+});
+
+registerCommand({
+  name: 'hide',
+  description: 'Hide a message from the prompt (by index)',
+  category: 'messages',
+  usage: '/hide messageIndex',
+  async handler(args, _raw, ctx) {
+    const idx = Number(args.find(a => !a.key)?.value ?? ctx.pipe ?? -1);
+    const state = await getChatStore();
+    if (idx >= 0 && idx < state.messages.length) {
+      state.editMessage(idx, state.messages[idx].content, undefined, true);
+    }
+    return '';
+  },
+});
+
+registerCommand({
+  name: 'unhide',
+  description: 'Unhide a hidden message (by index)',
+  category: 'messages',
+  usage: '/unhide messageIndex',
+  async handler(args, _raw, ctx) {
+    const idx = Number(args.find(a => !a.key)?.value ?? ctx.pipe ?? -1);
+    const state = await getChatStore();
+    if (idx >= 0 && idx < state.messages.length) {
+      state.editMessage(idx, state.messages[idx].content, undefined, false);
+    }
+    return '';
+  },
+});

--- a/src/utils/stscript/commands/flow.ts
+++ b/src/utils/stscript/commands/flow.ts
@@ -1,0 +1,198 @@
+// Flow control commands: /if, /while, /times, /break, /abort, /return, /delay
+
+import { registerCommand } from '../registry';
+import { isClosure, unwrapClosure, executeClosure, MAX_LOOP_ITERATIONS } from '../executor';
+import type { ParsedArg, ExecutionContext } from '../types';
+
+function getNamedArg(args: ParsedArg[], key: string): string | undefined {
+  return args.find(a => a.key === key)?.value;
+}
+
+function getClosures(args: ParsedArg[]): string[] {
+  return args.filter(a => !a.key && isClosure(a.value)).map(a => unwrapClosure(a.value));
+}
+
+function evaluateCondition(left: string, rule: string, right: string): boolean {
+  const numL = Number(left);
+  const numR = Number(right);
+  const bothNumeric = isFinite(numL) && isFinite(numR);
+
+  switch (rule.toLowerCase()) {
+    case 'eq':
+    case '==':
+    case '===':
+      return left === right;
+    case 'neq':
+    case '!=':
+    case '!==':
+      return left !== right;
+    case 'gt':
+    case '>':
+      return bothNumeric ? numL > numR : left > right;
+    case 'gte':
+    case '>=':
+      return bothNumeric ? numL >= numR : left >= right;
+    case 'lt':
+    case '<':
+      return bothNumeric ? numL < numR : left < right;
+    case 'lte':
+    case '<=':
+      return bothNumeric ? numL <= numR : left <= right;
+    case 'in':
+      return right.includes(left);
+    case 'nin':
+      return !right.includes(left);
+    case 'not':
+      return !left || left === '0' || left === 'false' || left === '';
+    default:
+      return false;
+  }
+}
+
+registerCommand({
+  name: 'if',
+  description: 'Conditional execution',
+  category: 'flow',
+  usage: '/if left=A rule=eq right=B {: then :} [else={: else :}]',
+  async handler(args, _raw, ctx) {
+    const left = getNamedArg(args, 'left') ?? '';
+    const right = getNamedArg(args, 'right') ?? '';
+    const rule = getNamedArg(args, 'rule') ?? 'eq';
+    const closures = getClosures(args);
+    const elseArg = getNamedArg(args, 'else');
+
+    const condition = evaluateCondition(left, rule, right);
+
+    if (condition) {
+      if (closures.length > 0) {
+        return await executeClosure(closures[0], ctx);
+      }
+    } else {
+      // else branch: named arg or second closure
+      if (elseArg && isClosure(elseArg)) {
+        return await executeClosure(unwrapClosure(elseArg), ctx);
+      }
+      if (closures.length > 1) {
+        return await executeClosure(closures[1], ctx);
+      }
+    }
+    return '';
+  },
+});
+
+registerCommand({
+  name: 'while',
+  description: 'Loop while condition is true',
+  category: 'flow',
+  usage: '/while left=A rule=eq right=B {: body :}',
+  async handler(args, _raw, ctx) {
+    const closures = getClosures(args);
+    if (closures.length === 0) return '';
+    const body = closures[0];
+    let result = '';
+
+    for (let i = 0; i < MAX_LOOP_ITERATIONS; i++) {
+      // Re-evaluate condition each iteration (macro expansion happens in evaluateCondition args)
+      const left = getNamedArg(args, 'left') ?? '';
+      const right = getNamedArg(args, 'right') ?? '';
+      const rule = getNamedArg(args, 'rule') ?? 'eq';
+
+      if (!evaluateCondition(left, rule, right)) break;
+
+      result = await executeClosure(body, ctx);
+
+      if (ctx.abortSignal) {
+        if (ctx.abortSignal.type === 'break') {
+          result = ctx.abortSignal.value;
+          ctx.abortSignal = null; // consume break
+        }
+        break;
+      }
+    }
+
+    return result;
+  },
+});
+
+registerCommand({
+  name: 'times',
+  description: 'Execute a closure N times',
+  category: 'flow',
+  usage: '/times count {: body :}',
+  async handler(args, _raw, ctx) {
+    const countArg = args.find(a => !a.key && !isClosure(a.value));
+    const count = Math.min(Number(countArg?.value ?? 0), MAX_LOOP_ITERATIONS);
+    const closures = getClosures(args);
+    if (closures.length === 0 || count <= 0) return '';
+    const body = closures[0];
+    let result = '';
+
+    const prevTimesIndex = ctx.timesIndex;
+    for (let i = 0; i < count; i++) {
+      ctx.timesIndex = i;
+      result = await executeClosure(body, ctx);
+
+      if (ctx.abortSignal) {
+        if (ctx.abortSignal.type === 'break') {
+          result = ctx.abortSignal.value;
+          ctx.abortSignal = null;
+        }
+        break;
+      }
+    }
+    ctx.timesIndex = prevTimesIndex;
+
+    return result;
+  },
+});
+
+registerCommand({
+  name: 'break',
+  description: 'Exit a loop or closure',
+  category: 'flow',
+  usage: '/break [value]',
+  handler(args, rawArgs, ctx) {
+    const value = args.filter(a => !a.key).map(a => a.value).join(' ') || rawArgs || ctx.pipe;
+    ctx.abortSignal = { type: 'break', value };
+    return value;
+  },
+});
+
+registerCommand({
+  name: 'return',
+  description: 'Return a value from a closure',
+  category: 'flow',
+  usage: '/return [value]',
+  handler(args, rawArgs, ctx) {
+    const value = args.filter(a => !a.key).map(a => a.value).join(' ') || rawArgs || ctx.pipe;
+    ctx.abortSignal = { type: 'return', value };
+    return value;
+  },
+});
+
+registerCommand({
+  name: 'abort',
+  description: 'Stop all script execution',
+  category: 'flow',
+  usage: '/abort [reason]',
+  handler(args, rawArgs, ctx) {
+    const reason = args.filter(a => !a.key).map(a => a.value).join(' ') || rawArgs || 'Script aborted';
+    ctx.abortSignal = { type: 'abort', reason };
+    if (reason) ctx.showToast(reason, 'warning');
+    return '';
+  },
+});
+
+registerCommand({
+  name: 'delay',
+  description: 'Pause execution for milliseconds',
+  category: 'flow',
+  usage: '/delay milliseconds',
+  async handler(args) {
+    const ms = Number(args.find(a => !a.key)?.value ?? 0);
+    if (ms > 0 && ms <= 30000) {
+      await new Promise(resolve => setTimeout(resolve, ms));
+    }
+    return '';
+  },
+});

--- a/src/utils/stscript/commands/generation.ts
+++ b/src/utils/stscript/commands/generation.ts
@@ -1,0 +1,154 @@
+// Generation commands: /gen, /trigger, /continue, /swipe, /regenerate
+
+import { registerCommand } from '../registry';
+import type { ParsedArg, ExecutionContext } from '../types';
+
+function getUnnamedArgs(args: ParsedArg[]): string {
+  return args.filter(a => !a.key).map(a => a.value).join(' ');
+}
+
+registerCommand({
+  name: 'gen',
+  description: 'Generate an AI response (uses pipe or args as prompt context)',
+  category: 'generation',
+  usage: '/gen [prompt text]',
+  async handler(args, rawArgs, ctx) {
+    const prompt = getUnnamedArgs(args) || rawArgs || ctx.pipe;
+    try {
+      const { useChatStore } = await import('../../../stores/chatStore');
+      const state = useChatStore.getState();
+      const { useCharacterStore } = await import('../../../stores/characterStore');
+      const charState = useCharacterStore.getState();
+      const character = charState.selectedCharacter;
+      if (!character) {
+        ctx.showToast('/gen: no character selected', 'error');
+        return '';
+      }
+
+      // Inject prompt as a temporary system message, generate, capture response
+      if (prompt) {
+        state.addMessage({
+          name: 'System',
+          content: prompt,
+          isUser: false,
+          isSystem: true,
+          timestamp: Date.now(),
+        });
+      }
+
+      await state.sendMessage('', character);
+
+      // Get last AI message as result
+      const messages = useChatStore.getState().messages;
+      const lastAi = [...messages].reverse().find(m => !m.isUser && !m.isSystem);
+      return lastAi?.content ?? '';
+    } catch (err) {
+      ctx.showToast(`/gen error: ${err instanceof Error ? err.message : err}`, 'error');
+      return '';
+    }
+  },
+});
+
+registerCommand({
+  name: 'trigger',
+  description: 'Trigger a normal AI response generation',
+  category: 'generation',
+  usage: '/trigger',
+  async handler(_args, _raw, ctx) {
+    try {
+      const { useChatStore } = await import('../../../stores/chatStore');
+      const state = useChatStore.getState();
+      const { useCharacterStore } = await import('../../../stores/characterStore');
+      const character = useCharacterStore.getState().selectedCharacter;
+      if (!character) {
+        ctx.showToast('/trigger: no character selected', 'error');
+        return '';
+      }
+
+      const content = ctx.pipe || '';
+      await state.sendMessage(content, character);
+
+      const messages = useChatStore.getState().messages;
+      const lastAi = [...messages].reverse().find(m => !m.isUser && !m.isSystem);
+      return lastAi?.content ?? '';
+    } catch (err) {
+      ctx.showToast(`/trigger error: ${err instanceof Error ? err.message : err}`, 'error');
+      return '';
+    }
+  },
+});
+
+registerCommand({
+  name: 'continue',
+  aliases: ['cont'],
+  description: 'Continue the last AI message',
+  category: 'generation',
+  usage: '/continue',
+  async handler(_args, _raw, ctx) {
+    try {
+      const { useChatStore } = await import('../../../stores/chatStore');
+      const state = useChatStore.getState();
+      const { useCharacterStore } = await import('../../../stores/characterStore');
+      const character = useCharacterStore.getState().selectedCharacter;
+      if (!character) return '';
+
+      await state.continueMessage(character);
+      return '';
+    } catch (err) {
+      ctx.showToast(`/continue error: ${err instanceof Error ? err.message : err}`, 'error');
+      return '';
+    }
+  },
+});
+
+registerCommand({
+  name: 'swipe',
+  description: 'Swipe to generate an alternate response',
+  category: 'generation',
+  usage: '/swipe',
+  async handler(_args, _raw, ctx) {
+    try {
+      const { useChatStore } = await import('../../../stores/chatStore');
+      const state = useChatStore.getState();
+      const { useCharacterStore } = await import('../../../stores/characterStore');
+      const character = useCharacterStore.getState().selectedCharacter;
+      if (!character) return '';
+
+      const messages = state.messages;
+      const lastAi = [...messages].reverse().find(m => !m.isUser);
+      if (!lastAi) return '';
+
+      const idx = messages.indexOf(lastAi);
+      if (idx >= 0) {
+        await state.swipeRight(idx, character);
+      }
+      return '';
+    } catch (err) {
+      ctx.showToast(`/swipe error: ${err instanceof Error ? err.message : err}`, 'error');
+      return '';
+    }
+  },
+});
+
+registerCommand({
+  name: 'regenerate',
+  aliases: ['regen'],
+  description: 'Regenerate the last AI response',
+  category: 'generation',
+  usage: '/regenerate',
+  async handler(_args, _raw, ctx) {
+    try {
+      const { useChatStore } = await import('../../../stores/chatStore');
+      const state = useChatStore.getState();
+      const { useCharacterStore } = await import('../../../stores/characterStore');
+      const character = useCharacterStore.getState().selectedCharacter;
+      if (!character) return '';
+
+      await state.regenerateMessage(character);
+      return '';
+    } catch (err) {
+      ctx.showToast(`/regenerate error: ${err instanceof Error ? err.message : err}`, 'error');
+      return '';
+    }
+  },
+});

--- a/src/utils/stscript/commands/io.ts
+++ b/src/utils/stscript/commands/io.ts
@@ -1,0 +1,92 @@
+// I/O commands: /echo, /pass, /setinput, /input, /popup, /buttons
+
+import { registerCommand } from '../registry';
+import type { ParsedArg, ExecutionContext } from '../types';
+
+function getUnnamedArgs(args: ParsedArg[]): string {
+  return args.filter(a => !a.key).map(a => a.value).join(' ');
+}
+
+function getNamedArg(args: ParsedArg[], key: string): string | undefined {
+  return args.find(a => a.key === key)?.value;
+}
+
+registerCommand({
+  name: 'echo',
+  description: 'Display a toast notification',
+  category: 'io',
+  usage: '/echo [severity=info|warning|error|success] message',
+  handler(args, rawArgs, ctx) {
+    const severity = getNamedArg(args, 'severity');
+    const variant = (['info', 'warning', 'error', 'success'] as const).includes(severity as any)
+      ? severity as 'info' | 'warning' | 'error' | 'success'
+      : 'info';
+    const message = args.filter(a => a.key !== 'severity' && !a.key).map(a => a.value).join(' ') || rawArgs;
+    ctx.showToast(message, variant);
+    return message;
+  },
+});
+
+registerCommand({
+  name: 'pass',
+  description: 'Pass a value to the pipe without side effects',
+  category: 'io',
+  usage: '/pass value',
+  handler(args, rawArgs) {
+    return getUnnamedArgs(args) || rawArgs;
+  },
+});
+
+registerCommand({
+  name: 'setinput',
+  description: 'Set the chat input text',
+  category: 'io',
+  usage: '/setinput text',
+  handler(args, rawArgs, ctx) {
+    const text = getUnnamedArgs(args) || rawArgs;
+    ctx.setInputText(text);
+    return '';
+  },
+});
+
+registerCommand({
+  name: 'input',
+  description: 'Show an input dialog and return user text',
+  category: 'io',
+  usage: '/input [default=value] prompt',
+  async handler(args, rawArgs, ctx) {
+    const defaultValue = getNamedArg(args, 'default') ?? '';
+    const message = args.filter(a => a.key !== 'default' && !a.key).map(a => a.value).join(' ') || rawArgs;
+    const result = await ctx.showInputPrompt(message, defaultValue);
+    return result ?? '';
+  },
+});
+
+registerCommand({
+  name: 'popup',
+  description: 'Show a popup message',
+  category: 'io',
+  usage: '/popup message',
+  async handler(args, rawArgs, ctx) {
+    const message = getUnnamedArgs(args) || rawArgs;
+    await ctx.showPopup(message);
+    return 'ok';
+  },
+});
+
+registerCommand({
+  name: 'buttons',
+  description: 'Show a button selection popup',
+  category: 'io',
+  usage: '/buttons labels=["A","B","C"] message',
+  async handler(args, rawArgs, ctx) {
+    const labelsRaw = getNamedArg(args, 'labels');
+    let buttons: string[] = ['OK'];
+    if (labelsRaw) {
+      try { buttons = JSON.parse(labelsRaw); } catch { /* use default */ }
+    }
+    const message = args.filter(a => a.key !== 'labels' && !a.key).map(a => a.value).join(' ') || rawArgs;
+    const chosen = await ctx.showPopup(message, buttons);
+    return chosen;
+  },
+});

--- a/src/utils/stscript/commands/math.ts
+++ b/src/utils/stscript/commands/math.ts
@@ -1,0 +1,134 @@
+// Math commands: /add, /sub, /mul, /div, /mod, /pow, /sqrt, /abs, /round, /rand, /max, /min
+
+import { registerCommand } from '../registry';
+import type { ParsedArg, ExecutionContext } from '../types';
+
+/** Extract up to 2 numeric operands from unnamed args, using pipe as fallback for first. */
+function getOperands(args: ParsedArg[], ctx: ExecutionContext): [number, number] {
+  const unnamed = args.filter(a => !a.key).map(a => Number(a.value));
+  if (unnamed.length >= 2) return [unnamed[0], unnamed[1]];
+  if (unnamed.length === 1) return [Number(ctx.pipe || 0), unnamed[0]];
+  return [Number(ctx.pipe || 0), 0];
+}
+
+function getSingle(args: ParsedArg[], ctx: ExecutionContext): number {
+  const first = args.find(a => !a.key);
+  return Number(first?.value ?? ctx.pipe ?? 0);
+}
+
+function safeNum(n: number): string {
+  return isFinite(n) ? String(n) : '0';
+}
+
+registerCommand({
+  name: 'add',
+  description: 'Add two numbers',
+  category: 'math',
+  usage: '/add a b',
+  handler(args, _raw, ctx) { const [a, b] = getOperands(args, ctx); return safeNum(a + b); },
+});
+
+registerCommand({
+  name: 'sub',
+  description: 'Subtract two numbers',
+  category: 'math',
+  usage: '/sub a b',
+  handler(args, _raw, ctx) { const [a, b] = getOperands(args, ctx); return safeNum(a - b); },
+});
+
+registerCommand({
+  name: 'mul',
+  description: 'Multiply two numbers',
+  category: 'math',
+  usage: '/mul a b',
+  handler(args, _raw, ctx) { const [a, b] = getOperands(args, ctx); return safeNum(a * b); },
+});
+
+registerCommand({
+  name: 'div',
+  description: 'Divide two numbers',
+  category: 'math',
+  usage: '/div a b',
+  handler(args, _raw, ctx) {
+    const [a, b] = getOperands(args, ctx);
+    return b === 0 ? '0' : safeNum(a / b);
+  },
+});
+
+registerCommand({
+  name: 'mod',
+  description: 'Modulo of two numbers',
+  category: 'math',
+  usage: '/mod a b',
+  handler(args, _raw, ctx) {
+    const [a, b] = getOperands(args, ctx);
+    return b === 0 ? '0' : safeNum(a % b);
+  },
+});
+
+registerCommand({
+  name: 'pow',
+  description: 'Raise to a power',
+  category: 'math',
+  usage: '/pow base exponent',
+  handler(args, _raw, ctx) { const [a, b] = getOperands(args, ctx); return safeNum(Math.pow(a, b)); },
+});
+
+registerCommand({
+  name: 'sqrt',
+  description: 'Square root',
+  category: 'math',
+  usage: '/sqrt number',
+  handler(args, _raw, ctx) { return safeNum(Math.sqrt(getSingle(args, ctx))); },
+});
+
+registerCommand({
+  name: 'abs',
+  description: 'Absolute value',
+  category: 'math',
+  usage: '/abs number',
+  handler(args, _raw, ctx) { return safeNum(Math.abs(getSingle(args, ctx))); },
+});
+
+registerCommand({
+  name: 'round',
+  description: 'Round to nearest integer',
+  category: 'math',
+  usage: '/round number',
+  handler(args, _raw, ctx) { return safeNum(Math.round(getSingle(args, ctx))); },
+});
+
+registerCommand({
+  name: 'rand',
+  description: 'Random number in range',
+  category: 'math',
+  usage: '/rand [min] [max]',
+  handler(args) {
+    const unnamed = args.filter(a => !a.key).map(a => Number(a.value));
+    if (unnamed.length >= 2) {
+      const min = Math.floor(unnamed[0]);
+      const max = Math.floor(unnamed[1]);
+      return String(min + Math.floor(Math.random() * (max - min + 1)));
+    }
+    if (unnamed.length === 1) {
+      return String(Math.floor(Math.random() * Math.floor(unnamed[0])));
+    }
+    return String(Math.random());
+  },
+});
+
+registerCommand({
+  name: 'max',
+  description: 'Maximum of two numbers',
+  category: 'math',
+  usage: '/max a b',
+  handler(args, _raw, ctx) { const [a, b] = getOperands(args, ctx); return safeNum(Math.max(a, b)); },
+});
+
+registerCommand({
+  name: 'min',
+  description: 'Minimum of two numbers',
+  category: 'math',
+  usage: '/min a b',
+  handler(args, _raw, ctx) { const [a, b] = getOperands(args, ctx); return safeNum(Math.min(a, b)); },
+});

--- a/src/utils/stscript/commands/quickreply.ts
+++ b/src/utils/stscript/commands/quickreply.ts
@@ -1,0 +1,177 @@
+// Quick Reply commands: /run, /qr-create, /qr-delete, /qr-update, /qr-get
+
+import { registerCommand } from '../registry';
+import { executeClosure, isClosure, unwrapClosure } from '../executor';
+import type { ParsedArg, ExecutionContext } from '../types';
+
+function getNamedArg(args: ParsedArg[], key: string): string | undefined {
+  return args.find(a => a.key === key)?.value;
+}
+
+function getUnnamedArgs(args: ParsedArg[]): string {
+  return args.filter(a => !a.key).map(a => a.value).join(' ');
+}
+
+async function getQRStore() {
+  const { useQuickReplyStore } = await import('../../../stores/quickReplyStore');
+  return useQuickReplyStore.getState();
+}
+
+registerCommand({
+  name: 'run',
+  description: 'Execute a Quick Reply entry or closure by label',
+  category: 'quickreply',
+  usage: '/run [set.label | {: closure :}]',
+  async handler(args, rawArgs, ctx) {
+    // Check for inline closure first
+    const closureArg = args.find(a => !a.key && isClosure(a.value));
+    if (closureArg) {
+      return await executeClosure(unwrapClosure(closureArg.value), ctx);
+    }
+
+    const label = getUnnamedArgs(args) || rawArgs || ctx.pipe;
+    if (!label) return '';
+
+    const store = await getQRStore();
+    let entry: { message: string } | undefined;
+
+    // Try "setName.entryLabel" format
+    if (label.includes('.')) {
+      const [setName, entryLabel] = label.split('.', 2);
+      const set = store.sets.find(s => s.name.toLowerCase() === setName.toLowerCase());
+      entry = set?.entries.find(e => e.label.toLowerCase() === entryLabel.toLowerCase());
+    }
+
+    // Fall back to searching all sets by label
+    if (!entry) {
+      for (const set of store.sets) {
+        const found = set.entries.find(e => e.label.toLowerCase() === label.toLowerCase());
+        if (found) { entry = found; break; }
+      }
+    }
+
+    if (!entry) {
+      ctx.showToast(`/run: QR entry "${label}" not found`, 'error');
+      return '';
+    }
+
+    // Execute the QR message as a script
+    return await executeClosure(entry.message, ctx);
+  },
+});
+
+registerCommand({
+  name: 'qr-create',
+  description: 'Create a Quick Reply entry',
+  category: 'quickreply',
+  usage: '/qr-create set=SetName label=Label message=Text',
+  async handler(args, _raw, ctx) {
+    const setName = getNamedArg(args, 'set');
+    const label = getNamedArg(args, 'label');
+    const message = getNamedArg(args, 'message') || getUnnamedArgs(args) || ctx.pipe;
+
+    if (!label) { ctx.showToast('/qr-create: label required', 'error'); return ''; }
+
+    const store = await getQRStore();
+    let targetSet = setName
+      ? store.sets.find(s => s.name.toLowerCase() === setName.toLowerCase())
+      : store.sets.find(s => s.id === store.activeSetId);
+
+    if (!targetSet && setName) {
+      store.createSet(setName);
+      targetSet = store.sets.find(s => s.name === setName);
+    }
+
+    if (targetSet) {
+      store.addEntry(targetSet.id, label, message || '');
+      return label;
+    }
+    ctx.showToast('/qr-create: no active QR set', 'error');
+    return '';
+  },
+});
+
+registerCommand({
+  name: 'qr-delete',
+  description: 'Delete a Quick Reply entry',
+  category: 'quickreply',
+  usage: '/qr-delete set=SetName label=Label',
+  async handler(args, _raw, ctx) {
+    const setName = getNamedArg(args, 'set');
+    const label = getNamedArg(args, 'label') || getUnnamedArgs(args);
+
+    if (!label) { ctx.showToast('/qr-delete: label required', 'error'); return ''; }
+
+    const store = await getQRStore();
+    const targetSet = setName
+      ? store.sets.find(s => s.name.toLowerCase() === setName.toLowerCase())
+      : store.sets.find(s => s.id === store.activeSetId);
+
+    if (targetSet) {
+      const entry = targetSet.entries.find(e => e.label.toLowerCase() === label.toLowerCase());
+      if (entry) {
+        store.deleteEntry(targetSet.id, entry.id);
+        return label;
+      }
+    }
+    ctx.showToast(`/qr-delete: "${label}" not found`, 'error');
+    return '';
+  },
+});
+
+registerCommand({
+  name: 'qr-update',
+  description: 'Update a Quick Reply entry',
+  category: 'quickreply',
+  usage: '/qr-update set=SetName label=Label [newlabel=NewLabel] [message=Text]',
+  async handler(args, _raw, ctx) {
+    const setName = getNamedArg(args, 'set');
+    const label = getNamedArg(args, 'label') || getUnnamedArgs(args);
+    const newLabel = getNamedArg(args, 'newlabel');
+    const message = getNamedArg(args, 'message');
+
+    if (!label) { ctx.showToast('/qr-update: label required', 'error'); return ''; }
+
+    const store = await getQRStore();
+    const targetSet = setName
+      ? store.sets.find(s => s.name.toLowerCase() === setName.toLowerCase())
+      : store.sets.find(s => s.id === store.activeSetId);
+
+    if (targetSet) {
+      const entry = targetSet.entries.find(e => e.label.toLowerCase() === label.toLowerCase());
+      if (entry) {
+        const updates: Record<string, string> = {};
+        if (newLabel) updates.label = newLabel;
+        if (message !== undefined) updates.message = message;
+        store.updateEntry(targetSet.id, entry.id, updates);
+        return newLabel || label;
+      }
+    }
+    ctx.showToast(`/qr-update: "${label}" not found`, 'error');
+    return '';
+  },
+});
+
+registerCommand({
+  name: 'qr-get',
+  description: 'Get the message text of a Quick Reply entry',
+  category: 'quickreply',
+  usage: '/qr-get set=SetName label=Label',
+  async handler(args, _raw, ctx) {
+    const setName = getNamedArg(args, 'set');
+    const label = getNamedArg(args, 'label') || getUnnamedArgs(args);
+
+    if (!label) return '';
+
+    const store = await getQRStore();
+    const targetSet = setName
+      ? store.sets.find(s => s.name.toLowerCase() === setName.toLowerCase())
+      : store.sets.find(s => s.id === store.activeSetId);
+
+    if (targetSet) {
+      const entry = targetSet.entries.find(e => e.label.toLowerCase() === label.toLowerCase());
+      if (entry) return entry.message;
+    }
+    return '';
+  },
+});

--- a/src/utils/stscript/commands/system.ts
+++ b/src/utils/stscript/commands/system.ts
@@ -1,0 +1,51 @@
+// System commands: /help
+
+import { registerCommand, getAllCommands } from '../registry';
+import type { CommandCategory } from '../types';
+
+const CATEGORY_LABELS: Record<CommandCategory, string> = {
+  io: 'I/O',
+  variables: 'Variables',
+  flow: 'Flow Control',
+  math: 'Math',
+  generation: 'Generation',
+  messages: 'Messages',
+  character: 'Character',
+  quickreply: 'Quick Reply',
+  prompt: 'Prompt',
+  text: 'Text',
+  ui: 'UI',
+  system: 'System',
+};
+
+registerCommand({
+  name: 'help',
+  description: 'List all available slash commands',
+  category: 'system',
+  usage: '/help [category]',
+  async handler(args, _raw, ctx) {
+    const filter = args.find(a => !a.key)?.value?.toLowerCase();
+    const commands = getAllCommands();
+
+    // Group by category
+    const groups = new Map<CommandCategory, typeof commands>();
+    for (const cmd of commands) {
+      if (filter && cmd.category !== filter && cmd.name !== filter) continue;
+      const list = groups.get(cmd.category) ?? [];
+      list.push(cmd);
+      groups.set(cmd.category, list);
+    }
+
+    const lines: string[] = [];
+    for (const [cat, cmds] of groups) {
+      lines.push(`\n${CATEGORY_LABELS[cat] || cat}:`);
+      for (const cmd of cmds) {
+        lines.push(`  /${cmd.name} — ${cmd.description}`);
+      }
+    }
+
+    const text = lines.join('\n');
+    await ctx.showPopup(text);
+    return text;
+  },
+});

--- a/src/utils/stscript/commands/variables.ts
+++ b/src/utils/stscript/commands/variables.ts
@@ -1,0 +1,253 @@
+// Variable commands: /setvar, /getvar, /addvar, /incvar, /decvar,
+// /setglobalvar, /getglobalvar, /addglobalvar, /incglobalvar, /decglobalvar,
+// /let, /var, /flushvar, /flushglobalvar
+
+import { registerCommand } from '../registry';
+import { resolveVariable } from '../executor';
+import type { ParsedArg, ExecutionContext } from '../types';
+
+function getNamedArg(args: ParsedArg[], key: string): string | undefined {
+  return args.find(a => a.key === key)?.value;
+}
+
+function getFirstUnnamed(args: ParsedArg[]): string {
+  return args.find(a => !a.key)?.value ?? '';
+}
+
+// ───── Chat-scoped variables ─────
+
+registerCommand({
+  name: 'setvar',
+  description: 'Set a chat-scoped variable',
+  category: 'variables',
+  usage: '/setvar key=name [value]',
+  handler(args, _raw, ctx) {
+    const key = getNamedArg(args, 'key');
+    if (!key) { ctx.showToast('/setvar requires key=name', 'error'); return ''; }
+    const value = getFirstUnnamed(args) || ctx.pipe;
+    ctx.chatVariables[key] = value;
+    return value;
+  },
+});
+
+registerCommand({
+  name: 'getvar',
+  description: 'Get a chat-scoped variable',
+  category: 'variables',
+  usage: '/getvar key=name',
+  handler(args, _raw, ctx) {
+    const key = getNamedArg(args, 'key') || getFirstUnnamed(args);
+    if (!key) return '';
+    return ctx.chatVariables[key] ?? '';
+  },
+});
+
+registerCommand({
+  name: 'addvar',
+  description: 'Add a numeric value to a chat variable',
+  category: 'variables',
+  usage: '/addvar key=name [delta]',
+  handler(args, _raw, ctx) {
+    const key = getNamedArg(args, 'key');
+    if (!key) return '';
+    const delta = Number(getFirstUnnamed(args) || ctx.pipe || 0);
+    const current = Number(ctx.chatVariables[key] ?? 0);
+    const result = String((isFinite(current) ? current : 0) + (isFinite(delta) ? delta : 0));
+    ctx.chatVariables[key] = result;
+    return result;
+  },
+});
+
+registerCommand({
+  name: 'incvar',
+  description: 'Increment a chat variable by 1',
+  category: 'variables',
+  usage: '/incvar key=name',
+  handler(args, _raw, ctx) {
+    const key = getNamedArg(args, 'key') || getFirstUnnamed(args);
+    if (!key) return '';
+    const current = Number(ctx.chatVariables[key] ?? 0);
+    const result = String((isFinite(current) ? current : 0) + 1);
+    ctx.chatVariables[key] = result;
+    return result;
+  },
+});
+
+registerCommand({
+  name: 'decvar',
+  description: 'Decrement a chat variable by 1',
+  category: 'variables',
+  usage: '/decvar key=name',
+  handler(args, _raw, ctx) {
+    const key = getNamedArg(args, 'key') || getFirstUnnamed(args);
+    if (!key) return '';
+    const current = Number(ctx.chatVariables[key] ?? 0);
+    const result = String((isFinite(current) ? current : 0) - 1);
+    ctx.chatVariables[key] = result;
+    return result;
+  },
+});
+
+registerCommand({
+  name: 'flushvar',
+  description: 'Clear all chat-scoped variables',
+  category: 'variables',
+  usage: '/flushvar',
+  handler(_args, _raw, ctx) {
+    for (const k of Object.keys(ctx.chatVariables)) {
+      delete ctx.chatVariables[k];
+    }
+    return '';
+  },
+});
+
+// ───── Global variables ─────
+
+registerCommand({
+  name: 'setglobalvar',
+  description: 'Set a global variable (cross-chat)',
+  category: 'variables',
+  usage: '/setglobalvar key=name [value]',
+  handler(args, _raw, ctx) {
+    const key = getNamedArg(args, 'key');
+    if (!key) { ctx.showToast('/setglobalvar requires key=name', 'error'); return ''; }
+    const value = getFirstUnnamed(args) || ctx.pipe;
+    ctx.globalVariables[key] = value;
+    return value;
+  },
+});
+
+registerCommand({
+  name: 'getglobalvar',
+  description: 'Get a global variable',
+  category: 'variables',
+  usage: '/getglobalvar key=name',
+  handler(args, _raw, ctx) {
+    const key = getNamedArg(args, 'key') || getFirstUnnamed(args);
+    if (!key) return '';
+    return ctx.globalVariables[key] ?? '';
+  },
+});
+
+registerCommand({
+  name: 'addglobalvar',
+  description: 'Add a numeric value to a global variable',
+  category: 'variables',
+  usage: '/addglobalvar key=name [delta]',
+  handler(args, _raw, ctx) {
+    const key = getNamedArg(args, 'key');
+    if (!key) return '';
+    const delta = Number(getFirstUnnamed(args) || ctx.pipe || 0);
+    const current = Number(ctx.globalVariables[key] ?? 0);
+    const result = String((isFinite(current) ? current : 0) + (isFinite(delta) ? delta : 0));
+    ctx.globalVariables[key] = result;
+    return result;
+  },
+});
+
+registerCommand({
+  name: 'incglobalvar',
+  description: 'Increment a global variable by 1',
+  category: 'variables',
+  usage: '/incglobalvar key=name',
+  handler(args, _raw, ctx) {
+    const key = getNamedArg(args, 'key') || getFirstUnnamed(args);
+    if (!key) return '';
+    const current = Number(ctx.globalVariables[key] ?? 0);
+    const result = String((isFinite(current) ? current : 0) + 1);
+    ctx.globalVariables[key] = result;
+    return result;
+  },
+});
+
+registerCommand({
+  name: 'decglobalvar',
+  description: 'Decrement a global variable by 1',
+  category: 'variables',
+  usage: '/decglobalvar key=name',
+  handler(args, _raw, ctx) {
+    const key = getNamedArg(args, 'key') || getFirstUnnamed(args);
+    if (!key) return '';
+    const current = Number(ctx.globalVariables[key] ?? 0);
+    const result = String((isFinite(current) ? current : 0) - 1);
+    ctx.globalVariables[key] = result;
+    return result;
+  },
+});
+
+registerCommand({
+  name: 'flushglobalvar',
+  description: 'Clear all global variables',
+  category: 'variables',
+  usage: '/flushglobalvar',
+  handler(_args, _raw, ctx) {
+    for (const k of Object.keys(ctx.globalVariables)) {
+      delete ctx.globalVariables[k];
+    }
+    return '';
+  },
+});
+
+// ───── Scoped variables (closures) ─────
+
+registerCommand({
+  name: 'let',
+  description: 'Set a variable in the current scope',
+  category: 'variables',
+  usage: '/let name=varname [value]',
+  handler(args, _raw, ctx) {
+    const name = getNamedArg(args, 'name') || getNamedArg(args, 'key');
+    if (!name) {
+      // Alternative syntax: /let varname value
+      const unnamed = args.filter(a => !a.key);
+      if (unnamed.length >= 1) {
+        const varName = unnamed[0].value;
+        const value = unnamed.length > 1 ? unnamed.slice(1).map(a => a.value).join(' ') : ctx.pipe;
+        ctx.scope.locals[varName] = value;
+        return value;
+      }
+      return '';
+    }
+    const value = getFirstUnnamed(args) || ctx.pipe;
+    ctx.scope.locals[name] = value;
+    return value;
+  },
+});
+
+registerCommand({
+  name: 'var',
+  description: 'Set a variable in the parent scope',
+  category: 'variables',
+  usage: '/var name=varname [value]',
+  handler(args, _raw, ctx) {
+    const target = ctx.scope.parent ?? ctx.scope;
+    const name = getNamedArg(args, 'name') || getNamedArg(args, 'key');
+    if (!name) {
+      const unnamed = args.filter(a => !a.key);
+      if (unnamed.length >= 1) {
+        const varName = unnamed[0].value;
+        const value = unnamed.length > 1 ? unnamed.slice(1).map(a => a.value).join(' ') : ctx.pipe;
+        target.locals[varName] = value;
+        return value;
+      }
+      return '';
+    }
+    const value = getFirstUnnamed(args) || ctx.pipe;
+    target.locals[name] = value;
+    return value;
+  },
+});
+
+// ───── Resolve scoped variable by name (for /run closures) ─────
+
+registerCommand({
+  name: 'getscoped',
+  description: 'Get a scoped variable from the scope chain',
+  category: 'variables',
+  usage: '/getscoped name',
+  handler(args, _raw, ctx) {
+    const name = getFirstUnnamed(args);
+    if (!name) return '';
+    return resolveVariable(name, ctx.scope) ?? '';
+  },
+});

--- a/src/utils/stscript/executor.ts
+++ b/src/utils/stscript/executor.ts
@@ -1,0 +1,269 @@
+// STscript executor — runs parsed pipelines with scope stack,
+// pipe threading, macro expansion, and control flow.
+
+import type {
+  ParsedPipeline,
+  ParsedCommand,
+  ParsedArg,
+  ExecutionContext,
+  Scope,
+  AbortReason,
+} from './types';
+import { parsePipeline } from './parser';
+import { getCommand } from './registry';
+import { processMacros, type MacroContext } from '../macros';
+import { getUICallbacks } from './uiCallbacks';
+import { useChatStore } from '../../stores/chatStore';
+
+const MAX_LOOP_ITERATIONS = 100;
+const MAX_RECURSION_DEPTH = 10;
+const GLOBAL_VARS_KEY = 'stm:global-vars';
+
+// ───── Global variable persistence ─────
+
+function loadGlobalVars(): Record<string, string> {
+  try {
+    const stored = localStorage.getItem(GLOBAL_VARS_KEY);
+    if (!stored) return {};
+    const parsed = JSON.parse(stored);
+    return (parsed && typeof parsed === 'object') ? parsed : {};
+  } catch { return {}; }
+}
+
+function saveGlobalVars(vars: Record<string, string>): void {
+  try {
+    localStorage.setItem(GLOBAL_VARS_KEY, JSON.stringify(vars));
+  } catch { /* ignore quota */ }
+}
+
+// ───── Scope helpers ─────
+
+export function createScope(parent: Scope | null = null): Scope {
+  return { locals: {}, parent };
+}
+
+/** Walk scope chain upward to find a variable. */
+export function resolveVariable(name: string, scope: Scope): string | undefined {
+  let s: Scope | null = scope;
+  while (s) {
+    if (name in s.locals) return s.locals[name];
+    s = s.parent;
+  }
+  return undefined;
+}
+
+/** Collect all scope variables (for {{var::name}} macro expansion). */
+function collectScopeVars(scope: Scope): Record<string, string> {
+  const result: Record<string, string> = {};
+  const chain: Scope[] = [];
+  let s: Scope | null = scope;
+  while (s) { chain.push(s); s = s.parent; }
+  // Walk from root to leaf so closer scopes shadow ancestors
+  for (let i = chain.length - 1; i >= 0; i--) {
+    Object.assign(result, chain[i].locals);
+  }
+  return result;
+}
+
+// ───── Macro expansion for STscript ─────
+
+function buildMacroContext(ctx: ExecutionContext): MacroContext {
+  let lastMessage = '';
+  let lastMessageId = '';
+  try {
+    const messages = useChatStore.getState().messages;
+    if (messages.length > 0) {
+      const last = messages[messages.length - 1];
+      lastMessage = last.content || '';
+      lastMessageId = String(messages.length - 1);
+    }
+  } catch { /* not available */ }
+
+  return {
+    variables: ctx.chatVariables,
+    extra: {
+      pipe: ctx.pipe,
+      timesIndex: String(ctx.timesIndex),
+      input: ctx.originalInput,
+      lastMessageId,
+      lastMessage,
+      __scopeVars: JSON.stringify(collectScopeVars(ctx.scope)),
+    },
+  };
+}
+
+function expandMacros(text: string, ctx: ExecutionContext): string {
+  if (!text) return text;
+  return processMacros(text, buildMacroContext(ctx));
+}
+
+// ───── Closure helpers ─────
+
+/** Check if a value is a closure literal {: ... :} */
+export function isClosure(value: string): boolean {
+  const trimmed = value.trim();
+  return trimmed.startsWith('{:') && trimmed.endsWith(':}');
+}
+
+/** Strip {: :} delimiters from a closure literal. */
+export function unwrapClosure(value: string): string {
+  const trimmed = value.trim();
+  return trimmed.slice(2, -2).trim();
+}
+
+/** Execute a closure string in a child scope. */
+export async function executeClosure(
+  source: string,
+  ctx: ExecutionContext,
+): Promise<string> {
+  if (ctx.recursionDepth >= MAX_RECURSION_DEPTH) {
+    ctx.showToast('Max recursion depth exceeded', 'error');
+    ctx.abortSignal = { type: 'error', message: 'Max recursion depth exceeded' };
+    return '';
+  }
+
+  const childScope = createScope(ctx.scope);
+  const childCtx: ExecutionContext = {
+    ...ctx,
+    scope: childScope,
+    recursionDepth: ctx.recursionDepth + 1,
+    abortSignal: null,
+  };
+
+  const pipeline = parsePipeline(source);
+  const result = await executePipeline(pipeline, childCtx);
+
+  // Propagate abort/return signals up (but not break — break stops at the loop level)
+  if (childCtx.abortSignal) {
+    if (childCtx.abortSignal.type === 'abort' || childCtx.abortSignal.type === 'error') {
+      ctx.abortSignal = childCtx.abortSignal;
+    } else if (childCtx.abortSignal.type === 'return') {
+      return childCtx.abortSignal.value;
+    } else if (childCtx.abortSignal.type === 'break') {
+      ctx.abortSignal = childCtx.abortSignal;
+      return childCtx.abortSignal.value;
+    }
+  }
+
+  // Sync variables back
+  ctx.chatVariables = childCtx.chatVariables;
+  ctx.globalVariables = childCtx.globalVariables;
+
+  return result;
+}
+
+// ───── Pipeline execution ─────
+
+export async function executePipeline(
+  pipeline: ParsedPipeline,
+  ctx: ExecutionContext,
+): Promise<string> {
+  let pipeValue = ctx.pipe;
+
+  for (let i = 0; i < pipeline.commands.length; i++) {
+    if (ctx.abortSignal) break;
+
+    const cmd = pipeline.commands[i];
+
+    // Expand macros in all arg values and rawArgs
+    const expandedArgs: ParsedArg[] = cmd.args.map(a => ({
+      key: a.key,
+      value: isClosure(a.value) ? a.value : expandMacros(a.value, ctx),
+    }));
+    const expandedRawArgs = expandMacros(cmd.rawArgs, ctx);
+
+    // Auto-pipe injection: if not breakPipe and not first command,
+    // prepend pipe value to unnamed args (unless rawArgs references {{pipe}})
+    if (i > 0 && !cmd.breakPipe) {
+      const hasPipeRef = cmd.rawArgs.toLowerCase().includes('{{pipe}}');
+      if (!hasPipeRef && pipeValue) {
+        expandedArgs.unshift({ value: pipeValue });
+      }
+    }
+
+    // Look up command handler
+    const def = getCommand(cmd.name);
+    if (!def) {
+      ctx.showToast(`Unknown command: /${cmd.name}`, 'error');
+      pipeValue = '';
+      ctx.pipe = pipeValue;
+      continue;
+    }
+
+    // Execute handler
+    try {
+      const result = await def.handler(expandedArgs, expandedRawArgs, ctx);
+      pipeValue = result;
+      ctx.pipe = pipeValue;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      ctx.showToast(`Error in /${cmd.name}: ${msg}`, 'error');
+      ctx.abortSignal = { type: 'error', message: msg };
+      break;
+    }
+  }
+
+  return pipeValue;
+}
+
+// ───── Top-level entry point ─────
+
+export async function executeSlashCommand(
+  input: string,
+  ctx: ExecutionContext,
+): Promise<string> {
+  const pipeline = parsePipeline(input);
+  if (pipeline.commands.length === 0) return '';
+
+  const result = await executePipeline(pipeline, ctx);
+
+  // Persist variables
+  try {
+    const state = useChatStore.getState();
+    const chatFile = state.currentChatFile;
+    if (chatFile) {
+      state.setChatVariables(chatFile, ctx.chatVariables);
+    }
+  } catch { /* not available */ }
+  saveGlobalVars(ctx.globalVariables);
+
+  return result;
+}
+
+// ───── Context factory ─────
+
+export function buildExecutionContext(
+  overrides?: Partial<ExecutionContext>,
+): ExecutionContext {
+  const cbs = getUICallbacks();
+
+  // Load current chat variables
+  let chatVariables: Record<string, string> = {};
+  try {
+    const state = useChatStore.getState();
+    const chatFile = state.currentChatFile;
+    if (chatFile) {
+      chatVariables = { ...state.getChatVariables(chatFile) };
+    }
+  } catch { /* not available */ }
+
+  return {
+    pipe: '',
+    scope: createScope(),
+    chatVariables,
+    globalVariables: loadGlobalVars(),
+    timesIndex: -1,
+    originalInput: '',
+    abortSignal: null,
+    recursionDepth: 0,
+    showToast: cbs.showToast,
+    setInputText: cbs.setInputText,
+    showPopup: cbs.showPopup,
+    showInputPrompt: cbs.showInputPrompt,
+    navigate: cbs.navigate,
+    ...overrides,
+  };
+}
+
+// Re-export for loop use in commands
+export { MAX_LOOP_ITERATIONS, MAX_RECURSION_DEPTH };

--- a/src/utils/stscript/index.ts
+++ b/src/utils/stscript/index.ts
@@ -1,0 +1,17 @@
+// STscript barrel — imports all command modules to trigger registration,
+// then re-exports the public API.
+
+import './commands/io';
+import './commands/variables';
+import './commands/flow';
+import './commands/math';
+import './commands/generation';
+import './commands/chat';
+import './commands/character';
+import './commands/quickreply';
+import './commands/system';
+
+export { executeSlashCommand, buildExecutionContext } from './executor';
+export { getAllCommands, getCommand } from './registry';
+export { registerUICallbacks } from './uiCallbacks';
+export type { ExecutionContext, CommandDefinition } from './types';

--- a/src/utils/stscript/parser.ts
+++ b/src/utils/stscript/parser.ts
@@ -1,0 +1,232 @@
+// STscript parser — tokenizes raw input into a pipeline of commands,
+// handling pipes (|), double-pipes (||), closures ({: :}), quoted strings,
+// and named/unnamed arguments.
+
+import type { ParsedArg, ParsedCommand, ParsedPipeline } from './types';
+
+// ───── Phase A: Split on pipes ─────
+
+interface PipeSegment {
+  text: string;
+  breakPipe: boolean;  // preceded by ||
+}
+
+/**
+ * Walk the input char-by-char, splitting on | while respecting:
+ * - Closure delimiters {: and :} (track nesting depth)
+ * - Quoted strings "..." (no split inside)
+ * - Escaped pipe \| (literal, no split)
+ * - Double-pipe || (break-pipe marker)
+ */
+function splitPipeline(input: string): PipeSegment[] {
+  const segments: PipeSegment[] = [];
+  let current = '';
+  let closureDepth = 0;
+  let inQuote = false;
+  let breakPipe = false;
+
+  for (let i = 0; i < input.length; i++) {
+    const ch = input[i];
+    const next = input[i + 1];
+
+    // Escape: \| or \" etc.
+    if (ch === '\\' && i + 1 < input.length) {
+      current += ch + next;
+      i++;
+      continue;
+    }
+
+    // Quoted strings
+    if (ch === '"' && closureDepth === 0) {
+      inQuote = !inQuote;
+      current += ch;
+      continue;
+    }
+
+    if (inQuote) {
+      current += ch;
+      continue;
+    }
+
+    // Closure open: {:
+    if (ch === '{' && next === ':') {
+      closureDepth++;
+      current += '{:';
+      i++;
+      continue;
+    }
+
+    // Closure close: :}
+    if (ch === ':' && next === '}' && closureDepth > 0) {
+      closureDepth--;
+      current += ':}';
+      i++;
+      continue;
+    }
+
+    // Pipe (only at top level, not inside closures)
+    if (ch === '|' && closureDepth === 0) {
+      // Double pipe?
+      if (next === '|') {
+        segments.push({ text: current, breakPipe });
+        current = '';
+        breakPipe = true;
+        i++; // skip second |
+        continue;
+      }
+      segments.push({ text: current, breakPipe });
+      current = '';
+      breakPipe = false;
+      continue;
+    }
+
+    current += ch;
+  }
+
+  // Last segment
+  if (current.trim()) {
+    segments.push({ text: current, breakPipe });
+  }
+
+  return segments;
+}
+
+// ───── Phase B: Parse a single command segment ─────
+
+/**
+ * Parse arguments from the text after the command name.
+ * Handles: key=value, key="quoted value", bare tokens, closure {: ... :} literals.
+ */
+function parseArgs(text: string): ParsedArg[] {
+  const args: ParsedArg[] = [];
+  let i = 0;
+
+  while (i < text.length) {
+    // Skip whitespace
+    if (text[i] === ' ' || text[i] === '\t') {
+      i++;
+      continue;
+    }
+
+    // Closure literal {: ... :}
+    if (text[i] === '{' && text[i + 1] === ':') {
+      let depth = 1;
+      let j = i + 2;
+      while (j < text.length && depth > 0) {
+        if (text[j] === '{' && text[j + 1] === ':') { depth++; j += 2; continue; }
+        if (text[j] === ':' && text[j + 1] === '}') { depth--; j += 2; continue; }
+        j++;
+      }
+      args.push({ value: text.slice(i, j) });
+      i = j;
+      continue;
+    }
+
+    // Quoted string
+    if (text[i] === '"') {
+      let j = i + 1;
+      let val = '';
+      while (j < text.length && text[j] !== '"') {
+        if (text[j] === '\\' && j + 1 < text.length) {
+          val += text[j + 1];
+          j += 2;
+          continue;
+        }
+        val += text[j];
+        j++;
+      }
+      if (j < text.length) j++; // skip closing quote
+
+      // Check if this was part of a key="value" pattern
+      // Look back to see if there's a key= preceding
+      if (args.length > 0) {
+        const last = args[args.length - 1];
+        if (last.key !== undefined && last.value === '') {
+          last.value = val;
+          i = j;
+          continue;
+        }
+      }
+      args.push({ value: val });
+      i = j;
+      continue;
+    }
+
+    // Token (bare word, possibly key=value)
+    let j = i;
+    while (j < text.length && text[j] !== ' ' && text[j] !== '\t') {
+      // Don't break on = inside quoted values
+      if (text[j] === '"') {
+        // jump to end of quote
+        j++;
+        while (j < text.length && text[j] !== '"') {
+          if (text[j] === '\\') j++;
+          j++;
+        }
+        if (j < text.length) j++; // skip closing "
+        continue;
+      }
+      if (text[j] === '{' && text[j + 1] === ':') break; // closure starts, separate token
+      j++;
+    }
+
+    const token = text.slice(i, j);
+    i = j;
+
+    // Check for key=value
+    const eqIdx = token.indexOf('=');
+    if (eqIdx > 0) {
+      const key = token.slice(0, eqIdx);
+      let value = token.slice(eqIdx + 1);
+      // Strip surrounding quotes from value if present
+      if (value.startsWith('"') && value.endsWith('"')) {
+        value = value.slice(1, -1);
+      }
+      args.push({ key, value });
+    } else {
+      args.push({ value: token });
+    }
+  }
+
+  return args;
+}
+
+/**
+ * Parse a single pipe segment into a ParsedCommand.
+ * If the segment doesn't start with /, treat it as /pass.
+ */
+function parseCommand(segment: string, breakPipe: boolean): ParsedCommand {
+  const trimmed = segment.trim();
+
+  if (!trimmed.startsWith('/')) {
+    // Bare text segment in pipeline → treat as /pass
+    return {
+      name: 'pass',
+      args: [{ value: trimmed }],
+      rawArgs: trimmed,
+      breakPipe,
+    };
+  }
+
+  // Find command name (text between / and first whitespace)
+  let nameEnd = 1;
+  while (nameEnd < trimmed.length && trimmed[nameEnd] !== ' ' && trimmed[nameEnd] !== '\t') {
+    nameEnd++;
+  }
+  const name = trimmed.slice(1, nameEnd).toLowerCase();
+  const rawArgs = trimmed.slice(nameEnd).trim();
+  const args = parseArgs(rawArgs);
+
+  return { name, args, rawArgs, breakPipe };
+}
+
+// ───── Top-level API ─────
+
+/** Parse a full slash command input into a pipeline of commands. */
+export function parsePipeline(input: string): ParsedPipeline {
+  const segments = splitPipeline(input);
+  const commands = segments
+    .filter(s => s.text.trim())
+    .map(s => parseCommand(s.text, s.breakPipe));
+  return { commands };
+}

--- a/src/utils/stscript/registry.ts
+++ b/src/utils/stscript/registry.ts
@@ -1,0 +1,29 @@
+// Command registry — singleton map of command names to handlers.
+
+import type { CommandDefinition, CommandHandler } from './types';
+
+const commands = new Map<string, CommandDefinition>();
+
+export function registerCommand(def: CommandDefinition): void {
+  commands.set(def.name, def);
+  for (const alias of def.aliases ?? []) {
+    commands.set(alias, def);
+  }
+}
+
+export function getCommand(name: string): CommandDefinition | undefined {
+  return commands.get(name.toLowerCase());
+}
+
+/** All unique commands (deduped across aliases), sorted by name. */
+export function getAllCommands(): CommandDefinition[] {
+  const seen = new Set<CommandHandler>();
+  const result: CommandDefinition[] = [];
+  for (const def of commands.values()) {
+    if (!seen.has(def.handler)) {
+      seen.add(def.handler);
+      result.push(def);
+    }
+  }
+  return result.sort((a, b) => a.name.localeCompare(b.name));
+}

--- a/src/utils/stscript/types.ts
+++ b/src/utils/stscript/types.ts
@@ -1,0 +1,91 @@
+// STscript type definitions — shared across parser, executor, registry, and commands.
+
+// ───── Parsed Representation ─────
+
+/** A single parsed argument — either named (key=value) or positional. */
+export interface ParsedArg {
+  key?: string;
+  value: string;
+}
+
+/** A single command invocation within a pipeline. */
+export interface ParsedCommand {
+  name: string;              // e.g. "echo", "setvar" (no leading /)
+  args: ParsedArg[];         // ordered list of parsed arguments
+  rawArgs: string;           // raw argument string after command name
+  /** Preceded by || (double pipe) — pipe value NOT auto-injected. */
+  breakPipe: boolean;
+}
+
+/** A complete parsed pipeline — one or more commands separated by | */
+export interface ParsedPipeline {
+  commands: ParsedCommand[];
+}
+
+// ───── Execution ─────
+
+export type AbortReason =
+  | { type: 'break'; value: string }
+  | { type: 'return'; value: string }
+  | { type: 'abort'; reason: string }
+  | { type: 'error'; message: string };
+
+/** A variable scope — /let creates entries here; scopes nest for closures. */
+export interface Scope {
+  locals: Record<string, string>;
+  parent: Scope | null;
+}
+
+export type ToastVariant = 'info' | 'warning' | 'error' | 'success';
+
+/** Mutable execution state threaded through every command. */
+export interface ExecutionContext {
+  pipe: string;
+  scope: Scope;
+  chatVariables: Record<string, string>;
+  globalVariables: Record<string, string>;
+  timesIndex: number;
+  originalInput: string;
+  abortSignal: AbortReason | null;
+  recursionDepth: number;
+
+  // UI callbacks (registered by ChatView)
+  showToast: (message: string, variant?: ToastVariant) => void;
+  setInputText: (text: string) => void;
+  showPopup: (message: string, buttons?: string[]) => Promise<string>;
+  showInputPrompt: (message: string, defaultValue?: string) => Promise<string | null>;
+
+  // Navigation
+  navigate: (path: string) => void;
+}
+
+// ───── Command Registration ─────
+
+export type CommandHandler = (
+  args: ParsedArg[],
+  rawArgs: string,
+  ctx: ExecutionContext,
+) => Promise<string> | string;
+
+export type CommandCategory =
+  | 'io'
+  | 'variables'
+  | 'flow'
+  | 'math'
+  | 'generation'
+  | 'messages'
+  | 'character'
+  | 'quickreply'
+  | 'prompt'
+  | 'text'
+  | 'ui'
+  | 'system';
+
+export interface CommandDefinition {
+  name: string;
+  aliases?: string[];
+  description: string;
+  category: CommandCategory;
+  usage?: string;
+  handler: CommandHandler;
+}

--- a/src/utils/stscript/uiCallbacks.ts
+++ b/src/utils/stscript/uiCallbacks.ts
@@ -1,0 +1,33 @@
+// Module-level callback bridge for STscript UI operations.
+// ChatView registers its callbacks on mount; the executor reads them.
+
+import type { ToastVariant } from './types';
+
+export interface UICallbacks {
+  showToast: (message: string, variant?: ToastVariant) => void;
+  setInputText: (text: string) => void;
+  showPopup: (message: string, buttons?: string[]) => Promise<string>;
+  showInputPrompt: (message: string, defaultValue?: string) => Promise<string | null>;
+  navigate: (path: string) => void;
+}
+
+const noop = () => {};
+const noopAsync = async () => '' as string;
+const noopAsyncNull = async () => null as string | null;
+const noopNavigate = () => {};
+
+let callbacks: UICallbacks = {
+  showToast: noop,
+  setInputText: noop,
+  showPopup: noopAsync,
+  showInputPrompt: noopAsyncNull,
+  navigate: noopNavigate,
+};
+
+export function registerUICallbacks(cbs: Partial<UICallbacks>): void {
+  callbacks = { ...callbacks, ...cbs };
+}
+
+export function getUICallbacks(): UICallbacks {
+  return callbacks;
+}


### PR DESCRIPTION
## Summary
- Full STscript parser with pipes (`|`, `||`), closures (`{: :}`), quoted strings, named/unnamed args
- Executor with scope stack, pipe value threading, macro expansion (`{{pipe}}`, `{{timesIndex}}`, `{{var::}}`), and flow control (100 iteration / 10 recursion caps)
- 40+ commands across 9 modules: I/O, variables (chat + global + scoped), flow control, math, generation, messages, character, Quick Reply, system
- Autocomplete dropdown in chat input — fuzzy matches command names with descriptions and category badges
- Toast notification system for `/echo` output and error messages
- Popup/input/buttons modal for interactive STscript commands
- QR integration for free — entries starting with `/` auto-execute via the chatStore intercept
- Global variables persisted in `stm:global-vars` localStorage (separate from chat-scoped vars)

## Test plan
- [ ] Type `/echo hello` → toast appears with "hello"
- [ ] Type `/pass hello | /echo` → toast "hello" (pipe threading)
- [ ] Type `/setvar key=x 42 | /getvar key=x | /echo {{pipe}}` → toast "42"
- [ ] Type `/times 3 {: /echo {{timesIndex}} :}` → toasts 0, 1, 2
- [ ] Type `/if left=5 rule=gt right=3 {: /echo bigger :}` → toast "bigger"
- [ ] Type `/add 5 3 | /echo` → toast "8"
- [ ] Type `/ec` → autocomplete dropdown shows `/echo`
- [ ] Create QR with `/echo QR works` → long-press → toast "QR works"
- [ ] Type `/help` → popup listing all commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)