### PR TITLE
feat: Phase 10.3 — text completion API support

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -474,7 +474,9 @@ export const api = {
     model?: string,
     signal?: AbortSignal,
     generationOptions?: GenerationOptions,
-    images?: GenerationImage[]
+    images?: GenerationImage[],
+    /** Phase 10.3: when true, send as text completion (single prompt string). */
+    textCompletionMode?: boolean,
   ): Promise<ReadableStream<Uint8Array> | null> {
     const token = await getCsrfToken();
 
@@ -514,13 +516,28 @@ export const api = {
     // Build request body with optional sampler params.
     // Unknown fields are ignored by most providers.
     const body: Record<string, unknown> = {
-      messages: messagesToSend,
       stream: true,
       max_tokens: generationOptions?.maxTokens ?? 1024,
       temperature: generationOptions?.temperature ?? 0.9,
-      chat_completion_source: provider || 'openai',
       model: model || 'gpt-4o',
     };
+
+    // Phase 10.3: text completion mode sends a single prompt string
+    // to a separate backend endpoint.
+    let endpoint: string;
+    if (textCompletionMode) {
+      // In text-completion mode, instruct mode has already flattened
+      // messages into a single user message containing the full prompt.
+      const prompt = messages.length === 1
+        ? messages[0].content
+        : messages.map(m => m.content).join('\n');
+      body.prompt = prompt;
+      endpoint = '/api/backends/text-completions/generate';
+    } else {
+      body.messages = messagesToSend;
+      body.chat_completion_source = provider || 'openai';
+      endpoint = '/api/backends/chat-completions/generate';
+    }
 
     if (generationOptions) {
       if (generationOptions.topP !== undefined) body.top_p = generationOptions.topP;
@@ -544,7 +561,7 @@ export const api = {
       }
     }
 
-    const response = await fetch('/api/backends/chat-completions/generate', {
+    const response = await fetch(endpoint, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/src/components/settings/GenerationSettingsPage.tsx
+++ b/src/components/settings/GenerationSettingsPage.tsx
@@ -541,6 +541,42 @@ export function GenerationSettingsPage() {
                 Added on top of the template's built-in stop strings.
               </p>
             </div>
+
+            {/* Phase 10.3: Completion Mode */}
+            <div>
+              <label className="block text-sm font-medium text-[var(--color-text-secondary)] mb-1.5">
+                Completion Mode
+              </label>
+              <div className="grid grid-cols-2 gap-2">
+                {([
+                  { value: 'chat' as const, label: 'Chat' },
+                  { value: 'text' as const, label: 'Text' },
+                ]).map((opt) => (
+                  <button
+                    key={opt.value}
+                    onClick={() => {
+                      setInstruct({ completionMode: opt.value });
+                      // Text mode requires instruct formatting
+                      if (opt.value === 'text' && !instruct.enabled) {
+                        setInstruct({ enabled: true, completionMode: opt.value });
+                      }
+                    }}
+                    className={`p-2.5 rounded-lg text-center text-xs font-medium transition-all ${
+                      instruct.completionMode === opt.value
+                        ? 'bg-[var(--color-primary)] text-white'
+                        : 'bg-[var(--color-bg-tertiary)] text-[var(--color-text-secondary)]'
+                    }`}
+                  >
+                    {opt.label}
+                  </button>
+                ))}
+              </div>
+              <p className="mt-1.5 text-xs text-[var(--color-text-secondary)]">
+                {instruct.completionMode === 'text'
+                  ? 'Sends a single prompt string to the text completion endpoint. Best for local models (llama.cpp, KoboldCpp).'
+                  : 'Sends a messages array to the chat completion endpoint. Works with all cloud providers.'}
+              </p>
+            </div>
           </section>
         )}
       </div>

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -1227,7 +1227,8 @@ async function generateGroupTurn(
     model,
     abortController.signal,
     getGenerationOptions(),
-    images
+    images,
+    isTextCompletionMode()
   );
 
   if (!stream) return false;
@@ -1333,18 +1334,23 @@ function getGenerationOptions(): GenerationOptions {
 }
 
 // Helper: optionally convert message array into a single instruct-mode message
-// when instruct mode is enabled. The backend still expects chat-completion-style
-// messages, so we wrap the formatted prompt as a single user message.
+// when instruct mode is enabled (or text completion mode requires it).
 function maybeApplyInstructMode(
   messages: { role: 'user' | 'assistant' | 'system'; content: string }[]
 ): { role: 'user' | 'assistant' | 'system'; content: string }[] {
   const { instruct } = useGenerationStore.getState();
-  if (!instruct.enabled) return messages;
+  // Text completion mode implicitly requires instruct formatting
+  if (!instruct.enabled && instruct.completionMode !== 'text') return messages;
   const tpl = getInstructTemplate(instruct.templateId);
   if (!tpl) return messages;
 
   const prompt = formatInstructPrompt(messages, tpl);
   return [{ role: 'user', content: prompt }];
+}
+
+/** Phase 10.3: returns true when the user has selected text completion mode. */
+function isTextCompletionMode(): boolean {
+  return useGenerationStore.getState().instruct.completionMode === 'text';
 }
 
 // Helper: save chat to backend
@@ -2054,7 +2060,8 @@ export const useChatStore = create<ChatState>((set, get) => ({
         model,
         abortController.signal,
         getGenerationOptions(),
-        imagesFromLastUserMessage(contextMessages, provider, model)
+        imagesFromLastUserMessage(contextMessages, provider, model),
+        isTextCompletionMode()
       );
       if (!stream) return;
 
@@ -2143,7 +2150,8 @@ export const useChatStore = create<ChatState>((set, get) => ({
         model,
         abortController.signal,
         getGenerationOptions(),
-        imagesFromLastUserMessage(messages, provider, model)
+        imagesFromLastUserMessage(messages, provider, model),
+        isTextCompletionMode()
       );
       if (!stream) return;
 
@@ -2206,7 +2214,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
 
       const { provider, model } = getProviderAndModel();
       const finalContext = maybeApplyInstructMode(context);
-      const stream = await api.generateMessage(finalContext, character.name, provider, model, abortController.signal, getGenerationOptions());
+      const stream = await api.generateMessage(finalContext, character.name, provider, model, abortController.signal, getGenerationOptions(), undefined, isTextCompletionMode());
       if (!stream) return '';
 
       let responseText = '';
@@ -2352,7 +2360,8 @@ export const useChatStore = create<ChatState>((set, get) => ({
         model,
         abortController.signal,
         getGenerationOptions(),
-        resolveImagesForSend(attachedImages)
+        resolveImagesForSend(attachedImages),
+        isTextCompletionMode()
       );
 
       if (stream) {
@@ -2685,7 +2694,8 @@ export const useChatStore = create<ChatState>((set, get) => ({
         model,
         abortController.signal,
         getGenerationOptions(),
-        imagesFromLastUserMessage(updatedMessages, provider, model)
+        imagesFromLastUserMessage(updatedMessages, provider, model),
+        isTextCompletionMode()
       );
 
       if (stream) {

--- a/src/stores/generationStore.ts
+++ b/src/stores/generationStore.ts
@@ -74,17 +74,22 @@ export const DEFAULT_CONTEXT_CONFIG: ContextConfig = {
   messageCount: 20,
 };
 
+export type CompletionMode = 'chat' | 'text';
+
 export interface InstructConfig {
   enabled: boolean;
   templateId: string;
   /** Extra stop strings applied on top of template defaults. */
   extraStopStrings: string[];
+  /** Phase 10.3: 'chat' sends messages array, 'text' sends a single prompt string. */
+  completionMode: CompletionMode;
 }
 
 export const DEFAULT_INSTRUCT_CONFIG: InstructConfig = {
   enabled: false,
   templateId: 'chatml',
   extraStopStrings: [],
+  completionMode: 'chat',
 };
 
 /** Phase 9.1: stable IDs for every reorderable prompt section. */


### PR DESCRIPTION
Add completionMode setting ('chat' | 'text') to instruct config. When text mode is selected, requests are sent as { prompt: "..." } to the /api/backends/text-completions/generate endpoint instead of the chat completion endpoint. Text mode auto-enables instruct formatting. UI toggle added to the Instruct Mode tab in Generation Settings.