### PR TITLE
feat: add onboarding walkthrough and per-user AI credentials

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -859,6 +859,45 @@ export const settingsApi = {
       body: JSON.stringify(settings),
     });
   },
+
+  // --- Global secrets (owner-managed, shared with all users) ---
+
+  async getGlobalSecrets(): Promise<SecretsResponse> {
+    try {
+      return await apiRequest('/api/secrets/global/read', { method: 'POST' });
+    } catch {
+      return {};
+    }
+  },
+
+  async writeGlobalSecret(key: string, value: string, label?: string): Promise<void> {
+    await apiRequest('/api/secrets/global/write', {
+      method: 'POST',
+      body: JSON.stringify({ key, value, label }),
+    });
+  },
+
+  async deleteGlobalSecret(key: string, id?: string): Promise<void> {
+    await apiRequest('/api/secrets/global/delete', {
+      method: 'POST',
+      body: JSON.stringify({ key, id }),
+    });
+  },
+
+  async getGlobalSharingStatus(): Promise<{ enabled: boolean }> {
+    try {
+      return await apiRequest('/api/secrets/global/status', { method: 'POST' });
+    } catch {
+      return { enabled: false };
+    }
+  },
+
+  async setGlobalSharing(enabled: boolean): Promise<void> {
+    await apiRequest('/api/secrets/global/toggle', {
+      method: 'POST',
+      body: JSON.stringify({ enabled }),
+    });
+  },
 };
 
 // Sprites/Expressions API

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Download, Menu, Settings, LogOut, Pencil, History, UserCircle } from 'lucide-react';
+import { Download, Key, Menu, Settings, LogOut, Pencil, History, UserCircle } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useAuthStore } from '../../stores/authStore';
 import { useSettingsPanelStore } from '../../stores/settingsPanelStore';
@@ -121,6 +121,17 @@ export function Header({ onMenuClick }: HeaderProps) {
             onClick={() => useSettingsPanelStore.getState().open()}
           >
             <Settings size={20} />
+          </Button>
+        )}
+        {!canViewSettings && can(userRole, 'settings:personal') && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="p-2"
+            aria-label="My API Keys"
+            onClick={() => useSettingsPanelStore.getState().openToPage('my-keys')}
+          >
+            <Key size={20} />
           </Button>
         )}
         <Button

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -6,6 +6,8 @@ import { useSwipeSidebar } from '../../hooks/useSwipeSidebar';
 import { Header } from './Header';
 import { Sidebar } from './Sidebar';
 import { SettingsPanel } from '../settings/SettingsPanel';
+import { OnboardingWalkthrough } from '../onboarding/OnboardingWalkthrough';
+import { useOnboardingStore } from '../../stores/onboardingStore';
 
 export function MainLayout() {
   const [sidebarOpen, setSidebarOpen] = useState(false);
@@ -13,7 +15,7 @@ export function MainLayout() {
   const closeSidebar = useCallback(() => setSidebarOpen(false), []);
   const swipeRef = useSwipeSidebar(sidebarOpen, openSidebar, closeSidebar);
   const { isAuthenticated, isLoading, checkAuth } = useAuthStore();
-  const { fetchSettings, fetchSecrets } = useSettingsStore();
+  const { fetchSettings, fetchSecrets, fetchGlobalSecrets } = useSettingsStore();
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -25,14 +27,23 @@ export function MainLayout() {
     if (isAuthenticated) {
       fetchSettings();
       fetchSecrets();
+      fetchGlobalSecrets();
     }
-  }, [isAuthenticated, fetchSettings, fetchSecrets]);
+  }, [isAuthenticated, fetchSettings, fetchSecrets, fetchGlobalSecrets]);
 
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {
       navigate('/login');
     }
   }, [isAuthenticated, isLoading, navigate]);
+
+  // Onboarding: trigger walkthrough on first authenticated visit
+  const { hasCompleted, start: startOnboarding } = useOnboardingStore();
+  useEffect(() => {
+    if (isAuthenticated && !hasCompleted) {
+      startOnboarding();
+    }
+  }, [isAuthenticated, hasCompleted, startOnboarding]);
 
   if (isLoading) {
     return (
@@ -62,6 +73,9 @@ export function MainLayout() {
 
       {/* Settings Panel — slides in from right, overlays chat */}
       <SettingsPanel />
+
+      {/* Onboarding Walkthrough */}
+      <OnboardingWalkthrough openSidebar={openSidebar} />
     </div>
   );
 }

--- a/src/components/onboarding/OnboardingWalkthrough.tsx
+++ b/src/components/onboarding/OnboardingWalkthrough.tsx
@@ -1,0 +1,202 @@
+import { useEffect, useCallback, useMemo } from 'react';
+import { Sparkles, Key, Users, MessageSquare, PartyPopper } from 'lucide-react';
+import { useOnboardingStore, TOTAL_STEPS } from '../../stores/onboardingStore';
+import { useSettingsPanelStore } from '../../stores/settingsPanelStore';
+import { useAuthStore } from '../../stores/authStore';
+import { can } from '../../utils/permissions';
+import { Button } from '../ui';
+
+interface StepDef {
+  icon: React.ComponentType<{ size?: number; className?: string }>;
+  title: string;
+  description: string;
+  ctaLabel?: string;
+}
+
+function buildSteps(isAdmin: boolean): StepDef[] {
+  return [
+    {
+      icon: Sparkles,
+      title: 'Welcome to GoodGirlsBotClub',
+      description:
+        'Your personal AI character chat platform. Let\u2019s walk through the basics so you can start chatting in under a minute.',
+    },
+    {
+      icon: Key,
+      title: 'Set Up Your AI Provider',
+      description: isAdmin
+        ? 'To chat with characters you\u2019ll need an API key from a provider like OpenAI, Anthropic, or Google. You can configure this in AI Settings.'
+        : 'Enter your own API key from a provider like OpenAI, Anthropic, or Google. If your admin has shared keys, you can start chatting right away!',
+      ctaLabel: isAdmin ? 'Open AI Settings' : 'Set Up My Keys',
+    },
+    {
+      icon: Users,
+      title: 'Browse Characters',
+      description:
+        'Open the sidebar to browse available characters, import character cards, or create your own from scratch. Tap any character to start a conversation.',
+      ctaLabel: 'Open Character List',
+    },
+    {
+      icon: MessageSquare,
+      title: 'Start Chatting',
+      description:
+        'Select a character, type your message, and hit send. You can edit, regenerate, or swipe between alternate responses. Try group chats with multiple characters too!',
+    },
+    {
+      icon: PartyPopper,
+      title: "You're All Set!",
+      description: isAdmin
+        ? 'You can replay this walkthrough anytime from the Settings page. Enjoy chatting!'
+        : 'Enjoy chatting with your characters!',
+    },
+  ];
+}
+
+interface OnboardingWalkthroughProps {
+  openSidebar: () => void;
+}
+
+export function OnboardingWalkthrough({ openSidebar }: OnboardingWalkthroughProps) {
+  const { isOpen, currentStep, nextStep, prevStep, complete, skip } =
+    useOnboardingStore();
+  const userRole = useAuthStore((s) => s.currentUser?.role);
+  const isAdmin = can(userRole, 'settings:view');
+  const steps = useMemo(() => buildSteps(isAdmin), [isAdmin]);
+
+  // Escape key to skip
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') skip();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [isOpen, skip]);
+
+  // Lock body scroll
+  useEffect(() => {
+    if (!isOpen) return;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [isOpen]);
+
+  const handleCta = useCallback(() => {
+    const step = steps[currentStep];
+    if (!step.ctaLabel) return;
+
+    // Close walkthrough first, then open target UI
+    complete();
+
+    if (currentStep === 1) {
+      if (isAdmin) {
+        // Open AI Settings (admin/owner)
+        const panel = useSettingsPanelStore.getState();
+        panel.open();
+        requestAnimationFrame(() => {
+          useSettingsPanelStore.getState().pushPage('ai');
+        });
+      } else {
+        // Open My Keys (non-admin)
+        useSettingsPanelStore.getState().openToPage('my-keys');
+      }
+    } else if (currentStep === 2) {
+      // Open sidebar
+      openSidebar();
+    }
+  }, [currentStep, complete, openSidebar, steps]);
+
+  if (!isOpen) return null;
+
+  const step = steps[currentStep];
+  const StepIcon = step.icon;
+  const isFirst = currentStep === 0;
+  const isLast = currentStep === TOTAL_STEPS - 1;
+
+  return (
+    <div className="fixed inset-0 z-[110] flex items-center justify-center p-6" role="dialog" aria-modal="true">
+      {/* Backdrop */}
+      <div className="absolute inset-0 bg-black/70 backdrop-blur-sm" />
+
+      {/* Card */}
+      <div className="relative w-full max-w-sm bg-[var(--color-bg-secondary)] border border-[var(--color-border)] rounded-2xl shadow-2xl animate-fade-in-up">
+        {/* Progress dots */}
+        <div className="flex justify-center gap-2 pt-6">
+          {steps.map((_, i) => (
+            <div
+              key={i}
+              className={`w-2 h-2 rounded-full transition-colors duration-200 ${
+                i <= currentStep
+                  ? 'bg-[var(--color-primary)]'
+                  : 'bg-[var(--color-bg-tertiary)]'
+              }`}
+              aria-label={`Step ${i + 1} of ${TOTAL_STEPS}`}
+            />
+          ))}
+        </div>
+
+        {/* Icon */}
+        <div className="flex justify-center pt-6">
+          <div className="w-16 h-16 rounded-2xl bg-[var(--color-primary)]/20 flex items-center justify-center">
+            <StepIcon size={32} className="text-[var(--color-primary)]" />
+          </div>
+        </div>
+
+        {/* Title */}
+        <h2 className="text-xl font-bold text-center text-[var(--color-text-primary)] px-6 pt-4">
+          {step.title}
+        </h2>
+
+        {/* Description */}
+        <p className="text-sm text-center text-[var(--color-text-secondary)] leading-relaxed px-6 pt-2 pb-6">
+          {step.description}
+        </p>
+
+        {/* CTA button */}
+        {step.ctaLabel && (
+          <div className="px-6 pb-4">
+            <Button variant="secondary" className="w-full" onClick={handleCta}>
+              {step.ctaLabel}
+            </Button>
+          </div>
+        )}
+
+        {/* Navigation footer */}
+        <div className="flex items-center justify-between px-6 py-4 border-t border-[var(--color-border)]">
+          {isFirst ? (
+            <Button variant="ghost" size="sm" onClick={skip}>
+              Skip
+            </Button>
+          ) : (
+            <Button variant="ghost" size="sm" onClick={prevStep}>
+              Back
+            </Button>
+          )}
+
+          {isLast ? (
+            <Button variant="primary" size="sm" onClick={complete}>
+              Finish
+            </Button>
+          ) : (
+            <Button variant="primary" size="sm" onClick={nextStep}>
+              Next
+            </Button>
+          )}
+        </div>
+
+        {/* Skip link on middle steps */}
+        {!isFirst && !isLast && (
+          <div className="text-center pb-4">
+            <button
+              className="text-xs text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors"
+              onClick={skip}
+            >
+              Skip walkthrough
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/settings/AISettingsPage.tsx
+++ b/src/components/settings/AISettingsPage.tsx
@@ -5,6 +5,8 @@ import { useSettingsStore } from '../../stores/settingsStore';
 import { useConnectionProfileStore } from '../../stores/connectionProfileStore';
 import { useGenerationStore } from '../../stores/generationStore';
 import { PROVIDERS, type SecretState } from '../../api/client';
+import { useAuthStore } from '../../stores/authStore';
+import { hasMinRole } from '../../utils/permissions';
 import { Button, Input } from '../ui';
 
 type TestState =
@@ -44,15 +46,20 @@ async function testLocalEndpoint(
 export function AISettingsPage(_props?: { params?: Record<string, string> }) {
   const { goBack } = useSettingsPanelStore();
   const {
-    secrets, activeProvider, activeModel, customUrl,
+    secrets, globalSecrets, globalSharingEnabled, globalSharingSupported,
+    activeProvider, activeModel, customUrl,
     isSaving, error, successMessage,
-    fetchSecrets, fetchSettings,
-    saveApiKey, deleteApiKey,
-    setActiveProvider, setActiveModel, setCustomUrl, clearMessages,
+    fetchSecrets, fetchSettings, fetchGlobalSecrets,
+    saveApiKey, deleteApiKey, saveGlobalApiKey, deleteGlobalApiKey,
+    setActiveProvider, setActiveModel, setCustomUrl, setGlobalSharing, clearMessages,
   } = useSettingsStore();
+  const userRole = useAuthStore((s) => s.currentUser?.role);
+  const isOwner = hasMinRole(userRole, 'owner');
 
   const [apiKeyInputs, setApiKeyInputs] = useState<Record<string, string>>({});
   const [showApiKey, setShowApiKey] = useState<Record<string, boolean>>({});
+  const [globalKeyInputs, setGlobalKeyInputs] = useState<Record<string, string>>({});
+  const [showGlobalKey, setShowGlobalKey] = useState<Record<string, boolean>>({});
 
   // Connection profiles
   const { profiles, activeProfileId, saveProfile, deleteProfile, renameProfile, setActiveProfileId } = useConnectionProfileStore();
@@ -68,7 +75,7 @@ export function AISettingsPage(_props?: { params?: Record<string, string> }) {
   const [testState, setTestState] = useState<TestState>({ kind: 'idle' });
   const [discoveredModels, setDiscoveredModels] = useState<string[]>([]);
 
-  useEffect(() => { fetchSecrets(); fetchSettings(); }, [fetchSecrets, fetchSettings]);
+  useEffect(() => { fetchSecrets(); fetchSettings(); if (isOwner) fetchGlobalSecrets(); }, [fetchSecrets, fetchSettings, fetchGlobalSecrets, isOwner]);
   useEffect(() => {
     if (successMessage || error) {
       const timer = setTimeout(clearMessages, 3000);
@@ -84,6 +91,26 @@ export function AISettingsPage(_props?: { params?: Record<string, string> }) {
     if (!key?.trim()) return;
     await saveApiKey(providerId, key.trim());
     setApiKeyInputs((prev) => ({ ...prev, [providerId]: '' }));
+  };
+
+  const handleSaveGlobalKey = async (providerId: string) => {
+    const key = globalKeyInputs[providerId];
+    if (!key?.trim()) return;
+    await saveGlobalApiKey(providerId, key.trim());
+    setGlobalKeyInputs((prev) => ({ ...prev, [providerId]: '' }));
+  };
+
+  const hasGlobalKey = (secretKey: string): boolean => {
+    const data = globalSecrets[secretKey];
+    return Array.isArray(data) && data.length > 0;
+  };
+
+  const getGlobalSecretInfo = (secretKey: string): SecretState | null => {
+    const data = globalSecrets[secretKey];
+    if (Array.isArray(data) && data.length > 0) {
+      return data.find((s) => s.active) || data[0];
+    }
+    return null;
   };
 
   const hasApiKey = (secretKey: string): boolean => {
@@ -347,6 +374,77 @@ export function AISettingsPage(_props?: { params?: Record<string, string> }) {
             })}
           </div>
         </section>
+
+        {/* Global API Keys — Owner only */}
+        {isOwner && globalSharingSupported && (
+          <section className="bg-[var(--color-bg-secondary)] rounded-lg p-4 cyberpunk-card">
+            <div className="flex items-center justify-between mb-3">
+              <div className="flex items-center gap-2">
+                <Globe size={16} className="text-[var(--color-text-secondary)]" />
+                <h2 className="text-sm font-semibold text-[var(--color-text-primary)]">Global API Keys</h2>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="text-xs text-[var(--color-text-secondary)]">Share with all users</span>
+                <button
+                  role="switch"
+                  aria-checked={globalSharingEnabled}
+                  onClick={() => setGlobalSharing(!globalSharingEnabled)}
+                  disabled={isSaving}
+                  className={`relative inline-flex h-6 w-11 shrink-0 rounded-full border-2 border-transparent transition-colors ${
+                    globalSharingEnabled ? 'bg-[var(--color-primary)]' : 'bg-zinc-600'
+                  }`}
+                >
+                  <span className={`pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow-sm transition-transform ${
+                    globalSharingEnabled ? 'translate-x-5' : 'translate-x-0'
+                  }`} />
+                </button>
+              </div>
+            </div>
+            <p className="text-xs text-[var(--color-text-secondary)] mb-3">
+              Keys set here are used as defaults for users who haven't entered their own. Your personal keys above always take priority.
+            </p>
+            <div className="space-y-4">
+              {PROVIDERS.filter((p) => p.id !== 'custom').map((provider) => {
+                const globalInfo = getGlobalSecretInfo(provider.secretKey);
+                const configured = !!globalInfo;
+                const inputValue = globalKeyInputs[provider.id] || '';
+                const showKey = showGlobalKey[provider.id] || false;
+                return (
+                  <div key={provider.id} className="p-3 bg-[var(--color-bg-tertiary)] rounded-lg">
+                    <div className="flex items-center justify-between mb-2">
+                      <div className="flex items-center gap-2">
+                        <Globe size={16} className="text-[var(--color-text-secondary)]" />
+                        <span className="text-sm font-medium text-[var(--color-text-primary)]">{provider.name}</span>
+                      </div>
+                      {configured && (
+                        <div className="flex items-center gap-2">
+                          <span className="text-xs text-blue-400">Shared</span>
+                          <Button variant="ghost" size="sm" onClick={() => deleteGlobalApiKey(provider.secretKey)} disabled={isSaving} className="p-1 text-red-400 hover:text-red-300">
+                            <Trash2 size={14} />
+                          </Button>
+                        </div>
+                      )}
+                    </div>
+                    <div className="flex gap-2">
+                      <div className="flex-1 relative">
+                        <Input type={showKey ? 'text' : 'password'} value={inputValue}
+                          onChange={(e) => setGlobalKeyInputs((prev) => ({ ...prev, [provider.id]: e.target.value }))}
+                          placeholder={configured ? 'Enter new key to replace...' : 'Enter global API key...'} className="pr-10" />
+                        <button type="button" onClick={() => setShowGlobalKey((prev) => ({ ...prev, [provider.id]: !prev[provider.id] }))}
+                          className="absolute right-3 top-1/2 -translate-y-1/2 text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]">
+                          {showKey ? <EyeOff size={16} /> : <Eye size={16} />}
+                        </button>
+                      </div>
+                      <Button onClick={() => handleSaveGlobalKey(provider.id)} disabled={!inputValue.trim() || isSaving} className="shrink-0">
+                        {isSaving ? <Loader2 size={16} className="animate-spin" /> : 'Save'}
+                      </Button>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </section>
+        )}
       </div>
     </div>
   );

--- a/src/components/settings/MyKeysPage.tsx
+++ b/src/components/settings/MyKeysPage.tsx
@@ -1,0 +1,299 @@
+import { useEffect, useState } from 'react';
+import { ArrowLeft, Check, Eye, EyeOff, Globe, Key, Loader2, Trash2 } from 'lucide-react';
+import { useSettingsPanelStore } from '../../stores/settingsPanelStore';
+import { useSettingsStore } from '../../stores/settingsStore';
+import { PROVIDERS, type SecretState } from '../../api/client';
+import { Button, Input } from '../ui';
+import {
+  getThemeMode,
+  setThemeMode,
+  getThemePreset,
+  setThemePreset,
+  applyTheme,
+  PRESET_SWATCHES,
+  getActivePreset,
+  setActivePreset,
+  type ThemeMode,
+  type ThemePreset,
+  type ActivePreset,
+} from '../../hooks/themePreferences';
+
+export function MyKeysPage(_props?: { params?: Record<string, string> }) {
+  const { goBack } = useSettingsPanelStore();
+  const {
+    secrets, globalSecrets, globalSharingEnabled,
+    activeProvider, activeModel, isSaving, error, successMessage,
+    fetchSecrets, fetchSettings, fetchGlobalSecrets,
+    saveApiKey, deleteApiKey, setActiveProvider, setActiveModel, clearMessages,
+  } = useSettingsStore();
+
+  const [apiKeyInputs, setApiKeyInputs] = useState<Record<string, string>>({});
+  const [showApiKey, setShowApiKey] = useState<Record<string, boolean>>({});
+
+  // Theme state
+  const [themeMode, setThemeModeState] = useState<ThemeMode>(() => getThemeMode());
+  const [, setThemePresetState] = useState<ThemePreset>(() => getThemePreset());
+  const [activePreset, setActivePresetState] = useState<ActivePreset>(() => getActivePreset());
+
+  useEffect(() => {
+    fetchSecrets();
+    fetchSettings();
+    fetchGlobalSecrets();
+  }, [fetchSecrets, fetchSettings, fetchGlobalSecrets]);
+
+  useEffect(() => {
+    if (successMessage || error) {
+      const timer = setTimeout(clearMessages, 3000);
+      return () => clearTimeout(timer);
+    }
+  }, [successMessage, error, clearMessages]);
+
+  const handleSaveApiKey = async (providerId: string) => {
+    const key = apiKeyInputs[providerId];
+    if (!key?.trim()) return;
+    await saveApiKey(providerId, key.trim());
+    setApiKeyInputs((prev) => ({ ...prev, [providerId]: '' }));
+  };
+
+  const hasPersonalKey = (secretKey: string): boolean => {
+    const data = secrets[secretKey];
+    return Array.isArray(data) && data.length > 0;
+  };
+
+  const hasGlobalKey = (secretKey: string): boolean => {
+    if (!globalSharingEnabled) return false;
+    const data = globalSecrets[secretKey];
+    return Array.isArray(data) && data.length > 0;
+  };
+
+  const getSecretInfo = (secretKey: string): SecretState | null => {
+    const data = secrets[secretKey];
+    if (Array.isArray(data) && data.length > 0) {
+      return data.find((s) => s.active) || data[0];
+    }
+    return null;
+  };
+
+  const isProviderAvailable = (provider: typeof PROVIDERS[number]) =>
+    hasPersonalKey(provider.secretKey) || hasGlobalKey(provider.secretKey);
+
+  const currentProvider = PROVIDERS.find((p) => p.id === activeProvider);
+
+  // Count providers with global keys
+  const globalKeyCount = PROVIDERS.filter((p) => p.secretKey && hasGlobalKey(p.secretKey)).length;
+
+  return (
+    <div className="min-h-screen bg-[var(--color-bg-primary)]">
+      <header className="h-14 bg-[var(--color-bg-secondary)] border-b border-[var(--color-border)] flex items-center px-4 gap-3 safe-top">
+        <Button variant="ghost" size="sm" onClick={() => goBack()} className="p-2" aria-label="Back">
+          <ArrowLeft size={24} />
+        </Button>
+        <h1 className="text-lg font-semibold text-[var(--color-text-primary)]">My API Keys</h1>
+      </header>
+
+      <div className="max-w-2xl mx-auto p-4 space-y-6">
+        {/* Status Messages */}
+        {error && (
+          <div className="p-3 bg-red-500/10 border border-red-500/30 rounded-lg">
+            <p className="text-sm text-red-400">{error}</p>
+          </div>
+        )}
+        {successMessage && (
+          <div className="p-3 bg-green-500/10 border border-green-500/30 rounded-lg">
+            <p className="text-sm text-green-400">{successMessage}</p>
+          </div>
+        )}
+
+        {/* Global Keys Banner */}
+        {globalKeyCount > 0 && (
+          <div className="p-3 bg-blue-500/10 border border-blue-500/30 rounded-lg flex items-start gap-3">
+            <Globe size={18} className="text-blue-400 mt-0.5 shrink-0" />
+            <div>
+              <p className="text-sm text-blue-300 font-medium">Shared API keys available</p>
+              <p className="text-xs text-blue-400/80 mt-0.5">
+                Your admin has shared {globalKeyCount} provider{globalKeyCount > 1 ? 's' : ''}. Add your own key below to use a personal one instead.
+              </p>
+            </div>
+          </div>
+        )}
+        {!globalKeyCount && (
+          <div className="p-3 bg-[var(--color-bg-secondary)] border border-[var(--color-border)] rounded-lg">
+            <p className="text-sm text-[var(--color-text-secondary)]">
+              Enter an API key from a provider like OpenAI, Anthropic, or Google to start chatting.
+            </p>
+          </div>
+        )}
+
+        {/* Active Provider */}
+        <section className="bg-[var(--color-bg-secondary)] rounded-lg p-4 cyberpunk-card">
+          <h2 className="text-sm font-semibold text-[var(--color-text-primary)] mb-3">Active Provider</h2>
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+            {PROVIDERS.filter((p) => p.id !== 'custom').map((provider) => {
+              const personal = hasPersonalKey(provider.secretKey);
+              const global = hasGlobalKey(provider.secretKey);
+              const available = personal || global;
+              const isActive = activeProvider === provider.id;
+              return (
+                <button
+                  key={provider.id}
+                  onClick={() => setActiveProvider(provider.id)}
+                  disabled={isSaving}
+                  className={`relative p-3 rounded-lg text-left transition-all ${
+                    isActive ? 'bg-[var(--color-primary)] text-white'
+                      : available ? 'bg-[var(--color-bg-tertiary)] hover:bg-zinc-700'
+                        : 'bg-[var(--color-bg-tertiary)] opacity-50'
+                  }`}
+                >
+                  <span className="text-sm font-medium">{provider.name}</span>
+                  {personal && (
+                    <Check size={14} className={`absolute top-2 right-2 ${isActive ? 'text-white' : 'text-green-400'}`} />
+                  )}
+                  {!personal && global && (
+                    <Globe size={14} className={`absolute top-2 right-2 ${isActive ? 'text-white' : 'text-blue-400'}`} />
+                  )}
+                </button>
+              );
+            })}
+          </div>
+          <div className="flex items-center gap-4 mt-2 text-xs text-[var(--color-text-secondary)]">
+            <span className="flex items-center gap-1"><Check size={12} className="text-green-400" /> Your key</span>
+            <span className="flex items-center gap-1"><Globe size={12} className="text-blue-400" /> Shared</span>
+          </div>
+        </section>
+
+        {/* Model Selector */}
+        {currentProvider && currentProvider.id !== 'custom' && currentProvider.models.length > 0 && (
+          <section className="bg-[var(--color-bg-secondary)] rounded-lg p-4 cyberpunk-card">
+            <h2 className="text-sm font-semibold text-[var(--color-text-primary)] mb-3">Model</h2>
+            <select
+              value={activeModel}
+              onChange={(e) => setActiveModel(e.target.value)}
+              disabled={isSaving}
+              className="w-full bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] rounded-lg px-3 py-2 text-[var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]"
+            >
+              {currentProvider.models.map((model) => (
+                <option key={model} value={model}>{model}</option>
+              ))}
+            </select>
+          </section>
+        )}
+
+        {/* Personal API Keys */}
+        <section className="bg-[var(--color-bg-secondary)] rounded-lg p-4 cyberpunk-card">
+          <h2 className="text-sm font-semibold text-[var(--color-text-primary)] mb-3">API Keys</h2>
+          <div className="space-y-4">
+            {PROVIDERS.filter((p) => p.id !== 'custom').map((provider) => {
+              const secretInfo = getSecretInfo(provider.secretKey);
+              const configured = !!secretInfo;
+              const global = hasGlobalKey(provider.secretKey);
+              const inputValue = apiKeyInputs[provider.id] || '';
+              const showKey = showApiKey[provider.id] || false;
+              return (
+                <div key={provider.id} className="p-3 bg-[var(--color-bg-tertiary)] rounded-lg">
+                  <div className="flex items-center justify-between mb-2">
+                    <div className="flex items-center gap-2">
+                      <Key size={16} className="text-[var(--color-text-secondary)]" />
+                      <span className="text-sm font-medium text-[var(--color-text-primary)]">{provider.name}</span>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      {configured && (
+                        <>
+                          <span className="text-xs text-green-400">Configured</span>
+                          <Button variant="ghost" size="sm" onClick={() => deleteApiKey(provider.secretKey)} disabled={isSaving} className="p-1 text-red-400 hover:text-red-300">
+                            <Trash2 size={14} />
+                          </Button>
+                        </>
+                      )}
+                      {!configured && global && (
+                        <span className="text-xs text-blue-400">Using shared</span>
+                      )}
+                    </div>
+                  </div>
+                  <div className="flex gap-2">
+                    <div className="flex-1 relative">
+                      <Input
+                        type={showKey ? 'text' : 'password'}
+                        value={inputValue}
+                        onChange={(e) => setApiKeyInputs((prev) => ({ ...prev, [provider.id]: e.target.value }))}
+                        placeholder={configured ? 'Enter new key to replace...' : 'Enter API key...'}
+                        className="pr-10"
+                      />
+                      <button
+                        type="button"
+                        onClick={() => setShowApiKey((prev) => ({ ...prev, [provider.id]: !prev[provider.id] }))}
+                        className="absolute right-3 top-1/2 -translate-y-1/2 text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]"
+                      >
+                        {showKey ? <EyeOff size={16} /> : <Eye size={16} />}
+                      </button>
+                    </div>
+                    <Button onClick={() => handleSaveApiKey(provider.id)} disabled={!inputValue.trim() || isSaving} className="shrink-0">
+                      {isSaving ? <Loader2 size={16} className="animate-spin" /> : 'Save'}
+                    </Button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </section>
+
+        {/* Appearance */}
+        <section className="bg-[var(--color-bg-secondary)] rounded-lg p-4 space-y-4 cyberpunk-card">
+          <h2 className="text-sm font-semibold text-[var(--color-text-primary)]">Appearance</h2>
+          {/* Theme Mode */}
+          <div>
+            <label className="block text-xs text-[var(--color-text-secondary)] mb-2">Theme</label>
+            <div className="grid grid-cols-3 gap-2">
+              {(['light', 'dark', 'auto'] as ThemeMode[]).map((mode) => (
+                <button
+                  key={mode}
+                  onClick={() => {
+                    setThemeMode(mode);
+                    setThemeModeState(mode);
+                    applyTheme();
+                  }}
+                  className={`p-2 rounded-lg text-sm capitalize transition-colors ${
+                    themeMode === mode
+                      ? 'bg-[var(--color-primary)] text-white'
+                      : 'bg-[var(--color-bg-tertiary)] text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]'
+                  }`}
+                >
+                  {mode}
+                </button>
+              ))}
+            </div>
+          </div>
+          {/* Accent Color */}
+          <div>
+            <label className="block text-xs text-[var(--color-text-secondary)] mb-2">Accent Color</label>
+            <div className="flex gap-2">
+              {(Object.entries(PRESET_SWATCHES) as [ThemePreset, string][]).map(([preset, swatch]) => (
+                <button
+                  key={preset}
+                  onClick={() => {
+                    setThemePreset(preset);
+                    setThemePresetState(preset);
+                    setActivePreset({ type: 'builtin', id: preset });
+                    setActivePresetState({ type: 'builtin', id: preset });
+                    applyTheme();
+                  }}
+                  className={`w-8 h-8 rounded-full transition-transform ${
+                    activePreset.type === 'builtin' && activePreset.id === preset ? 'ring-2 ring-white scale-110' : 'hover:scale-105'
+                  }`}
+                  style={{ backgroundColor: swatch }}
+                  aria-label={`${preset} theme`}
+                />
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* Help */}
+        <section className="text-center py-4">
+          <p className="text-xs text-[var(--color-text-secondary)]">
+            API keys are stored securely on the server and never exposed to the frontend.
+          </p>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react';
-import { ArrowLeft, BookOpen, ChevronRight, Database, Edit3, FileText, Image, Languages, Loader2, MessageSquare, Mic, Palette, Plus, Replace, Sliders, Trash2, UserPlus, Users, Volume2, Zap } from 'lucide-react';
+import { ArrowLeft, BookOpen, ChevronRight, Database, Edit3, FileText, Image, Languages, Loader2, MessageSquare, Mic, Palette, Plus, Replace, Sliders, Sparkles, Trash2, UserPlus, Users, Volume2, Zap } from 'lucide-react';
 import { useSettingsPanelStore } from '../../stores/settingsPanelStore';
 import { useSettingsStore } from '../../stores/settingsStore';
+import { useOnboardingStore } from '../../stores/onboardingStore';
 // PROVIDERS moved to AISettingsPage
 import { Button } from '../ui';
 import {
@@ -827,6 +828,28 @@ export function SettingsPage(_props?: { params?: Record<string, string> }) {
                   </option>
                 ))}
               </select>
+            </section>
+
+            {/* Replay Walkthrough */}
+            <section className="bg-[var(--color-bg-secondary)] rounded-lg overflow-hidden cyberpunk-card">
+              <button
+                onClick={() => {
+                  useOnboardingStore.getState().start();
+                  useSettingsPanelStore.getState().close();
+                }}
+                className="w-full flex items-center gap-3 p-4 hover:bg-[var(--color-bg-tertiary)] transition-colors text-left"
+              >
+                <div className="w-10 h-10 rounded-lg bg-[var(--color-primary)]/20 flex items-center justify-center">
+                  <Sparkles size={20} className="text-[var(--color-primary)]" />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium text-[var(--color-text-primary)]">Replay Walkthrough</p>
+                  <p className="text-xs text-[var(--color-text-secondary)] mt-0.5">
+                    Review the getting started guide
+                  </p>
+                </div>
+                <ChevronRight size={20} className="text-[var(--color-text-secondary)]" />
+              </button>
             </section>
 
             {/* Help Text */}

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -14,6 +14,7 @@ import { DataBankPage } from './DataBankPage';
 import { GalleryPage } from './GalleryPage';
 import { ThemeEditorPage } from './ThemeEditorPage';
 import { AISettingsPage } from './AISettingsPage';
+import { MyKeysPage } from './MyKeysPage';
 import { WorldInfoPage } from '../worldinfo';
 import { RegexScriptPage } from '../regexscripts';
 
@@ -23,6 +24,7 @@ import { RegexScriptPage } from '../regexscripts';
 
 const PAGE_COMPONENTS: Record<SettingsPageId, React.ComponentType<{ params?: Record<string, string> }>> = {
   main: SettingsPage,
+  'my-keys': MyKeysPage,
   ai: AISettingsPage,
   generation: GenerationSettingsPage,
   prompts: PromptTemplatesPage,

--- a/src/index.css
+++ b/src/index.css
@@ -393,3 +393,17 @@ body {
 .animate-slide-up {
   animation: slide-up 0.25s ease-out;
 }
+
+@keyframes fade-in-up {
+  from {
+    opacity: 0;
+    transform: translateY(24px) scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+.animate-fade-in-up {
+  animation: fade-in-up 0.35s ease-out;
+}

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -142,6 +142,9 @@ export const useAuthStore = create<AuthState>((set) => ({
       });
       useSettingsStore.setState({
         secrets: {},
+        globalSecrets: {},
+        globalSharingEnabled: false,
+        globalSharingSupported: false,
         activeProvider: 'openai',
         activeModel: 'gpt-4o',
         error: null,

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -1285,14 +1285,21 @@ async function generateGroupTurn(
 
 // Helper: get provider/model with auto-switch
 function getProviderAndModel(): { provider: string; model: string } {
-  const { activeProvider, activeModel, secrets } = useSettingsStore.getState();
+  const { activeProvider, activeModel, secrets, globalSecrets, globalSharingEnabled } = useSettingsStore.getState();
 
   let provider = activeProvider;
   let model = activeModel;
 
+  // Helper: check if a key exists in personal or global secrets
+  const hasKey = (key: string) => {
+    if (Array.isArray(secrets[key]) && secrets[key].length > 0) return true;
+    if (globalSharingEnabled && Array.isArray(globalSecrets[key]) && globalSecrets[key].length > 0) return true;
+    return false;
+  };
+
   if (!provider || provider === 'openai') {
-    const hasOpenAI = Array.isArray(secrets['api_key_openai']) && secrets['api_key_openai'].length > 0;
-    const hasClaude = Array.isArray(secrets['api_key_claude']) && secrets['api_key_claude'].length > 0;
+    const hasOpenAI = hasKey('api_key_openai');
+    const hasClaude = hasKey('api_key_claude');
     if (!hasOpenAI && hasClaude) {
       provider = 'claude';
       model = 'claude-sonnet-4-20250514';

--- a/src/stores/onboardingStore.ts
+++ b/src/stores/onboardingStore.ts
@@ -1,0 +1,51 @@
+import { create } from 'zustand';
+
+export const TOTAL_STEPS = 5;
+
+const STORAGE_KEY = 'sillytavern_onboarding_completed';
+
+interface OnboardingState {
+  isOpen: boolean;
+  currentStep: number;
+  hasCompleted: boolean;
+
+  start: () => void;
+  nextStep: () => void;
+  prevStep: () => void;
+  complete: () => void;
+  skip: () => void;
+}
+
+export const useOnboardingStore = create<OnboardingState>((set, get) => ({
+  isOpen: false,
+  currentStep: 0,
+  hasCompleted: localStorage.getItem(STORAGE_KEY) === 'true',
+
+  start: () => set({ isOpen: true, currentStep: 0 }),
+
+  nextStep: () => {
+    const { currentStep, complete } = get();
+    if (currentStep >= TOTAL_STEPS - 1) {
+      complete();
+    } else {
+      set({ currentStep: currentStep + 1 });
+    }
+  },
+
+  prevStep: () => {
+    const { currentStep } = get();
+    if (currentStep > 0) {
+      set({ currentStep: currentStep - 1 });
+    }
+  },
+
+  complete: () => {
+    localStorage.setItem(STORAGE_KEY, 'true');
+    set({ isOpen: false, currentStep: 0, hasCompleted: true });
+  },
+
+  skip: () => {
+    localStorage.setItem(STORAGE_KEY, 'true');
+    set({ isOpen: false, currentStep: 0, hasCompleted: true });
+  },
+}));

--- a/src/stores/settingsPanelStore.ts
+++ b/src/stores/settingsPanelStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 
 export type SettingsPageId =
   | 'main'
+  | 'my-keys'
   | 'ai'
   | 'generation'
   | 'prompts'
@@ -30,6 +31,7 @@ interface SettingsPanelState {
   pushPage: (page: SettingsPageId, params?: Record<string, string>) => void;
   goBack: () => void;
   currentPage: () => SettingsStackEntry;
+  openToPage: (page: SettingsPageId, params?: Record<string, string>) => void;
 }
 
 export const useSettingsPanelStore = create<SettingsPanelState>((set, get) => ({
@@ -58,4 +60,6 @@ export const useSettingsPanelStore = create<SettingsPanelState>((set, get) => ({
     const { pageStack } = get();
     return pageStack[pageStack.length - 1];
   },
+
+  openToPage: (page, params) => set({ isOpen: true, pageStack: [{ page: 'main' }, { page, params }] }),
 }));

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -11,6 +11,9 @@ interface SettingsState {
   isSaving: boolean;
   error: string | null;
   successMessage: string | null;
+  globalSecrets: SecretsResponse;
+  globalSharingEnabled: boolean;
+  globalSharingSupported: boolean;
 
   // Actions
   fetchSecrets: () => Promise<void>;
@@ -21,6 +24,10 @@ interface SettingsState {
   setActiveModel: (model: string) => Promise<void>;
   setCustomUrl: (url: string) => Promise<void>;
   clearMessages: () => void;
+  fetchGlobalSecrets: () => Promise<void>;
+  saveGlobalApiKey: (provider: string, apiKey: string) => Promise<void>;
+  deleteGlobalApiKey: (secretKey: string) => Promise<void>;
+  setGlobalSharing: (enabled: boolean) => Promise<void>;
 }
 
 export const useSettingsStore = create<SettingsState>((set, get) => ({
@@ -32,6 +39,9 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
   isSaving: false,
   error: null,
   successMessage: null,
+  globalSecrets: {},
+  globalSharingEnabled: false,
+  globalSharingSupported: false,
 
   fetchSecrets: async () => {
     set({ isLoading: true, error: null });
@@ -291,4 +301,63 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
   },
 
   clearMessages: () => set({ error: null, successMessage: null }),
+
+  fetchGlobalSecrets: async () => {
+    try {
+      const [globalSecrets, sharingStatus] = await Promise.all([
+        settingsApi.getGlobalSecrets(),
+        settingsApi.getGlobalSharingStatus(),
+      ]);
+      set({
+        globalSecrets,
+        globalSharingEnabled: sharingStatus.enabled,
+        globalSharingSupported: true,
+      });
+    } catch {
+      set({ globalSecrets: {}, globalSharingEnabled: false, globalSharingSupported: false });
+    }
+  },
+
+  saveGlobalApiKey: async (providerId: string, apiKey: string) => {
+    set({ isSaving: true, error: null, successMessage: null });
+    try {
+      const provider = PROVIDERS.find((p) => p.id === providerId);
+      if (!provider) throw new Error('Unknown provider');
+
+      const { globalSecrets } = get();
+      const existing = globalSecrets[provider.secretKey];
+      if (Array.isArray(existing) && existing.length > 0) {
+        for (const secret of existing) {
+          try { await settingsApi.deleteGlobalSecret(provider.secretKey, secret.id); } catch { /* ignore */ }
+        }
+      }
+
+      await settingsApi.writeGlobalSecret(provider.secretKey, apiKey, provider.name);
+      await get().fetchGlobalSecrets();
+      set({ isSaving: false, successMessage: `${provider.name} global API key saved` });
+    } catch (error) {
+      set({ isSaving: false, error: error instanceof Error ? error.message : 'Failed to save global API key' });
+    }
+  },
+
+  deleteGlobalApiKey: async (secretKey: string) => {
+    set({ isSaving: true, error: null, successMessage: null });
+    try {
+      await settingsApi.deleteGlobalSecret(secretKey);
+      await get().fetchGlobalSecrets();
+      set({ isSaving: false, successMessage: 'Global API key deleted' });
+    } catch (error) {
+      set({ isSaving: false, error: error instanceof Error ? error.message : 'Failed to delete global API key' });
+    }
+  },
+
+  setGlobalSharing: async (enabled: boolean) => {
+    set({ isSaving: true, error: null });
+    try {
+      await settingsApi.setGlobalSharing(enabled);
+      set({ globalSharingEnabled: enabled, isSaving: false });
+    } catch (error) {
+      set({ isSaving: false, error: error instanceof Error ? error.message : 'Failed to toggle global sharing' });
+    }
+  },
 }));

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -19,6 +19,7 @@ export type Action =
   | 'character:edit'        // edit existing characters
   | 'character:delete'      // delete characters
   | 'settings:view'         // access settings page
+  | 'settings:personal'     // manage own personal API keys
   | 'settings:api_keys'     // manage API keys / secrets
   | 'admin:panel';          // access admin panel / user management
 
@@ -30,7 +31,8 @@ const ACTION_MIN_ROLE: Record<Action, UserRole> = {
   'character:edit':    'contributor',
   'character:delete':  'contributor',
   'settings:view':     'admin',
-  'settings:api_keys': 'admin',
+  'settings:personal': 'end_user',
+  'settings:api_keys': 'end_user',
   'admin:panel':       'admin',
 };
 


### PR DESCRIPTION
First-time users see a 5-step guided walkthrough (welcome, AI provider, characters, chat, completion) that auto-triggers on login and can be replayed from Settings.

AI credentials are now per-user: all roles can enter personal API keys via a new "My API Keys" page (Key icon in header for non-admins). Owners get a "Global API Keys" section in AI Settings with a sharing toggle so their keys serve as defaults for users without personal ones.

- Add onboardingStore + OnboardingWalkthrough overlay component
- Add MyKeysPage for non-admin users with provider grid and key management
- Lower settings:api_keys permission to end_user, add settings:personal
- Add global secrets state/actions to settingsStore + API client
- Update chatStore getProviderAndModel() to check personal then global
- Add openToPage() to settingsPanelStore for direct page navigation
- Update AISettingsPage with owner-only global keys section + share toggle
- Update onboarding to show "Set Up My Keys" CTA for non-admin users