### PR TITLE
fix: resolve CharacterManagementPage build errors

### DIFF
--- a/src/components/settings/CharacterManagementPage.tsx
+++ b/src/components/settings/CharacterManagementPage.tsx
@@ -10,7 +10,7 @@ import {
   Trash2,
 } from 'lucide-react';
 import { useCharacterStore } from '../../stores/characterStore';
-import { useCharacterOwnershipStore } from '../../stores/characterOwnershipStore';
+import { useCharacterOwnershipStore, type CharacterOwnershipState } from '../../stores/characterOwnershipStore';
 import { useAuthStore } from '../../stores/authStore';
 import { useSettingsPanelStore } from '../../stores/settingsPanelStore';
 import { can } from '../../utils/permissions';
@@ -221,7 +221,7 @@ interface CharacterRowProps {
   character: CharacterInfo;
   userHandle: string;
   userRole: string | undefined;
-  ownershipStore: ReturnType<typeof useCharacterOwnershipStore>;
+  ownershipStore: CharacterOwnershipState;
   onEdit: (avatar: string) => void;
   onDuplicate: (avatar: string) => void;
   onDelete: (avatar: string) => void;

--- a/src/stores/characterOwnershipStore.ts
+++ b/src/stores/characterOwnershipStore.ts
@@ -26,7 +26,7 @@ function saveOwnership(map: Record<string, OwnershipEntry>) {
   }
 }
 
-interface CharacterOwnershipState {
+export interface CharacterOwnershipState {
   ownershipMap: Record<string, OwnershipEntry>;
 
   // Mutations


### PR DESCRIPTION
Export CharacterOwnershipState interface and use it directly as the prop type instead of ReturnType<typeof useCharacterOwnershipStore> which resolves to unknown in strict build mode (tsc -b).