### PR TITLE
fix: surface actual server error on extension install failure

### DIFF
--- a/src/components/settings/InstallFromUrlModal.tsx
+++ b/src/components/settings/InstallFromUrlModal.tsx
@@ -28,7 +28,8 @@ export function InstallFromUrlModal({ isOpen, onClose }: InstallFromUrlModalProp
       setUrl('');
       onClose();
     } else {
-      showToastGlobal('Failed to install extension', 'error');
+      const storeError = useServerExtensionStore.getState().error;
+      showToastGlobal(storeError || 'Failed to install extension', 'error');
     }
   }
 

--- a/src/components/settings/ServerExtensionsSection.tsx
+++ b/src/components/settings/ServerExtensionsSection.tsx
@@ -285,7 +285,8 @@ function AvailableCard({
     if (success) {
       showToastGlobal(`Installed ${ext.name}`, 'success');
     } else {
-      showToastGlobal(`Failed to install ${ext.name}`, 'error');
+      const storeError = useServerExtensionStore.getState().error;
+      showToastGlobal(storeError || `Failed to install ${ext.name}`, 'error');
     }
   }
 
@@ -435,6 +436,11 @@ export function ServerExtensionsSection() {
           <AlertCircle size={14} className="text-red-400 flex-shrink-0 mt-0.5" />
           <div className="flex-1 min-w-0">
             <p className="text-xs text-red-400">{error}</p>
+            {/already (installed|exists)/i.test(error) && (
+              <p className="text-xs text-red-300 mt-1 opacity-80">
+                A previous failed install may have left a partial folder. Delete the extension first, then retry.
+              </p>
+            )}
           </div>
           <button
             type="button"


### PR DESCRIPTION
## Summary
- Install toast now shows the real error message from the ST backend (instead of generic "Failed to install extension")
- 409 conflict errors in the section banner now include a recovery hint: *"A previous failed install may have left a partial folder. Delete the extension first, then retry."*

## Context
A failed install (500) can leave a partial extension folder on disk. Retrying then gets a 409 conflict. The backend should clean up on failure, but we can't control that — so surfacing the real error and adding the recovery hint at least makes it actionable.

## Test plan
- [ ] Attempt to install an extension that errors → toast shows the actual error from the server
- [ ] Trigger a 409 (install same extension twice) → error banner includes the recovery hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)