### PR TITLE
feat(characters): server-backed global character sharing

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -77,6 +77,16 @@ export interface UserInfo {
   created?: number;
 }
 
+export type CharacterVisibility = 'global' | 'personal';
+
+export interface CharacterMetadataEntry {
+  ownerHandle: string;
+  visibility: CharacterVisibility;
+  claimedAt: number;
+}
+
+export type CharacterMetadataMap = Record<string, CharacterMetadataEntry>;
+
 export interface CharacterInfo {
   name: string;
   avatar: string; // filename like "CharacterName.png"
@@ -91,6 +101,10 @@ export interface CharacterInfo {
   chat_size?: number;
   fav?: boolean;
   tags?: string[];
+  // Global character sharing (populated by the server; may be absent on older
+  // backends, in which case callers treat as 'personal' / null).
+  visibility?: CharacterVisibility;
+  owner_handle?: string | null;
   // Advanced Character Card V2 fields
   alternate_greetings?: string[];
   system_prompt?: string;
@@ -442,6 +456,36 @@ export const api = {
     } catch {
       return text;
     }
+  },
+
+  // --- Global character sharing ---
+
+  /**
+   * Fetches the character ownership/visibility map from the server.
+   * Returns {} on older backends that don't yet expose the endpoint, so
+   * callers can treat every character as personal/unowned.
+   */
+  async getCharacterMetadata(): Promise<CharacterMetadataMap> {
+    try {
+      const response = await apiRequest<CharacterMetadataMap>('/api/characters/metadata', {
+        method: 'POST',
+      });
+      return response || {};
+    } catch {
+      return {};
+    }
+  },
+
+  /**
+   * Moves a character between global and personal scope. OWNER-only on the
+   * server. On success, the caller should refetch characters + metadata —
+   * the file has physically moved directories.
+   */
+  async setCharacterVisibility(avatarUrl: string, visibility: CharacterVisibility): Promise<void> {
+    await apiRequest('/api/characters/set-visibility', {
+      method: 'POST',
+      body: JSON.stringify({ avatar_url: avatarUrl, visibility }),
+    });
   },
 
   // Chat endpoints - use avatar filename directly for consistency

--- a/src/components/settings/CharacterManagementPage.tsx
+++ b/src/components/settings/CharacterManagementPage.tsx
@@ -13,6 +13,7 @@ import {
 } from 'lucide-react';
 import { useCharacterStore } from '../../stores/characterStore';
 import { useCharacterOwnershipStore, type CharacterOwnershipState } from '../../stores/characterOwnershipStore';
+import type { UserRole } from '../../types';
 import { useAuthStore } from '../../stores/authStore';
 import { useSettingsPanelStore } from '../../stores/settingsPanelStore';
 import { can } from '../../utils/permissions';
@@ -86,13 +87,11 @@ export function CharacterManagementPage() {
   };
 
   const handleDuplicate = async (avatar: string) => {
-    const newAvatar = await duplicateCharacter(avatar);
-    if (newAvatar) {
-      // Copy original visibility to the duplicate
-      const originalVisibility = ownershipStore.getVisibility(avatar);
-      ownershipStore.setOwner(newAvatar, userHandle);
-      ownershipStore.setVisibility(newAvatar, originalVisibility);
-    }
+    // Server-side: duplicating always creates a new personal copy in the
+    // caller's directory. Visibility and ownership for the new copy are
+    // left at their defaults (personal, unowned) — the caller can promote
+    // the copy to global afterwards if desired.
+    await duplicateCharacter(avatar);
   };
 
   const handleDelete = async () => {
@@ -103,9 +102,22 @@ export function CharacterManagementPage() {
     setIsDeleting(false);
   };
 
-  const handleToggleVisibility = (avatar: string) => {
+  const [visibilityBusy, setVisibilityBusy] = useState<string | null>(null);
+
+  const handleToggleVisibility = async (avatar: string) => {
     const current = ownershipStore.getVisibility(avatar);
-    ownershipStore.setVisibility(avatar, current === 'global' ? 'personal' : 'global');
+    const next = current === 'global' ? 'personal' : 'global';
+    setVisibilityBusy(avatar);
+    try {
+      await ownershipStore.setVisibility(avatar, next);
+      // Server physically moved the file between directories — refresh the
+      // character list so subsequent API calls target the right scope.
+      await fetchCharacters();
+    } catch (err) {
+      console.error('Failed to change character visibility', err);
+    } finally {
+      setVisibilityBusy(null);
+    }
   };
 
   const handleExport = async (avatar: string, format: 'png' | 'json') => {
@@ -218,6 +230,7 @@ export function CharacterManagementPage() {
                 onToggleVisibility={handleToggleVisibility}
                 onExport={handleExport}
                 isExporting={exportingAvatar === char.avatar}
+                isVisibilityBusy={visibilityBusy === char.avatar}
               />
             ))}
           </ul>
@@ -268,7 +281,7 @@ export function CharacterManagementPage() {
 interface CharacterRowProps {
   character: CharacterInfo;
   userHandle: string;
-  userRole: string | undefined;
+  userRole: UserRole | undefined;
   ownershipStore: CharacterOwnershipState;
   onEdit: (avatar: string) => void;
   onDuplicate: (avatar: string) => void;
@@ -276,6 +289,7 @@ interface CharacterRowProps {
   onToggleVisibility: (avatar: string) => void;
   onExport: (avatar: string, format: 'png' | 'json') => void;
   isExporting: boolean;
+  isVisibilityBusy: boolean;
 }
 
 function CharacterRow({
@@ -289,15 +303,16 @@ function CharacterRow({
   onToggleVisibility,
   onExport,
   isExporting,
+  isVisibilityBusy,
 }: CharacterRowProps) {
   const avatar = character.avatar;
   const visibility = ownershipStore.getVisibility(avatar);
   const isOwned = ownershipStore.isOwnedBy(avatar, userHandle);
   const ownerHandle = ownershipStore.getOwner(avatar);
 
-  const canEdit = ownershipStore.canEditCharacter(avatar, userHandle, userRole as any);
-  const canDelete = ownershipStore.canDeleteCharacter(avatar, userHandle, userRole as any);
-  const canDuplicate = can(userRole as any, 'character:create');
+  const canEdit = ownershipStore.canEditCharacter(avatar, userHandle, userRole);
+  const canDelete = ownershipStore.canDeleteCharacter(avatar, userHandle, userRole);
+  const canDuplicate = can(userRole, 'character:create');
 
   const creator = character.creator || character.data?.creator || null;
   const thumbnailUrl = `/thumbnail?type=avatar&file=${encodeURIComponent(avatar)}`;
@@ -399,14 +414,21 @@ function CharacterRow({
               <Copy size={14} />
             </button>
           )}
-          {isOwned && (
+          {userRole === 'owner' && (
             <button
               onClick={() => onToggleVisibility(avatar)}
-              className="p-1.5 rounded-lg text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-tertiary)] transition-colors"
+              disabled={isVisibilityBusy}
+              className="p-1.5 rounded-lg text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-tertiary)] transition-colors disabled:opacity-50"
               title={visibility === 'global' ? 'Make personal' : 'Make global'}
               aria-label={`Toggle visibility for ${character.name}`}
             >
-              {visibility === 'global' ? <Globe size={14} /> : <Lock size={14} />}
+              {isVisibilityBusy ? (
+                <Loader2 size={14} className="animate-spin" />
+              ) : visibility === 'global' ? (
+                <Globe size={14} />
+              ) : (
+                <Lock size={14} />
+              )}
             </button>
           )}
           {canDelete && (

--- a/src/stores/characterOwnershipStore.ts
+++ b/src/stores/characterOwnershipStore.ts
@@ -1,85 +1,97 @@
 import { create } from 'zustand';
+import { api, type CharacterMetadataMap } from '../api/client';
 import type { UserRole } from '../types';
 
-const OWNERSHIP_KEY = 'sillytavern_character_ownership';
+/**
+ * Server-backed character ownership and visibility.
+ *
+ * Ownership and the personal/global visibility flag are stored in
+ * `_global/character-metadata.json` on the SillyTavern backend and exposed
+ * via `POST /api/characters/metadata`. Mutations go through
+ * `POST /api/characters/set-visibility`, which physically moves the PNG
+ * between a user's personal directory and `_global/characters/`.
+ *
+ * This store is a thin cache over the server map. It exposes synchronous
+ * query helpers (used widely in render paths like `CharacterRow`) plus async
+ * mutations that hit the server and refresh the cache.
+ *
+ * Anything not tracked in the server map defaults to `visibility: 'personal'`
+ * with no owner. The GLOBAL vs PERSONAL badge in the UI reflects the server's
+ * authoritative state — if it says global, the file physically lives in the
+ * shared directory and every user will see it.
+ */
 
 export interface OwnershipEntry {
   ownerHandle: string;
   visibility: 'global' | 'personal';
 }
 
-function loadOwnership(): Record<string, OwnershipEntry> {
-  try {
-    const raw = localStorage.getItem(OWNERSHIP_KEY);
-    if (!raw) return {};
-    return JSON.parse(raw);
-  } catch {
-    return {};
-  }
-}
-
-function saveOwnership(map: Record<string, OwnershipEntry>) {
-  try {
-    localStorage.setItem(OWNERSHIP_KEY, JSON.stringify(map));
-  } catch {
-    // ignore quota/security errors
-  }
-}
-
 export interface CharacterOwnershipState {
   ownershipMap: Record<string, OwnershipEntry>;
+  isLoading: boolean;
+  error: string | null;
 
-  // Mutations
-  setOwner: (avatar: string, ownerHandle: string) => void;
-  setVisibility: (avatar: string, visibility: 'global' | 'personal') => void;
-  removeOwnership: (avatar: string) => void;
+  // Fetch the current map from the server. Idempotent — safe to call on every
+  // character refresh.
+  fetchOwnership: () => Promise<void>;
 
-  // Queries
+  // Mutations — these hit the server. On success the cache is updated in
+  // place; on failure the error field is set and the cache is left alone.
+  setVisibility: (avatar: string, visibility: 'global' | 'personal') => Promise<void>;
+
+  // Queries — synchronous against the in-memory cache.
   getOwner: (avatar: string) => string | null;
   getVisibility: (avatar: string) => 'global' | 'personal';
   isOwnedBy: (avatar: string, handle: string) => boolean;
 
   // Permission helpers
-  canEditCharacter: (avatar: string, userHandle: string, userRole: UserRole) => boolean;
-  canDeleteCharacter: (avatar: string, userHandle: string, userRole: UserRole) => boolean;
+  canEditCharacter: (avatar: string, userHandle: string, userRole: UserRole | undefined) => boolean;
+  canDeleteCharacter: (avatar: string, userHandle: string, userRole: UserRole | undefined) => boolean;
+}
+
+function toOwnershipMap(serverMap: CharacterMetadataMap): Record<string, OwnershipEntry> {
+  const result: Record<string, OwnershipEntry> = {};
+  for (const [avatar, entry] of Object.entries(serverMap)) {
+    if (!entry || typeof entry !== 'object') continue;
+    result[avatar] = {
+      ownerHandle: entry.ownerHandle,
+      visibility: entry.visibility === 'global' ? 'global' : 'personal',
+    };
+  }
+  return result;
 }
 
 export const useCharacterOwnershipStore = create<CharacterOwnershipState>((set, get) => ({
-  ownershipMap: loadOwnership(),
+  ownershipMap: {},
+  isLoading: false,
+  error: null,
 
-  setOwner: (avatar, ownerHandle) => {
-    const { ownershipMap } = get();
-    const existing = ownershipMap[avatar];
-    const updated = {
-      ...ownershipMap,
-      [avatar]: {
-        ownerHandle,
-        visibility: existing?.visibility ?? 'global' as const,
-      },
-    };
-    saveOwnership(updated);
-    set({ ownershipMap: updated });
+  fetchOwnership: async () => {
+    set({ isLoading: true, error: null });
+    try {
+      const serverMap = await api.getCharacterMetadata();
+      set({ ownershipMap: toOwnershipMap(serverMap), isLoading: false });
+    } catch (err) {
+      set({
+        isLoading: false,
+        error: err instanceof Error ? err.message : 'Failed to load character ownership',
+      });
+    }
   },
 
-  setVisibility: (avatar, visibility) => {
-    const { ownershipMap } = get();
-    const existing = ownershipMap[avatar];
-    if (!existing) return;
-    const updated = {
-      ...ownershipMap,
-      [avatar]: { ...existing, visibility },
-    };
-    saveOwnership(updated);
-    set({ ownershipMap: updated });
-  },
-
-  removeOwnership: (avatar) => {
-    const { ownershipMap } = get();
-    if (!ownershipMap[avatar]) return;
-    const updated = { ...ownershipMap };
-    delete updated[avatar];
-    saveOwnership(updated);
-    set({ ownershipMap: updated });
+  setVisibility: async (avatar, visibility) => {
+    set({ error: null });
+    try {
+      await api.setCharacterVisibility(avatar, visibility);
+      // Refetch the map so we pick up the server's authoritative state
+      // (owner handle, claimedAt, and any file-move side effects).
+      await get().fetchOwnership();
+    } catch (err) {
+      set({
+        error: err instanceof Error ? err.message : 'Failed to update visibility',
+      });
+      throw err;
+    }
   },
 
   getOwner: (avatar) => {
@@ -87,7 +99,7 @@ export const useCharacterOwnershipStore = create<CharacterOwnershipState>((set, 
   },
 
   getVisibility: (avatar) => {
-    return get().ownershipMap[avatar]?.visibility ?? 'global';
+    return get().ownershipMap[avatar]?.visibility ?? 'personal';
   },
 
   isOwnedBy: (avatar, handle) => {
@@ -96,11 +108,19 @@ export const useCharacterOwnershipStore = create<CharacterOwnershipState>((set, 
 
   canEditCharacter: (avatar, userHandle, userRole) => {
     if (userRole === 'owner') return true;
-    return get().ownershipMap[avatar]?.ownerHandle === userHandle;
+    const entry = get().ownershipMap[avatar];
+    // No entry → character is unowned personal. Only the app owner can claim
+    // it; regular users cannot edit it through this path. The main character
+    // list still gates edits via the character endpoints, which are the
+    // authoritative check.
+    if (!entry) return false;
+    return entry.ownerHandle === userHandle;
   },
 
   canDeleteCharacter: (avatar, userHandle, userRole) => {
     if (userRole === 'owner') return true;
-    return get().ownershipMap[avatar]?.ownerHandle === userHandle;
+    const entry = get().ownershipMap[avatar];
+    if (!entry) return false;
+    return entry.ownerHandle === userHandle;
   },
 }));

--- a/src/stores/characterStore.ts
+++ b/src/stores/characterStore.ts
@@ -18,7 +18,6 @@ import {
   bookToCharacterBookV2,
 } from './worldInfoStore';
 import { useCharacterOwnershipStore } from './characterOwnershipStore';
-import { useAuthStore } from './authStore';
 
 const FAVORITES_KEY = 'sillytavern_character_favorites';
 const LINKED_BOOKS_KEY = 'sillytavern_character_linked_books_v1';
@@ -157,7 +156,12 @@ export const useCharacterStore = create<CharacterState>((set, get) => ({
   fetchCharacters: async () => {
     set({ isLoading: true, error: null });
     try {
-      const characters = await api.getCharacters();
+      // Fetch characters and ownership metadata in parallel — they're
+      // independent but both need to be fresh before UI renders badges.
+      const [characters] = await Promise.all([
+        api.getCharacters(),
+        useCharacterOwnershipStore.getState().fetchOwnership(),
+      ]);
       set({ characters, isLoading: false });
     } catch (error) {
       set({
@@ -206,14 +210,10 @@ export const useCharacterStore = create<CharacterState>((set, get) => ({
     set({ isCreating: true, error: null });
     try {
       const avatarUrl = await api.createCharacter(data, avatarFile);
-      // Record ownership for the creating user
-      if (avatarUrl) {
-        const currentUser = useAuthStore.getState().currentUser;
-        if (currentUser) {
-          useCharacterOwnershipStore.getState().setOwner(avatarUrl, currentUser.handle);
-        }
-      }
-      // Refresh the character list
+      // Ownership is recorded server-side when a character is flipped to
+      // global. Newly-created characters start personal with no metadata
+      // entry, which is the correct default.
+      // Refresh the character list (also refetches ownership).
       await get().fetchCharacters();
       set({ isCreating: false });
       return avatarUrl;
@@ -265,8 +265,9 @@ export const useCharacterStore = create<CharacterState>((set, get) => ({
         saveFavorites(newFavorites);
         set({ favorites: newFavorites });
       }
-      // Clean up ownership data
-      useCharacterOwnershipStore.getState().removeOwnership(avatar);
+      // Ownership cleanup happens server-side as part of /api/characters/delete
+      // when the target is a global character. For personal characters there's
+      // no metadata entry to clean up.
       // Clean up character-embedded lorebook and linked-book references
       useWorldInfoStore.getState().deleteCharacterBook(avatar);
       if (linkedBookIdsByAvatar[avatar]) {
@@ -291,17 +292,9 @@ export const useCharacterStore = create<CharacterState>((set, get) => ({
     set({ isDuplicating: true, error: null });
     try {
       const newAvatar = await api.duplicateCharacter(avatar);
-      // Record the duplicating user as owner of the new copy
-      if (newAvatar) {
-        const currentUser = useAuthStore.getState().currentUser;
-        if (currentUser) {
-          const ownershipStore = useCharacterOwnershipStore.getState();
-          const originalVisibility = ownershipStore.getVisibility(avatar);
-          ownershipStore.setOwner(newAvatar, currentUser.handle);
-          ownershipStore.setVisibility(newAvatar, originalVisibility);
-        }
-      }
-      // Refresh list to show the new character
+      // Server-side: duplicating a global character produces a personal
+      // copy in the caller's directory. No metadata to record client-side.
+      // Refresh list to show the new character (also refetches ownership).
       await get().fetchCharacters();
       set({ isDuplicating: false });
       return newAvatar;


### PR DESCRIPTION
## Summary

Replaces the localStorage-only character ownership store with a server-backed store that calls the new `/api/characters/metadata` and `/api/characters/set-visibility` endpoints on the ST fork. Flipping a character to GLOBAL now physically moves the PNG into the backend's `_global/characters/` directory so every logged-in user sees it.

Fixes the bug where GLOBAL-tagged characters were only visible to the owner because ST's multi-user mode isolates character directories per user.

## Changes

- `src/api/client.ts` — add `CharacterMetadataMap` type, `visibility` and `owner_handle` fields on `CharacterInfo`, and two new API methods: `getCharacterMetadata()` and `setCharacterVisibility()`.
- `src/stores/characterOwnershipStore.ts` — rewrite as an async cache over the server metadata map. Drops all localStorage persistence. Preserves the same synchronous query surface (`getOwner`, `getVisibility`, `isOwnedBy`, `canEdit`, `canDelete`) so callers don't change, and adds `fetchOwnership()` and async `setVisibility()`.
- `src/stores/characterStore.ts` — `fetchCharacters()` now loads characters and ownership metadata in parallel. Removed dead `setOwner` / `removeOwnership` calls from `createCharacter`, `deleteCharacter`, and `duplicateCharacter` — the server is authoritative.
- `src/components/settings/CharacterManagementPage.tsx` — `handleToggleVisibility` is now async, shows a spinner during the server round-trip, and refreshes the character list on success (the file physically moved directories). The toggle button is gated on `userRole === 'owner'` to match server enforcement. Also replaced pre-existing `as any` casts on `userRole` with the proper `UserRole` type while touching the file.

## Backend requirement

Requires the ST fork at sammygallo/SillyTavern#12 (merged) with the matching `/api/characters/metadata` and `/api/characters/set-visibility` endpoints. The `ghcr.io/sammygallo/sillytavern:feat-role-based-permissions` docker image has already been rebuilt.

## Test plan

- [ ] As the OWNER, open Character Management → click the Globe/Lock toggle on a personal character → verify it moves to GLOBAL and the PNG physically relocates to `_global/characters/`.
- [ ] Log in as a second (non-owner) user → the global character appears in their sidebar and Character Management.
- [ ] Second user cannot edit / rename / delete the global character (expect 403).
- [ ] Second user can start a chat with the global character — their chat history stays in their own `chats/` dir.
- [ ] OWNER can edit and delete the global character.
- [ ] Demoting a global character back to PERSONAL moves the file into the OWNER's personal dir.
- [ ] Duplicating a global character creates a new personal copy for the caller.
- [ ] Thumbnails render for globals on users who never had the file in their personal dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)