### PR TITLE
ci: publish frontend image to GHCR so droplet doesn't build

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,62 @@
+# Builds and publishes the frontend Docker image to GHCR so the droplet can
+# just pull a pre-built image instead of running the 10-minute Vite build on
+# a 1-vCPU box. Runs on every push to main and on manual dispatch.
+
+name: Publish Frontend Docker Image
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  # Repo name lowercased at runtime (GHCR requires lowercase)
+  REPO: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set lowercase image name
+        run: echo "IMAGE_NAME=${REPO,,}" >> "${GITHUB_ENV}"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        uses: docker/metadata-action@v5
+        id: metadata
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=sha,format=short
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,12 @@
 services:
   frontend:
-    build: .
+    # Pre-built by .github/workflows/docker-publish.yml on every push to main.
+    # The droplet pulls this image instead of running the 10-minute Vite build
+    # on its single vCPU. If you need a local image for dev, uncomment `build: .`
+    # below — docker compose will prefer a registry pull unless you run
+    # `docker compose build` explicitly.
+    image: ghcr.io/sammygallo/sillytavern-mobile:latest
+    # build: .
     ports:
       - "${PORT:-80}:80"
     restart: unless-stopped


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that builds the Vite/nginx frontend image on every push to \`main\` and publishes it to \`ghcr.io/sammygallo/sillytavern-mobile\`. Updates \`docker-compose.yml\` to pull that image instead of running \`build: .\` on the deploy target.

## Why

The production droplet is a DO \`s-1vcpu-1gb\` ($6/mo) box. Running \`vite build\` on it takes **10–13 minutes** and thrashes the memory budget (1890 TypeScript modules on 1 GB RAM with swap). That's also what bit us on the last deploy — a mid-build SSH timeout left the droplet running stale containers.

Building on a GitHub Actions runner takes **60–90 seconds**, with layer caching (\`type=gha\`) making subsequent runs even faster. After this lands, droplet deploys become:

\`\`\`bash
ssh droplet "cd /opt/sillytavern-mobile && git pull && docker compose pull && docker compose up -d"
\`\`\`

No more \`--build\`, no more 10-minute SSH tightrope.

## Changes

- \`.github/workflows/docker-publish.yml\` — new workflow, triggers on push to \`main\` and on \`workflow_dispatch\`. Publishes three tags: \`:latest\`, \`:main\`, \`:sha-<short>\`. Uses GHA cache for npm install + vite compile layers.
- \`docker-compose.yml\` — frontend service switches from \`build: .\` to \`image: ghcr.io/sammygallo/sillytavern-mobile:latest\`. The original \`build: .\` is kept as a commented-out local-dev fallback.
- (Out-of-repo) \`~/.claude/skills/deploy-ggbc/SKILL.md\` updated to wait for frontend CI and drop the \`--build\` flag.

## Rollout plan

1. Merge this PR.
2. Wait for the "Publish Frontend Docker Image" workflow run to finish (~2 min).
3. Confirm \`ghcr.io/sammygallo/sillytavern-mobile:latest\` exists.
4. SSH to droplet, \`git pull && docker compose pull && docker compose up -d\`. First deploy validates the whole path end-to-end.

## Test plan

- [ ] CI workflow runs successfully on the PR merge commit.
- [ ] \`ghcr.io/sammygallo/sillytavern-mobile:latest\` is visible under the \`sammygallo\` packages page.
- [ ] Droplet \`docker compose pull\` succeeds without \`manifest unknown\`.
- [ ] \`docker compose up -d\` recreates the frontend container and it comes up healthy.
- [ ] Site loads at production URL and the character management page renders.
- [ ] Subsequent deploy (via the \`deploy-ggbc\` skill with the new workflow) completes in <1 minute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)