### PR TITLE
chore(gitignore): ignore docker-compose.override.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,11 @@ dist/
 .env.local
 .env.*.local
 
+# Local docker compose overrides (host-specific port bindings, dev tweaks, etc.)
+# The production droplet uses this to bind frontend to 127.0.0.1:8080.
+docker-compose.override.yml
+docker-compose.override.yaml
+
 # Editor directories and files
 .idea/
 .vscode/


### PR DESCRIPTION
## Summary

Add \`docker-compose.override.yml\` (and \`.yaml\`) to \`.gitignore\` so host-specific compose overrides can live next to the tracked \`docker-compose.yml\` without being accidentally committed.

## Why

The production droplet has its own \`docker-compose.override.yml\` that binds the frontend container to \`127.0.0.1:8080\` for the reverse-proxy / Cloudflare tunnel in front of it. Without this entry, future \`git pull\`s on the droplet would show it as an untracked file forever (noise), and anyone else who creates a local override for dev would risk committing it.

This is the standard docker compose pattern — \`docker-compose.override.yml\` is auto-merged on top of the base file, so it's the idiomatic place to put env-specific tweaks.

## Changes

- \`.gitignore\`: adds \`docker-compose.override.yml\` and \`docker-compose.override.yaml\`

## Notes

- Commit message is marked \`[skip ci]\` because this change has zero effect on the built frontend image — no need to burn a CI run.
- Droplet already has its override in place and the effective \`docker compose config\` is correct; this PR just closes the loop for the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)