### PR TITLE
fix(ai-settings): resolve tsc -b errors from PR #80

### DIFF
--- a/src/components/settings/InstallProviderFromUrlModal.tsx
+++ b/src/components/settings/InstallProviderFromUrlModal.tsx
@@ -348,7 +348,17 @@ export function InstallProviderFromUrlModal({ isOpen, onClose }: Props) {
           <Button variant="ghost" size="sm" onClick={onClose} disabled={running}>
             Cancel
           </Button>
-          {phase !== 'preview' ? (
+          {phase === 'preview' || phase === 'saving' ? (
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={handleSave}
+              disabled={!name.trim() || !url.trim() || running}
+              isLoading={phase === 'saving'}
+            >
+              Save provider
+            </Button>
+          ) : (
             <Button
               variant="primary"
               size="sm"
@@ -363,16 +373,6 @@ export function InstallProviderFromUrlModal({ isOpen, onClose }: Props) {
               ) : (
                 'Extract'
               )}
-            </Button>
-          ) : (
-            <Button
-              variant="primary"
-              size="sm"
-              onClick={handleSave}
-              disabled={!name.trim() || !url.trim() || running}
-              isLoading={phase === 'saving'}
-            >
-              Save provider
             </Button>
           )}
         </div>

--- a/src/components/settings/ProviderCatalogPage.tsx
+++ b/src/components/settings/ProviderCatalogPage.tsx
@@ -25,6 +25,7 @@ import {
   BUILTIN_CATALOG,
   type CatalogProvider,
   type ProviderCategory,
+  type UserProvider,
 } from '../../api/providerCatalog';
 import { InstallProviderFromUrlModal } from './InstallProviderFromUrlModal';
 
@@ -134,7 +135,7 @@ function UserProviderCard({
   isActive,
   onDelete,
 }: {
-  provider: ReturnType<typeof useCustomProviderStore>['list'][number];
+  provider: UserProvider;
   isActive: boolean;
   onDelete: () => void;
 }) {


### PR DESCRIPTION
## Summary

Follow-up to #80. Two TypeScript errors passed local \`tsc --noEmit\` but failed \`tsc -b\` in the Docker CI build:

- **\`InstallProviderFromUrlModal.tsx\`**: Footer button conditional used \`phase !== 'preview'\` which TS narrowed so \`phase === 'saving'\` in the else branch was unreachable. Also a real latent bug — the Save button would flip back to Probe/Extract while the save was in flight. Rewrote as \`phase === 'preview' || phase === 'saving'\`.
- **\`ProviderCatalogPage.tsx\`**: \`UserProviderCard\` typed its \`provider\` prop as \`ReturnType<typeof useCustomProviderStore>['list'][number]\`, which hits the zustand hook's overloaded signature and resolves to \`unknown\`. Use the exported \`UserProvider\` type directly.

## Test plan

- [x] \`npx tsc -b\` clean
- [x] \`npx vite build\` clean
- [x] \`npx eslint\` clean on both files
- [x] Preview browser still renders cyberpunk default correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)