### PR TITLE
feat(permissions): permission groups UI + API client

### DIFF
--- a/docker/seed-owner.sh
+++ b/docker/seed-owner.sh
@@ -70,11 +70,14 @@ CSRF=$($WGET -O- \
 
 OWNER_NAME="${OWNER_NAME:-$OWNER_HANDLE}"
 
-# Create the owner account
+# Create the owner account. The backend uses permission groups as the source
+# of truth; the { admin, role } shape is still accepted for backward compat
+# but we send the new groupId shape to stay current. The owner-default group
+# is guaranteed to exist after the server-side migration runs on first boot.
 CREATE=$($WGET -O- \
   --header="Content-Type: application/json" \
   --header="X-CSRF-Token: $CSRF" \
-  --post-data="{\"handle\":\"$OWNER_HANDLE\",\"name\":\"$OWNER_NAME\",\"password\":\"$OWNER_PASSWORD\",\"admin\":true,\"role\":\"owner\"}" \
+  --post-data="{\"handle\":\"$OWNER_HANDLE\",\"name\":\"$OWNER_NAME\",\"password\":\"$OWNER_PASSWORD\",\"groupId\":\"owner-default\"}" \
   --load-cookies=/tmp/st-cookies.txt \
   "$ST/api/users/create" 2>/dev/null) || true
 

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -212,14 +212,36 @@ export const api = {
     await apiRequest('/api/users/logout', { method: 'POST' });
   },
 
-  async getCurrentUser(): Promise<{ handle: string; name: string; role: import('../types').UserRole; avatar?: string } | null> {
+  async getCurrentUser(): Promise<{
+    handle: string;
+    name: string;
+    role: import('../types').UserRole;
+    avatar?: string;
+    groupId?: string;
+    permissions?: import('../types').Permission[];
+  } | null> {
     try {
-      const user = await apiRequest<{ handle: string; name: string; admin: boolean; role?: string; avatar?: string }>('/api/users/me');
+      const user = await apiRequest<{
+        handle: string;
+        name: string;
+        admin: boolean;
+        role?: string;
+        avatar?: string;
+        groupId?: string;
+        permissions?: string[];
+      }>('/api/users/me');
       // Derive role: backend may return role directly (Phase 1 backend),
       // or fall back to admin boolean for older servers.
       const role = (user.role as import('../types').UserRole) ||
         (user.admin ? 'admin' : 'end_user');
-      return { handle: user.handle, name: user.name, role, avatar: user.avatar };
+      return {
+        handle: user.handle,
+        name: user.name,
+        role,
+        avatar: user.avatar,
+        groupId: user.groupId,
+        permissions: user.permissions,
+      };
     } catch {
       return null;
     }
@@ -264,10 +286,12 @@ export const api = {
     }
 
     // Now create the new user (we're logged in as default-user/admin)
-    // First registrant gets owner role + admin flag for backward compat
+    // First registrant gets the Owner group; the backend also accepts the
+    // legacy { admin, role } shape during the transition window, but we send
+    // the new shape to avoid the deprecation warning.
     const result = await apiRequest<{ handle: string }>('/api/users/create', {
       method: 'POST',
-      body: JSON.stringify({ handle, name, password, admin: true, role: 'owner' }),
+      body: JSON.stringify({ handle, name, password, groupId: 'owner-default' }),
     });
 
     // Logout default-user
@@ -733,8 +757,14 @@ export interface AdminUserInfo {
   handle: string;
   name: string;
   avatar: string;
+  /** @deprecated Shim derived from groupId. Use `permissions` instead. */
   admin: boolean;
+  /** @deprecated Shim derived from groupId. Use `permissions` instead. */
   role: import('../types').UserRole;
+  /** Current permission group id. */
+  groupId: string | null;
+  /** Resolved permission list. */
+  permissions?: import('../types').Permission[];
   enabled: boolean;
   created?: number;
   password: boolean;
@@ -745,10 +775,22 @@ export const adminApi = {
     return apiRequest('/api/users/get', { method: 'POST' });
   },
 
+  /**
+   * @deprecated Use `setUserGroup` instead. Kept so older UI code that still
+   *   reads the role dropdown keeps working while the UI is being migrated.
+   */
   async setRole(handle: string, role: import('../types').UserRole): Promise<void> {
     await apiRequest('/api/users/set-role', {
       method: 'POST',
       body: JSON.stringify({ handle, role }),
+    });
+  },
+
+  /** Assigns `handle` to a permission group. */
+  async setUserGroup(handle: string, groupId: string): Promise<void> {
+    await apiRequest('/api/users/set-group', {
+      method: 'POST',
+      body: JSON.stringify({ handle, groupId }),
     });
   },
 
@@ -774,11 +816,62 @@ export const adminApi = {
   },
 };
 
+// Permission groups API
+export const permissionGroupsApi = {
+  /** List every permission group (id, name, perms, etc.). */
+  async list(): Promise<import('../types').PermissionGroup[]> {
+    return apiRequest('/api/permission-groups', { method: 'GET' });
+  },
+
+  /** Fetch the master permission vocabulary, grouped by category. */
+  async getVocabulary(): Promise<{
+    permissions: import('../types').Permission[];
+    categories: Record<string, import('../types').Permission[]>;
+  }> {
+    return apiRequest('/api/permissions', { method: 'GET' });
+  },
+
+  async create(input: {
+    name: string;
+    description: string;
+    permissions: import('../types').Permission[];
+  }): Promise<import('../types').PermissionGroup> {
+    return apiRequest('/api/permission-groups/create', {
+      method: 'POST',
+      body: JSON.stringify(input),
+    });
+  },
+
+  async update(
+    id: string,
+    patch: {
+      name?: string;
+      description?: string;
+      permissions?: import('../types').Permission[];
+    },
+  ): Promise<import('../types').PermissionGroup> {
+    return apiRequest('/api/permission-groups/update', {
+      method: 'POST',
+      body: JSON.stringify({ id, ...patch }),
+    });
+  },
+
+  async delete(id: string): Promise<void> {
+    await apiRequest('/api/permission-groups/delete', {
+      method: 'POST',
+      body: JSON.stringify({ id }),
+    });
+  },
+};
+
 // Invitation types
 export interface Invitation {
   id: string;
   token: string;
-  role: import('../types').UserRole;
+  /** Permission group id to assign on accept. */
+  groupId: string;
+  /** @deprecated Shim derived from groupId. */
+  role?: import('../types').UserRole;
   label: string;
   createdBy: string;
   createdAt: number;
@@ -789,10 +882,10 @@ export interface Invitation {
 }
 
 export const invitationsApi = {
-  async create(role: string, label?: string, expiresIn?: number): Promise<Invitation> {
+  async create(groupId: string, label?: string, expiresIn?: number): Promise<Invitation> {
     return apiRequest('/api/invitations/create', {
       method: 'POST',
-      body: JSON.stringify({ role, label: label ?? '', expiresIn }),
+      body: JSON.stringify({ groupId, label: label ?? '', expiresIn }),
     });
   },
 
@@ -814,7 +907,14 @@ export const invitationsApi = {
     });
   },
 
-  async validate(token: string): Promise<{ valid: boolean; role?: string; label?: string; error?: string }> {
+  async validate(token: string): Promise<{
+    valid: boolean;
+    groupId?: string;
+    groupName?: string;
+    role?: string;
+    label?: string;
+    error?: string;
+  }> {
     return apiRequest(`/api/invitations/validate/${encodeURIComponent(token)}`);
   },
 

--- a/src/components/auth/RequirePermission.tsx
+++ b/src/components/auth/RequirePermission.tsx
@@ -1,0 +1,41 @@
+import { Navigate } from 'react-router-dom';
+import { useAuthStore } from '../../stores/authStore';
+import { hasAnyPermission, hasPermission } from '../../utils/permissions';
+import type { Permission } from '../../types';
+
+interface RequirePermissionProps {
+  /**
+   * Permission(s) the current user must hold. A single string requires that
+   * exact permission. An array is treated as OR — any one of the listed
+   * permissions grants access. For AND semantics, nest multiple guards.
+   */
+  permission: Permission | Permission[];
+  children: React.ReactNode;
+  /** Where to redirect when the user lacks permission. Defaults to "/". */
+  redirectTo?: string;
+}
+
+/**
+ * Route guard that renders children only when the current user holds the
+ * required permission. Otherwise redirects.
+ *
+ * Replaces `RequireRole` — the latter is still exported for backward compat
+ * but new routes should use this component.
+ */
+export function RequirePermission({ permission, children, redirectTo = '/' }: RequirePermissionProps) {
+  const { isAuthenticated, currentUser } = useAuthStore();
+
+  if (!isAuthenticated || !currentUser) {
+    return <Navigate to="/login" replace />;
+  }
+
+  const allowed = Array.isArray(permission)
+    ? hasAnyPermission(currentUser, permission)
+    : hasPermission(currentUser, permission);
+
+  if (!allowed) {
+    return <Navigate to={redirectTo} replace />;
+  }
+
+  return <>{children}</>;
+}

--- a/src/components/settings/InvitationManager.tsx
+++ b/src/components/settings/InvitationManager.tsx
@@ -1,15 +1,10 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { ArrowLeft, Copy, Check, Loader2, Plus, Trash2, UserPlus } from 'lucide-react';
 import { useSettingsPanelStore } from '../../stores/settingsPanelStore';
-import { invitationsApi, type Invitation } from '../../api/client';
+import { invitationsApi, permissionGroupsApi, type Invitation } from '../../api/client';
+import { useAuthStore } from '../../stores/authStore';
 import { Button } from '../ui';
-import type { UserRole } from '../../types';
-
-const ROLE_OPTIONS: { value: UserRole; label: string }[] = [
-  { value: 'end_user', label: 'User' },
-  { value: 'contributor', label: 'Contributor' },
-  { value: 'admin', label: 'Admin' },
-];
+import type { PermissionGroup } from '../../types';
 
 const STATUS_COLOR: Record<Invitation['status'], string> = {
   pending: 'text-green-400',
@@ -33,12 +28,14 @@ function timeAgo(ts: number): string {
 
 export function InvitationManager(_props?: { params?: Record<string, string> }) {
   const { goBack } = useSettingsPanelStore();
+  const { currentUser } = useAuthStore();
   const [invitations, setInvitations] = useState<Invitation[]>([]);
+  const [groups, setGroups] = useState<PermissionGroup[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   // Create form state
-  const [createRole, setCreateRole] = useState<UserRole>('end_user');
+  const [createGroupId, setCreateGroupId] = useState<string>('end-user-default');
   const [createLabel, setCreateLabel] = useState('');
   const [createExpiry, setCreateExpiry] = useState('');
   const [isCreating, setIsCreating] = useState(false);
@@ -46,10 +43,23 @@ export function InvitationManager(_props?: { params?: Record<string, string> }) 
   // Per-invite copy feedback
   const [copiedId, setCopiedId] = useState<string | null>(null);
 
-  const loadInvitations = useCallback(async () => {
+  const actorPermSet = useMemo(
+    () => new Set(currentUser?.permissions ?? []),
+    [currentUser?.permissions],
+  );
+
+  // A group is assignable iff the inviter holds every permission in the group.
+  const isGroupAssignable = (group: PermissionGroup) =>
+    group.permissions.every(p => actorPermSet.has(p));
+
+  const load = useCallback(async () => {
     try {
-      const list = await invitationsApi.list();
+      const [list, groupList] = await Promise.all([
+        invitationsApi.list(),
+        permissionGroupsApi.list(),
+      ]);
       setInvitations(list);
+      setGroups(groupList);
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to load invitations');
     } finally {
@@ -57,14 +67,17 @@ export function InvitationManager(_props?: { params?: Record<string, string> }) 
     }
   }, []);
 
-  useEffect(() => { loadInvitations(); }, [loadInvitations]);
+  useEffect(() => { load(); }, [load]);
+
+  const groupName = (id: string | undefined) =>
+    (id && groups.find(g => g.id === id)?.name) || id || 'unknown';
 
   const handleCreate = async () => {
     setIsCreating(true);
     setError(null);
     try {
       const expiresIn = createExpiry ? Number(createExpiry) : undefined;
-      const invite = await invitationsApi.create(createRole, createLabel.trim(), expiresIn);
+      const invite = await invitationsApi.create(createGroupId, createLabel.trim(), expiresIn);
       setInvitations(prev => [invite, ...prev]);
       setCreateLabel('');
       setCreateExpiry('');
@@ -122,13 +135,18 @@ export function InvitationManager(_props?: { params?: Record<string, string> }) 
 
           <div className="flex gap-2">
             <select
-              value={createRole}
-              onChange={e => setCreateRole(e.target.value as UserRole)}
+              value={createGroupId}
+              onChange={e => setCreateGroupId(e.target.value)}
               className="bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] rounded-lg px-3 py-2 text-sm text-[var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]"
             >
-              {ROLE_OPTIONS.map(opt => (
-                <option key={opt.value} value={opt.value}>{opt.label}</option>
-              ))}
+              {groups.map(g => {
+                const assignable = isGroupAssignable(g);
+                return (
+                  <option key={g.id} value={g.id} disabled={!assignable}>
+                    {g.name}{!assignable ? ' (requires more perms)' : ''}
+                  </option>
+                );
+              })}
             </select>
 
             <select
@@ -183,8 +201,8 @@ export function InvitationManager(_props?: { params?: Record<string, string> }) 
                   <div className="flex items-start gap-2">
                     <div className="flex-1 min-w-0">
                       <div className="flex items-center gap-2 flex-wrap">
-                        <span className="text-xs font-medium text-[var(--color-text-primary)] capitalize">
-                          {invite.role.replace('_', ' ')}
+                        <span className="text-xs font-medium text-[var(--color-text-primary)]">
+                          {groupName(invite.groupId)}
                         </span>
                         <span className={`text-xs capitalize ${STATUS_COLOR[invite.status]}`}>
                           {invite.status}

--- a/src/components/settings/PermissionGroupEditor.tsx
+++ b/src/components/settings/PermissionGroupEditor.tsx
@@ -1,0 +1,227 @@
+import { useState, useMemo } from 'react';
+import { X, Loader2, Lock } from 'lucide-react';
+import { permissionGroupsApi } from '../../api/client';
+import { Button } from '../ui';
+import type { PermissionGroup, Permission } from '../../types';
+
+interface PermissionGroupEditorProps {
+  mode: 'create' | 'edit';
+  group: PermissionGroup | null;
+  vocabulary: {
+    permissions: Permission[];
+    categories: Record<string, Permission[]>;
+  };
+  /**
+   * Permissions the editing user currently holds. Used to gate which
+   * permissions can be added — you cannot add a permission you don't hold
+   * yourself (mirrors the backend canEditGroup rule).
+   */
+  currentUserPermissions: Permission[];
+  /** If true, all fields are read-only (e.g. systemOwner group). */
+  readOnly: boolean;
+  onClose: () => void;
+  onSave: () => void;
+}
+
+/**
+ * Modal editor for a permission group.
+ *
+ * Renders a form with name / description / a checkbox tree for each
+ * permission category. On save, calls the appropriate API and closes.
+ *
+ * Permissions the current user does not hold are shown as disabled
+ * checkboxes with a "requires X" tooltip — clicking them is a no-op. If a
+ * group already holds such a permission (inherited from a higher-privilege
+ * admin), the checkbox stays checked but also disabled, so the current
+ * editor can't strip it accidentally.
+ */
+export function PermissionGroupEditor({
+  mode,
+  group,
+  vocabulary,
+  currentUserPermissions,
+  readOnly,
+  onClose,
+  onSave,
+}: PermissionGroupEditorProps) {
+  const [name, setName] = useState(group?.name ?? '');
+  const [description, setDescription] = useState(group?.description ?? '');
+  const [selectedPerms, setSelectedPerms] = useState<Set<Permission>>(
+    new Set(group?.permissions ?? []),
+  );
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const actorPermSet = useMemo(() => new Set(currentUserPermissions), [currentUserPermissions]);
+
+  const togglePerm = (perm: Permission) => {
+    if (readOnly) return;
+    // If the editor doesn't hold this perm and it's not already on the
+    // group, they can't add it.
+    if (!actorPermSet.has(perm) && !selectedPerms.has(perm)) return;
+    // If the editor doesn't hold it but the group already does, they also
+    // can't remove it (that would strip a permission they can't re-grant).
+    if (!actorPermSet.has(perm) && selectedPerms.has(perm)) return;
+
+    const next = new Set(selectedPerms);
+    if (next.has(perm)) next.delete(perm);
+    else next.add(perm);
+    setSelectedPerms(next);
+  };
+
+  const handleSave = async () => {
+    setError(null);
+    if (!name.trim()) {
+      setError('Name is required');
+      return;
+    }
+    setIsSaving(true);
+    try {
+      const payload = {
+        name: name.trim(),
+        description: description.trim(),
+        permissions: Array.from(selectedPerms),
+      };
+      if (mode === 'create') {
+        await permissionGroupsApi.create(payload);
+      } else if (group) {
+        await permissionGroupsApi.update(group.id, payload);
+      }
+      onSave();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to save group');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const title = mode === 'create'
+    ? 'New Permission Group'
+    : readOnly
+      ? `View: ${group?.name}`
+      : `Edit: ${group?.name}`;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
+      <div className="bg-[var(--color-bg-secondary)] rounded-xl border border-[var(--color-border)] w-full max-w-lg max-h-[90vh] overflow-hidden flex flex-col">
+        {/* Header */}
+        <div className="h-14 border-b border-[var(--color-border)] flex items-center px-4 gap-3 shrink-0">
+          <h2 className="text-base font-semibold text-[var(--color-text-primary)] flex-1 truncate">
+            {title}
+          </h2>
+          <button
+            onClick={onClose}
+            className="p-2 rounded-lg text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-tertiary)]"
+            aria-label="Close"
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto p-4 space-y-4">
+          {error && (
+            <div className="p-3 bg-red-500/10 border border-red-500/30 rounded-lg text-sm text-red-400">
+              {error}
+            </div>
+          )}
+
+          {readOnly && (
+            <div className="p-3 bg-amber-500/10 border border-amber-500/30 rounded-lg text-xs text-amber-300 flex items-start gap-2">
+              <Lock size={14} className="shrink-0 mt-0.5" />
+              <span>
+                This is the system Owner group. Its permission set is locked to
+                the full vocabulary and cannot be edited. The name and
+                description can be changed using the backend directly.
+              </span>
+            </div>
+          )}
+
+          {/* Name */}
+          <div>
+            <label className="block text-xs font-medium text-[var(--color-text-secondary)] mb-1">
+              Name
+            </label>
+            <input
+              type="text"
+              value={name}
+              onChange={e => setName(e.target.value)}
+              disabled={readOnly}
+              maxLength={80}
+              className="w-full bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] rounded-lg px-3 py-2 text-sm text-[var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)] disabled:opacity-50"
+              placeholder="e.g. Reviewers"
+            />
+          </div>
+
+          {/* Description */}
+          <div>
+            <label className="block text-xs font-medium text-[var(--color-text-secondary)] mb-1">
+              Description
+            </label>
+            <textarea
+              value={description}
+              onChange={e => setDescription(e.target.value)}
+              disabled={readOnly}
+              maxLength={500}
+              rows={2}
+              className="w-full bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] rounded-lg px-3 py-2 text-sm text-[var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)] disabled:opacity-50 resize-none"
+              placeholder="What can members of this group do?"
+            />
+          </div>
+
+          {/* Permissions by category */}
+          <div>
+            <label className="block text-xs font-medium text-[var(--color-text-secondary)] mb-2">
+              Permissions ({selectedPerms.size} selected)
+            </label>
+            <div className="space-y-3">
+              {Object.entries(vocabulary.categories).map(([category, perms]) => (
+                <div key={category} className="border border-[var(--color-border)] rounded-lg overflow-hidden">
+                  <div className="px-3 py-2 bg-[var(--color-bg-tertiary)] text-xs font-semibold text-[var(--color-text-primary)]">
+                    {category}
+                  </div>
+                  <div className="p-2 space-y-1">
+                    {perms.map(perm => {
+                      const isSelected = selectedPerms.has(perm);
+                      const canToggle =
+                        !readOnly && actorPermSet.has(perm);
+                      const disabled = readOnly || !canToggle;
+                      return (
+                        <label
+                          key={perm}
+                          className={`flex items-center gap-2 px-2 py-1 rounded text-xs ${disabled ? 'opacity-60 cursor-not-allowed' : 'cursor-pointer hover:bg-[var(--color-bg-tertiary)]'}`}
+                          title={!canToggle && !readOnly ? 'You do not hold this permission yourself' : undefined}
+                        >
+                          <input
+                            type="checkbox"
+                            checked={isSelected}
+                            disabled={disabled}
+                            onChange={() => togglePerm(perm)}
+                            className="rounded border-[var(--color-border)]"
+                          />
+                          <code className="text-[var(--color-text-primary)]">{perm}</code>
+                        </label>
+                      );
+                    })}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="h-14 border-t border-[var(--color-border)] flex items-center justify-end gap-2 px-4 shrink-0">
+          <Button variant="ghost" size="sm" onClick={onClose} disabled={isSaving}>
+            Cancel
+          </Button>
+          {!readOnly && (
+            <Button size="sm" onClick={handleSave} disabled={isSaving}>
+              {isSaving ? <Loader2 size={14} className="animate-spin" /> : 'Save'}
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/settings/PermissionGroupsPage.tsx
+++ b/src/components/settings/PermissionGroupsPage.tsx
@@ -1,0 +1,215 @@
+import { useState, useEffect, useCallback } from 'react';
+import { ArrowLeft, Loader2, Plus, Trash2, Lock, Shield, Users as UsersIcon } from 'lucide-react';
+import { useSettingsPanelStore } from '../../stores/settingsPanelStore';
+import { permissionGroupsApi } from '../../api/client';
+import { useAuthStore } from '../../stores/authStore';
+import { hasPermission } from '../../utils/permissions';
+import { Button } from '../ui';
+import type { PermissionGroup, Permission } from '../../types';
+import { PermissionGroupEditor } from './PermissionGroupEditor';
+
+type EditorMode =
+  | { kind: 'closed' }
+  | { kind: 'create' }
+  | { kind: 'edit'; group: PermissionGroup };
+
+/**
+ * Permission Groups management page.
+ *
+ * Lists every permission group. Owner-role users can create, edit, and
+ * delete custom groups. The four seeded groups (Owner, Admin, Contributor,
+ * End User) are marked with a "system" badge and cannot be deleted. The
+ * Owner group additionally has a "locked" badge and its permission set is
+ * read-only in the editor.
+ */
+export function PermissionGroupsPage(_props?: { params?: Record<string, string> }) {
+  const { goBack } = useSettingsPanelStore();
+  const { currentUser } = useAuthStore();
+
+  const canManageGroups = hasPermission(currentUser, 'admin:groups:manage');
+
+  const [groups, setGroups] = useState<PermissionGroup[]>([]);
+  const [vocabulary, setVocabulary] = useState<{
+    permissions: Permission[];
+    categories: Record<string, Permission[]>;
+  } | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [editor, setEditor] = useState<EditorMode>({ kind: 'closed' });
+  const [pendingDelete, setPendingDelete] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const [list, vocab] = await Promise.all([
+        permissionGroupsApi.list(),
+        permissionGroupsApi.getVocabulary(),
+      ]);
+      setGroups(list);
+      setVocabulary(vocab);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load permission groups');
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  const handleDelete = async (id: string) => {
+    setPendingDelete(id);
+    setError(null);
+    try {
+      await permissionGroupsApi.delete(id);
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to delete group');
+    } finally {
+      setPendingDelete(null);
+    }
+  };
+
+  const handleSave = async () => {
+    setEditor({ kind: 'closed' });
+    await load();
+  };
+
+  return (
+    <div className="min-h-screen bg-[var(--color-bg-primary)]">
+      {/* Header */}
+      <div className="sticky top-0 z-10 h-14 bg-[var(--color-bg-secondary)] border-b border-[var(--color-border)] flex items-center px-4 gap-3 safe-top">
+        <Button variant="ghost" size="sm" onClick={() => goBack()} className="p-2" aria-label="Back">
+          <ArrowLeft size={20} />
+        </Button>
+        <h1 className="text-base font-semibold text-[var(--color-text-primary)] flex-1">
+          Permission Groups
+        </h1>
+        {canManageGroups && (
+          <Button
+            size="sm"
+            onClick={() => setEditor({ kind: 'create' })}
+            className="text-xs py-1 px-2 flex items-center gap-1"
+          >
+            <Plus size={14} />
+            New
+          </Button>
+        )}
+      </div>
+
+      <div className="max-w-lg mx-auto p-4 space-y-4">
+        {error && (
+          <div className="p-3 bg-red-500/10 border border-red-500/30 rounded-lg text-sm text-red-400">
+            {error}
+          </div>
+        )}
+
+        {!canManageGroups && (
+          <div className="p-3 bg-amber-500/10 border border-amber-500/30 rounded-lg text-sm text-amber-300">
+            You have read-only access to permission groups. Only users with the
+            <code className="mx-1 px-1 bg-black/20 rounded">admin:groups:manage</code>
+            permission can create or edit groups.
+          </div>
+        )}
+
+        {isLoading ? (
+          <div className="flex items-center justify-center py-16">
+            <Loader2 size={28} className="animate-spin text-[var(--color-primary)]" />
+          </div>
+        ) : (
+          <ul className="space-y-2">
+            {groups.map(group => {
+              const isDeleting = pendingDelete === group.id;
+              const isSystemOwner = group.systemOwner;
+              const isSystem = group.system;
+              const canDelete = canManageGroups && !isSystem && (group.memberCount ?? 0) === 0;
+              return (
+                <li
+                  key={group.id}
+                  className="bg-[var(--color-bg-secondary)] rounded-xl border border-[var(--color-border)] overflow-hidden"
+                >
+                  <div className="p-4">
+                    <div className="flex items-start gap-3">
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2 flex-wrap">
+                          <span className="text-sm font-semibold text-[var(--color-text-primary)]">
+                            {group.name}
+                          </span>
+                          {isSystemOwner && (
+                            <span className="text-[10px] font-medium px-2 py-0.5 rounded-full bg-amber-500/20 text-amber-400 flex items-center gap-1">
+                              <Shield size={10} />
+                              Owner
+                            </span>
+                          )}
+                          {isSystem && !isSystemOwner && (
+                            <span className="text-[10px] font-medium px-2 py-0.5 rounded-full bg-blue-500/20 text-blue-400">
+                              system
+                            </span>
+                          )}
+                          {isSystemOwner && (
+                            <span className="text-[10px] font-medium px-2 py-0.5 rounded-full bg-[var(--color-bg-tertiary)] text-[var(--color-text-secondary)] flex items-center gap-1">
+                              <Lock size={10} />
+                              locked
+                            </span>
+                          )}
+                        </div>
+                        <p className="text-xs text-[var(--color-text-secondary)] mt-1">
+                          {group.description}
+                        </p>
+                        <div className="flex items-center gap-3 mt-2 text-xs text-[var(--color-text-secondary)]">
+                          <span>{group.permissions.length} permission{group.permissions.length === 1 ? '' : 's'}</span>
+                          {group.memberCount !== undefined && (
+                            <span className="flex items-center gap-1">
+                              <UsersIcon size={11} />
+                              {group.memberCount} member{group.memberCount === 1 ? '' : 's'}
+                            </span>
+                          )}
+                        </div>
+                      </div>
+
+                      {canManageGroups && (
+                        <div className="flex flex-col items-end gap-1 shrink-0">
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            onClick={() => setEditor({ kind: 'edit', group })}
+                            className="text-xs py-1 px-2"
+                          >
+                            {isSystemOwner ? 'View' : 'Edit'}
+                          </Button>
+                          {canDelete && (
+                            <button
+                              onClick={() => handleDelete(group.id)}
+                              disabled={isDeleting}
+                              className="p-1.5 rounded-lg text-[var(--color-text-secondary)] hover:text-red-400 hover:bg-[var(--color-bg-tertiary)] transition-colors disabled:opacity-50"
+                              aria-label="Delete group"
+                              title="Delete group"
+                            >
+                              {isDeleting ? <Loader2 size={14} className="animate-spin" /> : <Trash2 size={14} />}
+                            </button>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+
+      {editor.kind !== 'closed' && vocabulary && (
+        <PermissionGroupEditor
+          mode={editor.kind}
+          group={editor.kind === 'edit' ? editor.group : null}
+          vocabulary={vocabulary}
+          onClose={() => setEditor({ kind: 'closed' })}
+          onSave={handleSave}
+          readOnly={editor.kind === 'edit' && editor.group.systemOwner}
+          currentUserPermissions={currentUser?.permissions ?? []}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useState } from 'react';
-import { ArrowLeft, BookOpen, ChevronRight, Database, Edit3, FileText, Image, Languages, Loader2, MessageSquare, Mic, Palette, Plus, Replace, Sliders, Sparkles, Trash2, UserPlus, Users, Volume2, Zap } from 'lucide-react';
+import { ArrowLeft, BookOpen, ChevronRight, Database, Edit3, FileText, Image, Languages, Loader2, MessageSquare, Mic, Palette, Plus, Replace, Shield, Sliders, Sparkles, Trash2, UserPlus, Users, Volume2, Zap } from 'lucide-react';
 import { useSettingsPanelStore } from '../../stores/settingsPanelStore';
 import { useSettingsStore } from '../../stores/settingsStore';
 import { useOnboardingStore } from '../../stores/onboardingStore';
+import { useAuthStore } from '../../stores/authStore';
+import { hasPermission } from '../../utils/permissions';
 // PROVIDERS moved to AISettingsPage
 import { Button } from '../ui';
 import {
@@ -54,6 +56,10 @@ import { useTranslateStore } from '../../stores/translateStore';
 import { TRANSLATE_PROVIDERS, TRANSLATE_LANGUAGES, type TranslateProvider } from '../../api/translateApi';
 export function SettingsPage(_props?: { params?: Record<string, string> }) {
   const { pushPage, goBack } = useSettingsPanelStore();
+  const { currentUser } = useAuthStore();
+  const canManageInvitations = hasPermission(currentUser, 'admin:invitations:manage');
+  const canManageUsers = hasPermission(currentUser, 'admin:users:view');
+  const canManageGroups = hasPermission(currentUser, 'admin:groups:manage');
   const {
     isLoading,
     error,
@@ -249,46 +255,73 @@ export function SettingsPage(_props?: { params?: Record<string, string> }) {
             </section>
 
             {/* Invitations */}
-            <section className="bg-[var(--color-bg-secondary)] rounded-lg overflow-hidden cyberpunk-card">
-              <button
-                onClick={() => pushPage('invitations')}
-                className="w-full flex items-center gap-3 p-4 hover:bg-[var(--color-bg-tertiary)] transition-colors text-left"
-              >
-                <div className="w-10 h-10 rounded-lg bg-[var(--color-primary)]/20 flex items-center justify-center">
-                  <UserPlus size={20} className="text-[var(--color-primary)]" />
-                </div>
-                <div className="flex-1 min-w-0">
-                  <h3 className="text-sm font-semibold text-[var(--color-text-primary)]">
-                    Invitations
-                  </h3>
-                  <p className="text-xs text-[var(--color-text-secondary)]">
-                    Create invite links for new users
-                  </p>
-                </div>
-                <ChevronRight size={20} className="text-[var(--color-text-secondary)]" />
-              </button>
-            </section>
+            {canManageInvitations && (
+              <section className="bg-[var(--color-bg-secondary)] rounded-lg overflow-hidden cyberpunk-card">
+                <button
+                  onClick={() => pushPage('invitations')}
+                  className="w-full flex items-center gap-3 p-4 hover:bg-[var(--color-bg-tertiary)] transition-colors text-left"
+                >
+                  <div className="w-10 h-10 rounded-lg bg-[var(--color-primary)]/20 flex items-center justify-center">
+                    <UserPlus size={20} className="text-[var(--color-primary)]" />
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <h3 className="text-sm font-semibold text-[var(--color-text-primary)]">
+                      Invitations
+                    </h3>
+                    <p className="text-xs text-[var(--color-text-secondary)]">
+                      Create invite links for new users
+                    </p>
+                  </div>
+                  <ChevronRight size={20} className="text-[var(--color-text-secondary)]" />
+                </button>
+              </section>
+            )}
 
             {/* Users (Phase 3.1) */}
-            <section className="bg-[var(--color-bg-secondary)] rounded-lg overflow-hidden cyberpunk-card">
-              <button
-                onClick={() => pushPage('users')}
-                className="w-full flex items-center gap-3 p-4 hover:bg-[var(--color-bg-tertiary)] transition-colors text-left"
-              >
-                <div className="w-10 h-10 rounded-lg bg-[var(--color-primary)]/20 flex items-center justify-center">
-                  <Users size={20} className="text-[var(--color-primary)]" />
-                </div>
-                <div className="flex-1 min-w-0">
-                  <h3 className="text-sm font-semibold text-[var(--color-text-primary)]">
-                    Users
-                  </h3>
-                  <p className="text-xs text-[var(--color-text-secondary)]">
-                    Manage accounts, roles, and access
-                  </p>
-                </div>
-                <ChevronRight size={20} className="text-[var(--color-text-secondary)]" />
-              </button>
-            </section>
+            {canManageUsers && (
+              <section className="bg-[var(--color-bg-secondary)] rounded-lg overflow-hidden cyberpunk-card">
+                <button
+                  onClick={() => pushPage('users')}
+                  className="w-full flex items-center gap-3 p-4 hover:bg-[var(--color-bg-tertiary)] transition-colors text-left"
+                >
+                  <div className="w-10 h-10 rounded-lg bg-[var(--color-primary)]/20 flex items-center justify-center">
+                    <Users size={20} className="text-[var(--color-primary)]" />
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <h3 className="text-sm font-semibold text-[var(--color-text-primary)]">
+                      Users
+                    </h3>
+                    <p className="text-xs text-[var(--color-text-secondary)]">
+                      Manage accounts, groups, and access
+                    </p>
+                  </div>
+                  <ChevronRight size={20} className="text-[var(--color-text-secondary)]" />
+                </button>
+              </section>
+            )}
+
+            {/* Permission Groups (owner-only) */}
+            {canManageGroups && (
+              <section className="bg-[var(--color-bg-secondary)] rounded-lg overflow-hidden cyberpunk-card">
+                <button
+                  onClick={() => pushPage('permission-groups')}
+                  className="w-full flex items-center gap-3 p-4 hover:bg-[var(--color-bg-tertiary)] transition-colors text-left"
+                >
+                  <div className="w-10 h-10 rounded-lg bg-[var(--color-primary)]/20 flex items-center justify-center">
+                    <Shield size={20} className="text-[var(--color-primary)]" />
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <h3 className="text-sm font-semibold text-[var(--color-text-primary)]">
+                      Permission Groups
+                    </h3>
+                    <p className="text-xs text-[var(--color-text-secondary)]">
+                      Create custom roles with fine-grained permissions
+                    </p>
+                  </div>
+                  <ChevronRight size={20} className="text-[var(--color-text-secondary)]" />
+                </button>
+              </section>
+            )}
 
             {/* Character Management */}
             <section className="bg-[var(--color-bg-secondary)] rounded-lg overflow-hidden cyberpunk-card">

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -7,6 +7,7 @@ import { GenerationSettingsPage } from './GenerationSettingsPage';
 import { PromptTemplatesPage } from './PromptTemplatesPage';
 import { InvitationManager } from './InvitationManager';
 import { UserManagementPage } from './UserManagementPage';
+import { PermissionGroupsPage } from './PermissionGroupsPage';
 import { QuickReplyPage } from './QuickReplyPage';
 import { ExtensionsPage } from './ExtensionsPage';
 import { CharacterManagementPage } from './CharacterManagementPage';
@@ -34,6 +35,7 @@ const PAGE_COMPONENTS: Record<SettingsPageId, React.ComponentType<{ params?: Rec
   regex: RegexScriptPage,
   invitations: InvitationManager,
   users: UserManagementPage,
+  'permission-groups': PermissionGroupsPage,
   characters: CharacterManagementPage,
   quickreplies: QuickReplyPage,
   extensions: ExtensionsPage,

--- a/src/components/settings/UserManagementPage.tsx
+++ b/src/components/settings/UserManagementPage.tsx
@@ -1,24 +1,23 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { ArrowLeft, Loader2, Trash2, UserX, UserCheck, ShieldAlert } from 'lucide-react';
 import { useSettingsPanelStore } from '../../stores/settingsPanelStore';
-import { adminApi, type AdminUserInfo } from '../../api/client';
+import { adminApi, permissionGroupsApi, type AdminUserInfo } from '../../api/client';
 import { useAuthStore } from '../../stores/authStore';
+import { hasPermission } from '../../utils/permissions';
 import { Avatar, Button } from '../ui';
-import type { UserRole } from '../../types';
+import type { PermissionGroup } from '../../types';
 
-const ROLE_OPTIONS: { value: UserRole; label: string }[] = [
-  { value: 'end_user', label: 'User' },
-  { value: 'contributor', label: 'Contributor' },
-  { value: 'admin', label: 'Admin' },
-  { value: 'owner', label: 'Owner' },
-];
-
-const ROLE_COLOR: Record<UserRole, string> = {
-  owner: 'bg-amber-500/20 text-amber-400',
-  admin: 'bg-purple-500/20 text-purple-400',
-  contributor: 'bg-blue-500/20 text-blue-400',
-  end_user: 'bg-[var(--color-bg-tertiary)] text-[var(--color-text-secondary)]',
+const GROUP_BADGE_COLOR: Record<string, string> = {
+  'owner-default': 'bg-amber-500/20 text-amber-400',
+  'admin-default': 'bg-purple-500/20 text-purple-400',
+  'contributor-default': 'bg-blue-500/20 text-blue-400',
+  'end-user-default': 'bg-[var(--color-bg-tertiary)] text-[var(--color-text-secondary)]',
 };
+
+function groupBadgeColor(id: string | null | undefined): string {
+  if (!id) return 'bg-[var(--color-bg-tertiary)] text-[var(--color-text-secondary)]';
+  return GROUP_BADGE_COLOR[id] || 'bg-[var(--color-primary)]/20 text-[var(--color-primary)]';
+}
 
 function getAvatarUrl(avatar: string) {
   if (!avatar) return undefined;
@@ -29,16 +28,22 @@ function getAvatarUrl(avatar: string) {
 export function UserManagementPage(_props?: { params?: Record<string, string> }) {
   const { goBack } = useSettingsPanelStore();
   const { currentUser } = useAuthStore();
-  const isOwner = currentUser?.role === 'owner';
+  const canSetGroup = hasPermission(currentUser, 'admin:users:set_group');
+  const canManageUsers = hasPermission(currentUser, 'admin:users:manage');
+  const actorPermSet = useMemo(
+    () => new Set(currentUser?.permissions ?? []),
+    [currentUser?.permissions],
+  );
 
   const [users, setUsers] = useState<AdminUserInfo[]>([]);
+  const [groups, setGroups] = useState<PermissionGroup[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   // Per-user pending state: handle → action type
-  const [pending, setPending] = useState<Record<string, 'role' | 'toggle' | 'delete'>>({});
-  // Role select local state: handle → selected value (before save)
-  const [roleSelections, setRoleSelections] = useState<Record<string, UserRole>>({});
+  const [pending, setPending] = useState<Record<string, 'group' | 'toggle' | 'delete'>>({});
+  // Group select local state: handle → selected group id (before save)
+  const [groupSelections, setGroupSelections] = useState<Record<string, string>>({});
   // Confirm delete state
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
 
@@ -46,12 +51,18 @@ export function UserManagementPage(_props?: { params?: Record<string, string> })
     setIsLoading(true);
     setError(null);
     try {
-      const list = await adminApi.getUsers();
-      setUsers(list);
-      // Seed role selections from loaded data
-      const seeds: Record<string, UserRole> = {};
-      list.forEach(u => { seeds[u.handle] = u.role; });
-      setRoleSelections(seeds);
+      const [userList, groupList] = await Promise.all([
+        adminApi.getUsers(),
+        permissionGroupsApi.list(),
+      ]);
+      setUsers(userList);
+      setGroups(groupList);
+      // Seed group selections from loaded data
+      const seeds: Record<string, string> = {};
+      userList.forEach(u => {
+        if (u.groupId) seeds[u.handle] = u.groupId;
+      });
+      setGroupSelections(seeds);
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to load users');
     } finally {
@@ -61,19 +72,19 @@ export function UserManagementPage(_props?: { params?: Record<string, string> })
 
   useEffect(() => { load(); }, [load]);
 
-  const handleSetRole = async (handle: string) => {
-    const newRole = roleSelections[handle];
-    setPending(p => ({ ...p, [handle]: 'role' }));
+  const handleSetGroup = async (handle: string) => {
+    const newGroupId = groupSelections[handle];
+    if (!newGroupId) return;
+    setPending(p => ({ ...p, [handle]: 'group' }));
     setError(null);
     try {
-      await adminApi.setRole(handle, newRole);
-      setUsers(prev => prev.map(u => u.handle === handle ? { ...u, role: newRole } : u));
+      await adminApi.setUserGroup(handle, newGroupId);
+      setUsers(prev => prev.map(u => u.handle === handle ? { ...u, groupId: newGroupId } : u));
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Failed to change role');
-      // Revert selection on error
-      setRoleSelections(prev => ({
+      setError(e instanceof Error ? e.message : 'Failed to change group');
+      setGroupSelections(prev => ({
         ...prev,
-        [handle]: users.find(u => u.handle === handle)?.role ?? prev[handle],
+        [handle]: users.find(u => u.handle === handle)?.groupId ?? prev[handle],
       }));
     } finally {
       setPending(p => { const next = { ...p }; delete next[handle]; return next; });
@@ -111,24 +122,28 @@ export function UserManagementPage(_props?: { params?: Record<string, string> })
     }
   };
 
+  // A group is assignable by the current actor iff every permission in the
+  // group is held by the actor (mirrors the backend canAssignGroup rule).
+  const isGroupAssignable = useCallback(
+    (group: PermissionGroup) => group.permissions.every(p => actorPermSet.has(p)),
+    [actorPermSet],
+  );
+
   // Can the current user modify this target user?
   const canModify = (target: AdminUserInfo): boolean => {
     if (!currentUser) return false;
-    if (target.handle === currentUser.handle) return false; // can't modify yourself
+    if (target.handle === currentUser.handle) return false;
     if (target.handle === 'default-user') return false;
-    // Admins can't modify owners
-    if (target.role === 'owner' && !isOwner) return false;
-    return true;
+    return canManageUsers || canSetGroup;
   };
 
-  // Which roles can the current user assign?
-  const assignableRoles = isOwner
-    ? ROLE_OPTIONS
-    : ROLE_OPTIONS.filter(r => r.value !== 'owner');
+  const groupName = (id: string | null | undefined) => {
+    if (!id) return 'unknown';
+    return groups.find(g => g.id === id)?.name ?? id;
+  };
 
   return (
     <div className="min-h-screen bg-[var(--color-bg-primary)]">
-      {/* Header */}
       <div className="sticky top-0 z-10 h-14 bg-[var(--color-bg-secondary)] border-b border-[var(--color-border)] flex items-center px-4 gap-3 safe-top">
         <Button variant="ghost" size="sm" onClick={() => goBack()} className="p-2" aria-label="Back">
           <ArrowLeft size={20} />
@@ -160,19 +175,14 @@ export function UserManagementPage(_props?: { params?: Record<string, string> })
                 const isSelf = user.handle === currentUser?.handle;
                 const modifiable = canModify(user);
                 const isPending = !!pending[user.handle];
-                const selectedRole = roleSelections[user.handle] ?? user.role;
-                const roleChanged = selectedRole !== user.role;
+                const selectedGroupId = groupSelections[user.handle] ?? user.groupId ?? '';
+                const groupChanged = selectedGroupId !== user.groupId;
 
                 return (
                   <li key={user.handle} className={`px-4 py-3 ${!user.enabled ? 'opacity-60' : ''}`}>
                     <div className="flex items-start gap-3">
-                      {/* Avatar */}
                       <div className="relative shrink-0 mt-0.5">
-                        <Avatar
-                          src={getAvatarUrl(user.avatar)}
-                          alt={user.name}
-                          size="md"
-                        />
+                        <Avatar src={getAvatarUrl(user.avatar)} alt={user.name} size="md" />
                         {!user.enabled && (
                           <div className="absolute -bottom-0.5 -right-0.5 w-4 h-4 rounded-full bg-[var(--color-bg-secondary)] flex items-center justify-center">
                             <ShieldAlert size={10} className="text-red-400" />
@@ -180,7 +190,6 @@ export function UserManagementPage(_props?: { params?: Record<string, string> })
                         )}
                       </div>
 
-                      {/* Info */}
                       <div className="flex-1 min-w-0">
                         <div className="flex items-center gap-2 flex-wrap">
                           <span className="text-sm font-medium text-[var(--color-text-primary)] truncate">
@@ -189,8 +198,8 @@ export function UserManagementPage(_props?: { params?: Record<string, string> })
                           {isSelf && (
                             <span className="text-xs text-[var(--color-text-secondary)]">(you)</span>
                           )}
-                          <span className={`text-[10px] font-medium px-2 py-0.5 rounded-full ${ROLE_COLOR[user.role]}`}>
-                            {user.role.replace('_', ' ')}
+                          <span className={`text-[10px] font-medium px-2 py-0.5 rounded-full ${groupBadgeColor(user.groupId)}`}>
+                            {groupName(user.groupId)}
                           </span>
                           {!user.enabled && (
                             <span className="text-[10px] font-medium px-2 py-0.5 rounded-full bg-red-500/10 text-red-400">
@@ -200,31 +209,33 @@ export function UserManagementPage(_props?: { params?: Record<string, string> })
                         </div>
                         <p className="text-xs text-[var(--color-text-secondary)] mt-0.5">@{user.handle}</p>
 
-                        {/* Role selector (only for modifiable users) */}
-                        {modifiable && (
+                        {/* Group selector (only for modifiable users with canSetGroup) */}
+                        {modifiable && canSetGroup && (
                           <div className="flex items-center gap-2 mt-2">
                             <select
-                              value={selectedRole}
-                              onChange={e => setRoleSelections(prev => ({ ...prev, [user.handle]: e.target.value as UserRole }))}
+                              value={selectedGroupId}
+                              onChange={e => setGroupSelections(prev => ({ ...prev, [user.handle]: e.target.value }))}
                               disabled={isPending}
                               className="text-xs bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] rounded-lg px-2 py-1 text-[var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)] disabled:opacity-50"
                             >
-                              {assignableRoles.map(opt => (
-                                <option key={opt.value} value={opt.value}>{opt.label}</option>
-                              ))}
-                              {/* Allow showing owner option as disabled for admins viewing an owner */}
-                              {!isOwner && user.role === 'owner' && (
-                                <option value="owner" disabled>Owner</option>
-                              )}
+                              {groups.map(g => {
+                                const assignable = isGroupAssignable(g);
+                                const isCurrent = g.id === user.groupId;
+                                return (
+                                  <option key={g.id} value={g.id} disabled={!assignable && !isCurrent}>
+                                    {g.name}{!assignable && !isCurrent ? ' (requires more perms)' : ''}
+                                  </option>
+                                );
+                              })}
                             </select>
-                            {roleChanged && (
+                            {groupChanged && (
                               <Button
                                 size="sm"
-                                onClick={() => handleSetRole(user.handle)}
+                                onClick={() => handleSetGroup(user.handle)}
                                 disabled={isPending}
                                 className="text-xs py-1 px-2"
                               >
-                                {pending[user.handle] === 'role'
+                                {pending[user.handle] === 'group'
                                   ? <Loader2 size={12} className="animate-spin" />
                                   : 'Save'}
                               </Button>
@@ -233,10 +244,8 @@ export function UserManagementPage(_props?: { params?: Record<string, string> })
                         )}
                       </div>
 
-                      {/* Actions */}
-                      {modifiable && (
+                      {modifiable && canManageUsers && (
                         <div className="flex items-center gap-1 shrink-0">
-                          {/* Enable / Disable */}
                           <button
                             onClick={() => handleToggleEnabled(user)}
                             disabled={isPending}
@@ -251,7 +260,6 @@ export function UserManagementPage(_props?: { params?: Record<string, string> })
                                 : <UserCheck size={16} className="text-green-400" />}
                           </button>
 
-                          {/* Delete */}
                           {confirmDelete === user.handle ? (
                             <div className="flex items-center gap-1">
                               <button

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -3,12 +3,22 @@ import { api, clearCsrfToken, type UserInfo } from '../api/client';
 import { useCharacterStore } from './characterStore';
 import { useChatStore } from './chatStore';
 import { useSettingsStore } from './settingsStore';
-import type { UserRole } from '../types';
+import type { UserRole, Permission } from '../types';
+
+interface CurrentUser {
+  handle: string;
+  name: string;
+  /** @deprecated Legacy role shim. Use `permissions` instead. */
+  role: UserRole;
+  avatar?: string;
+  groupId?: string;
+  permissions?: Permission[];
+}
 
 interface AuthState {
   isAuthenticated: boolean;
   isLoading: boolean;
-  currentUser: { handle: string; name: string; role: UserRole; avatar?: string } | null;
+  currentUser: CurrentUser | null;
   availableUsers: UserInfo[];
   error: string | null;
   canSelfRegister: boolean;
@@ -39,7 +49,14 @@ export const useAuthStore = create<AuthState>((set) => ({
       if (user) {
         set({
           isAuthenticated: true,
-          currentUser: { handle: user.handle, name: user.name, role: user.role, avatar: user.avatar },
+          currentUser: {
+            handle: user.handle,
+            name: user.name,
+            role: user.role,
+            avatar: user.avatar,
+            groupId: user.groupId,
+            permissions: user.permissions,
+          },
           isLoading: false,
         });
       } else {
@@ -93,12 +110,19 @@ export const useAuthStore = create<AuthState>((set) => ({
     set({ isLoading: true, error: null });
     try {
       await api.login(handle, password);
-      // Fetch real user data so role and display name are correct.
+      // Fetch real user data so role, permissions, and display name are correct.
       const user = await api.getCurrentUser();
       set({
         isAuthenticated: true,
         currentUser: user
-          ? { handle: user.handle, name: user.name, role: user.role, avatar: user.avatar }
+          ? {
+              handle: user.handle,
+              name: user.name,
+              role: user.role,
+              avatar: user.avatar,
+              groupId: user.groupId,
+              permissions: user.permissions,
+            }
           : { handle, name: handle, role: 'end_user' },
         isLoading: false,
       });

--- a/src/stores/settingsPanelStore.ts
+++ b/src/stores/settingsPanelStore.ts
@@ -11,6 +11,7 @@ export type SettingsPageId =
   | 'regex'
   | 'invitations'
   | 'users'
+  | 'permission-groups'
   | 'characters'
   | 'quickreplies'
   | 'extensions'

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,12 +1,39 @@
 // User types
+/** @deprecated Use `permissions` array + `groupId` instead. Kept for backward compat during transition. */
 export type UserRole = 'owner' | 'admin' | 'contributor' | 'end_user';
+
+/** A permission string matching the backend vocabulary in `SillyTavern/src/permissions.js`. */
+export type Permission = string;
+
+export interface PermissionGroup {
+  id: string;
+  name: string;
+  description: string;
+  permissions: Permission[];
+  /** True for the four seeded default groups. Cannot be deleted. */
+  system: boolean;
+  /** True for exactly one group (the Owner default). Perm set locked to full vocabulary. */
+  systemOwner: boolean;
+  createdBy: string | null;
+  createdAt: number;
+  updatedAt: number;
+  /** Included on list responses when the caller has `admin:users:view`. */
+  memberCount?: number;
+  enabledMemberCount?: number;
+}
 
 export interface User {
   handle: string;
   name: string;
-  admin: boolean;
-  role: UserRole;
   avatar?: string;
+  /** Current permission group id. Source of truth for authorization. */
+  groupId?: string;
+  /** Resolved permission list from the user's group, included in /me responses. */
+  permissions?: Permission[];
+  /** @deprecated Shim derived from groupId. Use `permissions` instead. */
+  admin?: boolean;
+  /** @deprecated Shim derived from groupId. Use `permissions` instead. */
+  role?: UserRole;
 }
 
 // Character types

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -1,49 +1,223 @@
-import type { UserRole } from '../types';
+import type { Permission, User, UserRole } from '../types';
 
 /**
- * Role hierarchy (higher index = more privilege):
- *   end_user < contributor < admin < owner
+ * Frontend permission utility.
+ *
+ * The backend is the source of truth for the permission vocabulary; the
+ * constants exported here must match `SillyTavern/src/permissions.js`. The
+ * PermissionGroupEditor renders its checkboxes from the server-returned
+ * vocabulary (`GET /api/permissions`), so new backend permissions flow
+ * through without requiring a frontend update — this list exists only for
+ * type hints and legacy shim mapping.
  */
-const ROLE_LEVEL: Record<UserRole, number> = {
+
+/** The canonical permission vocabulary. Keep in sync with the backend. */
+export const PERMISSIONS = [
+  // Chat & generation
+  'chat:read',
+  'chat:write',
+  'chat:delete',
+  'chat:import_export',
+  'generation:use',
+  'generation:image',
+  'generation:audio',
+
+  // Characters
+  'character:view',
+  'character:create',
+  'character:edit',
+  'character:delete',
+  'character:import_export',
+  'character:set_global',
+
+  // Groups & Personas
+  'character_group:view',
+  'character_group:manage',
+  'persona:view',
+  'persona:manage',
+
+  // World Info
+  'worldinfo:view',
+  'worldinfo:manage',
+
+  // Settings
+  'settings:view',
+  'settings:connection',
+  'settings:api_keys',
+  'settings:generation',
+  'settings:appearance',
+  'settings:global_secrets',
+
+  // Extensions
+  'extension:view',
+  'extension:manage_personal',
+  'extension:manage_global',
+
+  // Data Bank
+  'databank:view',
+  'databank:manage',
+  'databank:manage_global',
+
+  // Automation
+  'automation:quickreplies:manage',
+  'automation:regex:manage',
+  'automation:prompts:manage',
+
+  // Administration
+  'admin:users:view',
+  'admin:users:manage',
+  'admin:users:reset_password',
+  'admin:users:set_group',
+  'admin:invitations:manage',
+  'admin:groups:manage',
+  'admin:data_maid:manage',
+  'admin:content_import',
+
+  // System
+  'system:backup:self',
+  'system:backup:others',
+] as const;
+
+/**
+ * Checks whether the user holds the given permission.
+ *
+ * If the user has no `permissions` array yet (very old client talking to an
+ * even older server), we fall back to the legacy `admin`/`role` shim fields —
+ * this keeps the UI functional during the transition window.
+ */
+export function hasPermission(
+  user: Pick<User, 'permissions' | 'admin' | 'role'> | null | undefined,
+  perm: Permission,
+): boolean {
+  if (!user) return false;
+  if (Array.isArray(user.permissions)) {
+    return user.permissions.includes(perm);
+  }
+  // Legacy shim path: approximate the new permission from the old role.
+  return legacyRoleHas(user.role, user.admin, perm);
+}
+
+/** Does the user hold every listed permission? */
+export function hasAllPermissions(
+  user: Pick<User, 'permissions' | 'admin' | 'role'> | null | undefined,
+  perms: Permission[],
+): boolean {
+  return perms.every(p => hasPermission(user, p));
+}
+
+/** Does the user hold any of the listed permissions? */
+export function hasAnyPermission(
+  user: Pick<User, 'permissions' | 'admin' | 'role'> | null | undefined,
+  perms: Permission[],
+): boolean {
+  return perms.some(p => hasPermission(user, p));
+}
+
+/**
+ * Legacy compatibility: map the old 4-tier role to an approximate permission
+ * check. This is only used when the server hasn't returned a `permissions`
+ * array on `/me`, i.e. when the frontend is talking to a pre-groups backend.
+ */
+function legacyRoleHas(role: UserRole | undefined, admin: boolean | undefined, perm: Permission): boolean {
+  const effectiveRole: UserRole = role ?? (admin ? 'admin' : 'end_user');
+  const level = LEGACY_ROLE_LEVEL[effectiveRole] ?? 0;
+  const min = LEGACY_PERM_MIN_LEVEL[perm];
+  if (min === undefined) {
+    // Unknown permission in legacy mode: owner-only by default (safe).
+    return effectiveRole === 'owner';
+  }
+  return level >= min;
+}
+
+const LEGACY_ROLE_LEVEL: Record<UserRole, number> = {
   end_user: 0,
   contributor: 1,
   admin: 2,
   owner: 3,
 };
 
-/** Actions that can be checked with `can()`. */
-export type Action =
-  | 'chat'                  // send/receive messages
-  | 'character:view'        // browse character list
-  | 'character:create'      // create / import characters
-  | 'character:edit'        // edit existing characters
-  | 'character:delete'      // delete characters
-  | 'settings:view'         // access settings page
-  | 'settings:personal'     // manage own personal API keys
-  | 'settings:api_keys'     // manage API keys / secrets
-  | 'admin:panel';          // access admin panel / user management
+/**
+ * Approximate legacy mapping from each permission back to the minimum 4-tier
+ * role that would have held it. Used only when the server doesn't yet return
+ * `permissions` on /me.
+ */
+const LEGACY_PERM_MIN_LEVEL: Record<string, number> = {
+  // end_user level
+  'chat:read': 0, 'chat:write': 0,
+  'character:view': 0, 'persona:view': 0, 'persona:manage': 0,
+  'databank:view': 0, 'settings:view': 0,
+  'generation:use': 0, 'system:backup:self': 0,
+  'settings:api_keys': 0,
 
-/** Minimum role required for each action. */
-const ACTION_MIN_ROLE: Record<Action, UserRole> = {
-  'chat':              'end_user',
-  'character:view':    'end_user',
-  'character:create':  'contributor',
-  'character:edit':    'contributor',
-  'character:delete':  'contributor',
-  'settings:view':     'admin',
-  'settings:personal': 'end_user',
-  'settings:api_keys': 'end_user',
-  'admin:panel':       'admin',
+  // contributor level
+  'chat:delete': 1, 'chat:import_export': 1,
+  'generation:image': 1, 'generation:audio': 1,
+  'character:create': 1, 'character:edit': 1, 'character:delete': 1,
+  'character:import_export': 1,
+  'character_group:view': 1, 'character_group:manage': 1,
+  'worldinfo:view': 1, 'worldinfo:manage': 1,
+  'extension:view': 1, 'extension:manage_personal': 1,
+  'databank:manage': 1,
+  'automation:quickreplies:manage': 1, 'automation:regex:manage': 1, 'automation:prompts:manage': 1,
+
+  // admin level
+  'settings:connection': 2, 'settings:generation': 2, 'settings:appearance': 2,
+  'admin:users:view': 2, 'admin:users:manage': 2, 'admin:users:set_group': 2,
+  'admin:invitations:manage': 2, 'admin:data_maid:manage': 2,
+
+  // owner-only
+  'character:set_global': 3,
+  'extension:manage_global': 3,
+  'databank:manage_global': 3,
+  'settings:global_secrets': 3,
+  'admin:users:reset_password': 3,
+  'admin:groups:manage': 3,
+  'admin:content_import': 3,
+  'system:backup:others': 3,
 };
 
-/** Check whether `role` is allowed to perform `action`. */
+// ---------------------------------------------------------------------------
+// Legacy shims — map the old action/role API to the new permission check.
+// Kept so any component that still calls `can(role, 'character:edit')` keeps
+// working during the transition. Remove in a follow-up cleanup.
+// ---------------------------------------------------------------------------
+
+/** @deprecated Old action type. */
+export type Action =
+  | 'chat'
+  | 'character:view'
+  | 'character:create'
+  | 'character:edit'
+  | 'character:delete'
+  | 'settings:view'
+  | 'settings:personal'
+  | 'settings:api_keys'
+  | 'admin:panel';
+
+const ACTION_TO_PERMISSION: Record<Action, Permission> = {
+  'chat': 'chat:write',
+  'character:view': 'character:view',
+  'character:create': 'character:create',
+  'character:edit': 'character:edit',
+  'character:delete': 'character:delete',
+  'settings:view': 'settings:view',
+  'settings:personal': 'settings:view',
+  'settings:api_keys': 'settings:api_keys',
+  'admin:panel': 'admin:users:view',
+};
+
+/**
+ * @deprecated Use `hasPermission(user, perm)` with the new permission
+ *   vocabulary. This shim maps the old `can(role, action)` API into a
+ *   permission lookup against a pseudo-user carrying only the legacy role.
+ */
 export function can(role: UserRole | undefined, action: Action): boolean {
-  if (!role) return false;
-  return ROLE_LEVEL[role] >= ROLE_LEVEL[ACTION_MIN_ROLE[action]];
+  const perm = ACTION_TO_PERMISSION[action];
+  return legacyRoleHas(role, role === 'admin' || role === 'owner', perm);
 }
 
-/** Check if role meets a minimum role threshold. */
+/** @deprecated Use `hasPermission` or `RequirePermission` instead. */
 export function hasMinRole(role: UserRole | undefined, minRole: UserRole): boolean {
   if (!role) return false;
-  return ROLE_LEVEL[role] >= ROLE_LEVEL[minRole];
+  return (LEGACY_ROLE_LEVEL[role] ?? 0) >= (LEGACY_ROLE_LEVEL[minRole] ?? 0);
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,10 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 
+// Backend URL can be overridden via ST_BACKEND for local dev when the
+// default port is already in use (e.g. running two worktrees in parallel).
+const BACKEND = process.env.ST_BACKEND || 'http://localhost:8000'
+
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss()],
@@ -9,19 +13,19 @@ export default defineConfig({
     port: 3000,
     proxy: {
       '/api': {
-        target: 'http://localhost:8000',
+        target: BACKEND,
         changeOrigin: true,
       },
       '/csrf-token': {
-        target: 'http://localhost:8000',
+        target: BACKEND,
         changeOrigin: true,
       },
       '/thumbnail': {
-        target: 'http://localhost:8000',
+        target: BACKEND,
         changeOrigin: true,
       },
       '/characters': {
-        target: 'http://localhost:8000',
+        target: BACKEND,
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
## Summary
- Replaces the 4-tier role ladder with HubSpot-style permission groups on the frontend side.
- 44-permission vocabulary in `src/utils/permissions.ts` mirroring the backend (`SillyTavern/feat/permission-groups`).
- New `PermissionGroupsPage` + `PermissionGroupEditor` under `/settings/permission-groups` (owner-only).
- `UserManagementPage` and `InvitationManager` rewritten to use group dropdowns.
- `adminApi.setUserGroup` / `permissionGroupsApi` added to `src/api/client.ts`.
- `/me` + register now speak `groupId`; backend still accepts the legacy `{admin, role}` shape during the transition.
- `docker/seed-owner.sh` posts `groupId: "owner-default"`.

## Ships with
- **Backend PR**: [sammygallo/SillyTavern#feat/permission-groups](https://github.com/sammygallo/SillyTavern/tree/feat/permission-groups) — must be merged and deployed in lockstep. The `/me` response shape changed.

## Out of scope (follow-up)
- Server-side enforcement on the ~100 currently-unguarded handlers (character CRUD, chats, generation pipeline, extensions, data bank). They stay login-only for now; the new vocabulary defines them so the UI gates them in this PR.
- Removing the deprecated `admin`/`role` shims from `/me` and removing `RequireRole` / `can()` / `hasMinRole()` legacy helpers.

## Test plan
- [x] `npm run build` clean locally (post-rebase onto current main)
- [x] Backend + frontend running together: login as default-user, navigate /settings/permission-groups, confirm all 4 seed groups load with correct badges
- [x] Create custom "Reviewers" group via the editor modal, confirm it appears in the list
- [x] Users page shows default-user with the amber Owner badge from its group
- [x] Invitations dropdown lists groups (including the custom one) instead of hardcoded roles
- [ ] Post-deploy: log in as owner on prod, smoke-test the new page
- [ ] Post-deploy: create a custom group with limited permissions and assign a test user to it

🤖 Generated with [Claude Code](https://claude.com/claude-code)