### PR TITLE
feat(import): support PNG + lorebook JSON multi-file drop

### DIFF
--- a/src/components/character/CharacterImport.tsx
+++ b/src/components/character/CharacterImport.tsx
@@ -55,30 +55,17 @@ export function CharacterImport({ isOpen, onClose, onImported }: CharacterImport
     tags: [],
   });
 
-  const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-
-    clearError();
-    setLorebookFile(null);
-    setLorebookImported(false);
-
-    // Read the file text upfront so we can hand it to importBookJson if needed
-    const fileText = await file.text();
-
-    const result = await importCharacter(file);
+  const processFiles = async (files: File[]) => {
+    const result = await importCharacter(files);
 
     if (result) {
       setImportedData(result.data);
       setImportedBook(result.characterBook || null);
       if (result.avatarFile) {
         setAvatarFile(result.avatarFile);
-        // Create preview URL
         const previewUrl = URL.createObjectURL(result.avatarFile);
         setAvatarPreview(previewUrl);
       }
-
-      // Populate form with imported data
       setFormData({
         name: result.data.name || '',
         description: result.data.description || result.data.data?.description || '',
@@ -90,30 +77,44 @@ export function CharacterImport({ isOpen, onClose, onImported }: CharacterImport
         creator: result.data.data?.creator || '',
         tags: result.data.tags || result.data.data?.tags || [],
       });
-    } else {
-      // importCharacter returned null — check if this is a lorebook file.
-      // The LorebookDetectedError was caught by the store and turned into
-      // an error string; detect the format here to offer lorebook import.
-      try {
-        const parsed = JSON.parse(fileText);
-        if (
-          parsed?.entries &&
-          typeof parsed.entries === 'object' &&
-          !parsed.name &&
-          !parsed.first_mes
-        ) {
-          clearError();
-          const entryCount = Object.keys(parsed.entries).length;
-          setLorebookFile({
-            text: fileText,
-            name: file.name.replace(/\.json$/i, ''),
-            entryCount,
-          });
+    } else if (files.length === 1) {
+      // Single file that failed character parsing — check if it's a standalone lorebook JSON
+      const file = files[0];
+      const isJSON = file.type === 'application/json' || file.name.toLowerCase().endsWith('.json');
+      if (isJSON) {
+        try {
+          const fileText = await file.text();
+          const parsed = JSON.parse(fileText);
+          if (
+            parsed?.entries &&
+            typeof parsed.entries === 'object' &&
+            !parsed.name &&
+            !parsed.first_mes
+          ) {
+            clearError();
+            const entryCount = Object.keys(parsed.entries).length;
+            setLorebookFile({
+              text: fileText,
+              name: file.name.replace(/\.json$/i, ''),
+              entryCount,
+            });
+          }
+        } catch {
+          // Not valid JSON — let the existing error stand
         }
-      } catch {
-        // Not valid JSON — let the existing error from importCharacter stand
       }
     }
+  };
+
+  const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files || []);
+    if (files.length === 0) return;
+
+    clearError();
+    setLorebookFile(null);
+    setLorebookImported(false);
+
+    await processFiles(files);
 
     // Reset file input
     if (fileInputRef.current) {
@@ -218,65 +219,18 @@ export function CharacterImport({ isOpen, onClose, onImported }: CharacterImport
     e.preventDefault();
     e.stopPropagation();
 
-    const file = e.dataTransfer.files?.[0];
-    if (!file) return;
-
-    // Check file type
-    const isPNG = file.type === 'image/png' || file.name.toLowerCase().endsWith('.png');
-    const isJSON = file.type === 'application/json' || file.name.toLowerCase().endsWith('.json');
-
-    if (!isPNG && !isJSON) {
-      return;
-    }
+    const files = Array.from(e.dataTransfer.files).filter((f) => {
+      const isPNG = f.type === 'image/png' || f.name.toLowerCase().endsWith('.png');
+      const isJSON = f.type === 'application/json' || f.name.toLowerCase().endsWith('.json');
+      return isPNG || isJSON;
+    });
+    if (files.length === 0) return;
 
     clearError();
     setLorebookFile(null);
     setLorebookImported(false);
 
-    const fileText = isJSON ? await file.text() : '';
-    const result = await importCharacter(file);
-
-    if (result) {
-      setImportedData(result.data);
-      setImportedBook(result.characterBook || null);
-      if (result.avatarFile) {
-        setAvatarFile(result.avatarFile);
-        const previewUrl = URL.createObjectURL(result.avatarFile);
-        setAvatarPreview(previewUrl);
-      }
-
-      setFormData({
-        name: result.data.name || '',
-        description: result.data.description || result.data.data?.description || '',
-        personality: result.data.personality || result.data.data?.personality || '',
-        firstMessage: result.data.first_mes || result.data.data?.first_mes || '',
-        scenario: result.data.scenario || result.data.data?.scenario || '',
-        exampleMessages: result.data.mes_example || '',
-        creatorNotes: result.data.data?.creator_notes || '',
-        creator: result.data.data?.creator || '',
-        tags: result.data.tags || result.data.data?.tags || [],
-      });
-    } else if (isJSON && fileText) {
-      try {
-        const parsed = JSON.parse(fileText);
-        if (
-          parsed?.entries &&
-          typeof parsed.entries === 'object' &&
-          !parsed.name &&
-          !parsed.first_mes
-        ) {
-          clearError();
-          const entryCount = Object.keys(parsed.entries).length;
-          setLorebookFile({
-            text: fileText,
-            name: file.name.replace(/\.json$/i, ''),
-            entryCount,
-          });
-        }
-      } catch {
-        // let existing error stand
-      }
-    }
+    await processFiles(files);
   };
 
   return (
@@ -293,10 +247,10 @@ export function CharacterImport({ isOpen, onClose, onImported }: CharacterImport
           >
             <Upload size={48} className="mx-auto text-[var(--color-text-secondary)] mb-4" />
             <p className="text-[var(--color-text-primary)] font-medium mb-2">
-              Drop a character file here
+              Drop character file(s) here
             </p>
             <p className="text-sm text-[var(--color-text-secondary)] mb-4">
-              or click to browse
+              or click to browse &mdash; you can drop a PNG and lorebook JSON together
             </p>
             <div className="flex justify-center gap-4 text-xs text-[var(--color-text-secondary)]">
               <span className="flex items-center gap-1">
@@ -305,7 +259,7 @@ export function CharacterImport({ isOpen, onClose, onImported }: CharacterImport
               </span>
               <span className="flex items-center gap-1">
                 <FileJson size={14} />
-                JSON
+                JSON (character or lorebook)
               </span>
             </div>
           </div>
@@ -314,6 +268,7 @@ export function CharacterImport({ isOpen, onClose, onImported }: CharacterImport
             ref={fileInputRef}
             type="file"
             accept=".png,.json,image/png,application/json"
+            multiple
             onChange={handleFileSelect}
             className="hidden"
           />

--- a/src/stores/characterStore.ts
+++ b/src/stores/characterStore.ts
@@ -4,6 +4,7 @@ import {
   extractCharacterFromPNG,
   extractCharacterBook,
   parseCharacterFromJSON,
+  parseLorebookFromJSON,
   cardToCharacterInfo,
   embedCharacterInPNG,
   exportCharacterAsJSON,
@@ -104,7 +105,7 @@ interface CharacterState {
   reorderGroupChatCharacters: (avatars: string[]) => void;
   // Import/Export actions
   importCharacter: (
-    file: File
+    files: File | File[]
   ) => Promise<{
     data: Partial<CharacterInfo>;
     avatarFile?: File;
@@ -526,32 +527,65 @@ export const useCharacterStore = create<CharacterState>((set, get) => ({
   },
 
   // Import/Export actions
-  importCharacter: async (file: File) => {
+  importCharacter: async (files: File | File[]) => {
+    const fileList = Array.isArray(files) ? files : [files];
     set({ isImporting: true, error: null });
     try {
       let characterData: CharacterCardV2 | CharacterExportData | null = null;
       let avatarFile: File | undefined;
+      let characterBook: CharacterBookV2 | undefined;
 
-      const isPNG = file.type === 'image/png' || file.name.toLowerCase().endsWith('.png');
-      const isJSON = file.type === 'application/json' || file.name.toLowerCase().endsWith('.json');
+      const isPNG = (f: File) =>
+        f.type === 'image/png' || f.name.toLowerCase().endsWith('.png');
+      const isJSON = (f: File) =>
+        f.type === 'application/json' || f.name.toLowerCase().endsWith('.json');
 
-      if (isPNG) {
-        // Extract character data from PNG
-        characterData = await extractCharacterFromPNG(file);
-        if (!characterData) {
-          throw new Error('No character data found in PNG file');
-        }
-        // Use the PNG as the avatar
-        avatarFile = file;
-      } else if (isJSON) {
-        // Parse JSON file
-        characterData = await parseCharacterFromJSON(file);
-      } else {
+      const pngFiles = fileList.filter(isPNG);
+      const jsonFiles = fileList.filter(isJSON);
+
+      if (fileList.some((f) => !isPNG(f) && !isJSON(f))) {
         throw new Error('Unsupported file format. Please use PNG or JSON files.');
       }
 
+      // Classify JSON files as either lorebook or character card
+      const standaloneBooks: CharacterBookV2[] = [];
+      const characterJsons: Array<CharacterCardV2 | CharacterExportData> = [];
+
+      for (const json of jsonFiles) {
+        const book = await parseLorebookFromJSON(json);
+        if (book) {
+          standaloneBooks.push(book);
+        } else {
+          try {
+            characterJsons.push(await parseCharacterFromJSON(json));
+          } catch {
+            // skip unparseable JSON
+          }
+        }
+      }
+
+      // Resolve character source: PNG takes priority over JSON
+      if (pngFiles.length > 0) {
+        const png = pngFiles[0];
+        characterData = await extractCharacterFromPNG(png);
+        if (!characterData) throw new Error('No character data found in PNG file');
+        avatarFile = png;
+      } else if (characterJsons.length > 0) {
+        characterData = characterJsons[0];
+      }
+
+      if (!characterData) {
+        throw new Error('No character data found. Please provide a PNG or character JSON file.');
+      }
+
+      // Lorebook priority: standalone JSON > embedded in card
+      if (standaloneBooks.length > 0) {
+        characterBook = standaloneBooks[0];
+      } else {
+        characterBook = extractCharacterBook(characterData) || undefined;
+      }
+
       const info = cardToCharacterInfo(characterData);
-      const characterBook = extractCharacterBook(characterData) || undefined;
       set({ isImporting: false });
       return { data: info, avatarFile, characterBook };
     } catch (error) {

--- a/src/utils/characterCard.ts
+++ b/src/utils/characterCard.ts
@@ -484,6 +484,27 @@ export function exportCharacterAsJSON(
 }
 
 /**
+ * Try to parse a JSON file as a standalone lorebook (CharacterBookV2).
+ * Returns null if the file looks like a character card or lacks a valid entries array.
+ */
+export async function parseLorebookFromJSON(file: File): Promise<CharacterBookV2 | null> {
+  try {
+    const data = JSON.parse(await file.text());
+    if (
+      data !== null &&
+      typeof data === 'object' &&
+      Array.isArray(data.entries) &&
+      !('spec' in data)
+    ) {
+      return data as CharacterBookV2;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Parse character from JSON file
  */
 export async function parseCharacterFromJSON(


### PR DESCRIPTION
## Summary
- Accept multiple files in the character import drop zone (drag-and-drop or file picker)
- `parseLorebookFromJSON` utility detects standalone lorebook JSONs (top-level `entries` array, no `spec` field)
- `importCharacter` in the store now accepts `File | File[]`, classifies JSONs as lorebook vs character card, merges results: PNG wins for character, explicit lorebook JSON takes priority over embedded book
- Single-file drops keep the existing lorebook-only fallback path intact
- Drop zone hint updated to describe multi-file behavior; file input gets `multiple`

## Test plan
- [ ] Drop a PNG character card → imports as before
- [ ] Drop a character JSON → imports as before  
- [ ] Drop a standalone lorebook JSON alone → shows "Import as Lorebook" fallback
- [ ] Drop a PNG + lorebook JSON together → character imported with lorebook pre-attached (lorebook badge shown)
- [ ] Drop a character JSON + lorebook JSON together → same as above without avatar
- [ ] Drop a PNG with embedded lorebook (no separate JSON) → embedded book still detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)