### PR TITLE
feat(appearance): sync theme preferences per-user to server

### DIFF
--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -35,21 +35,12 @@ import {
   type AvatarShape,
 } from '../../hooks/displayPreferences';
 import {
-  getThemeMode,
-  setThemeMode,
-  getThemePreset,
-  setThemePreset,
-  applyTheme,
   THEME_PRESETS,
   PRESET_SWATCHES,
   type ThemeMode,
   type ThemePreset,
-  type ActivePreset,
-  getActivePreset,
-  setActivePreset,
-  getCustomThemes,
-  deleteCustomTheme,
 } from '../../hooks/themePreferences';
+import { useThemeStore } from '../../stores/themeStore';
 import { useSpeechRecognition } from '../../hooks/useSpeechRecognition';
 import { useSpeechSynthesis } from '../../hooks/useSpeechSynthesis';
 import { useTranslateStore } from '../../stores/translateStore';
@@ -72,12 +63,15 @@ export function SettingsPage(_props?: { params?: Record<string, string> }) {
   const [speechLang, setSpeechLangState] = useState<string>(() => getSpeechLanguage());
   const { isSupported: isSpeechSupported } = useSpeechRecognition();
 
-  // Phase 7.4: Theme preferences
-  const [themeMode, setThemeModeState] = useState<ThemeMode>(() => getThemeMode());
-  const [themePresetVal, setThemePresetState] = useState<ThemePreset>(() => getThemePreset());
-  // Phase 6.1: Custom themes
-  const [activePreset, setActivePresetState] = useState<ActivePreset>(() => getActivePreset());
-  const [customThemes, setCustomThemes] = useState(() => getCustomThemes());
+  // Phase 7.4 + 6.1: Theme preferences (server-synced via themeStore)
+  const themeMode = useThemeStore(s => s.mode);
+  const activePreset = useThemeStore(s => s.activePreset);
+  const customThemes = useThemeStore(s => s.customThemes);
+  const setThemeMode = useThemeStore(s => s.setMode);
+  const setThemePreset = useThemeStore(s => s.setPreset);
+  const deleteCustomTheme = useThemeStore(s => s.deleteCustomTheme);
+  // Derived: built-in preset name for seeding the theme editor's base colors.
+  const themePresetVal = (activePreset.startsWith('custom:') ? 'cyberpunk' : activePreset) as ThemePreset;
 
   // Phase 7.3: Chat display preferences
   const [layoutMode, setLayoutModeState] = useState<ChatLayoutMode>(() => getChatLayoutMode());
@@ -441,11 +435,7 @@ export function SettingsPage(_props?: { params?: Record<string, string> }) {
                 ] as const).map((opt) => (
                   <button
                     key={opt.value}
-                    onClick={() => {
-                      setThemeModeState(opt.value);
-                      setThemeMode(opt.value);
-                      applyTheme();
-                    }}
+                    onClick={() => setThemeMode(opt.value)}
                     className={`p-2.5 rounded-lg text-center text-xs font-medium transition-all ${
                       themeMode === opt.value
                         ? 'bg-[var(--color-primary)] text-white'
@@ -465,12 +455,7 @@ export function SettingsPage(_props?: { params?: Record<string, string> }) {
                 {THEME_PRESETS.map((preset) => (
                   <button
                     key={preset}
-                    onClick={() => {
-                      setThemePresetState(preset);
-                      setThemePreset(preset);
-                      setActivePresetState(preset);
-                      applyTheme();
-                    }}
+                    onClick={() => setThemePreset(preset)}
                     className={`w-8 h-8 rounded-full transition-all ${
                       activePreset === preset
                         ? 'ring-2 ring-offset-2 ring-offset-[var(--color-bg-secondary)] ring-[var(--color-primary)] scale-110'
@@ -502,11 +487,7 @@ export function SettingsPage(_props?: { params?: Record<string, string> }) {
                             ? 'bg-[var(--color-bg-tertiary)] ring-1 ring-[var(--color-primary)]'
                             : 'hover:bg-[var(--color-bg-tertiary)]'
                         }`}
-                        onClick={() => {
-                          setActivePreset(`custom:${ct.id}`);
-                          setActivePresetState(`custom:${ct.id}`);
-                          applyTheme();
-                        }}
+                        onClick={() => setThemePreset(`custom:${ct.id}`)}
                       >
                         {/* Mini swatch preview */}
                         <div className="flex gap-0.5 shrink-0">
@@ -526,8 +507,6 @@ export function SettingsPage(_props?: { params?: Record<string, string> }) {
                           onClick={(e) => {
                             e.stopPropagation();
                             deleteCustomTheme(ct.id);
-                            setCustomThemes(getCustomThemes());
-                            setActivePresetState(getActivePreset());
                           }}
                           className="p-1 text-[var(--color-text-secondary)] hover:text-red-400"
                           title="Delete"

--- a/src/components/settings/ThemeEditorPage.tsx
+++ b/src/components/settings/ThemeEditorPage.tsx
@@ -7,19 +7,15 @@ import {
   type CustomTheme,
   type CustomThemeExport,
   type ThemePreset,
-  type ActivePreset,
   applyColors,
   applyTheme,
-  getCustomThemes,
   getPresetColors,
-  getThemeMode,
   generateThemeId,
   isValidThemeColors,
   resolveMode,
-  saveCustomTheme,
-  setActivePreset,
   THEME_PRESETS,
 } from '../../hooks/themePreferences';
+import { useThemeStore } from '../../stores/themeStore';
 
 // ---------------------------------------------------------------------------
 // CSS variable label mapping
@@ -44,15 +40,17 @@ export function ThemeEditorPage({ params: pageParams }: { params?: Record<string
   const { goBack } = useSettingsPanelStore();
   const fileRef = useRef<HTMLInputElement>(null);
 
+  const { mode: themeMode, saveCustomTheme, setPreset: setActivePreset } = useThemeStore();
+
   const editId = pageParams?.id ?? null;
   const fromPreset = (pageParams?.from ?? null) as ThemePreset | null;
-  const resolved = resolveMode(getThemeMode());
+  const resolved = resolveMode(themeMode);
 
   // Load initial colors
   const [themeId] = useState(() => editId ?? generateThemeId());
   const [themeName, setThemeName] = useState(() => {
     if (editId) {
-      const existing = getCustomThemes().find(t => t.id === editId);
+      const existing = useThemeStore.getState().customThemes.find(t => t.id === editId);
       if (existing) return existing.name;
     }
     if (fromPreset) return `${fromPreset.charAt(0).toUpperCase() + fromPreset.slice(1)} (custom)`;
@@ -61,7 +59,7 @@ export function ThemeEditorPage({ params: pageParams }: { params?: Record<string
 
   const getInitialColors = useCallback((): { dark: ThemeColors; light: ThemeColors } => {
     if (editId) {
-      const existing = getCustomThemes().find(t => t.id === editId);
+      const existing = useThemeStore.getState().customThemes.find(t => t.id === editId);
       if (existing) return { dark: { ...existing.dark }, light: { ...existing.light } };
     }
     const base = fromPreset && THEME_PRESETS.includes(fromPreset) ? fromPreset : 'purple';
@@ -101,8 +99,7 @@ export function ThemeEditorPage({ params: pageParams }: { params?: Record<string
   const handleSave = () => {
     const theme: CustomTheme = { id: themeId, name: themeName.trim() || 'Untitled', dark: darkColors, light: lightColors };
     saveCustomTheme(theme);
-    setActivePreset(`custom:${themeId}` as ActivePreset);
-    applyTheme();
+    setActivePreset(`custom:${themeId}`);
     goBack();
   };
 

--- a/src/hooks/themePreferences.ts
+++ b/src/hooks/themePreferences.ts
@@ -201,6 +201,11 @@ export function saveCustomTheme(theme: CustomTheme): void {
   saveCustomThemes(themes);
 }
 
+/** Replace the entire custom theme list (used by server-sync on login). */
+export function replaceCustomThemes(themes: CustomTheme[]): void {
+  saveCustomThemes(themes);
+}
+
 export function deleteCustomTheme(id: string): void {
   const themes = getCustomThemes().filter(t => t.id !== id);
   saveCustomThemes(themes);

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -4,6 +4,7 @@ import { useCharacterStore } from './characterStore';
 import { useChatStore } from './chatStore';
 import { useSettingsStore } from './settingsStore';
 import { useWorldInfoStore } from './worldInfoStore';
+import { useThemeStore } from './themeStore';
 import type { UserRole, Permission } from '../types';
 
 interface CurrentUser {
@@ -61,6 +62,7 @@ export const useAuthStore = create<AuthState>((set) => ({
           },
           isLoading: false,
         });
+        useThemeStore.getState().fetchTheme();
       } else {
         set({ isAuthenticated: false, currentUser: null, isLoading: false });
       }
@@ -130,6 +132,7 @@ export const useAuthStore = create<AuthState>((set) => ({
           : { handle, name: handle, role: 'end_user' },
         isLoading: false,
       });
+      useThemeStore.getState().fetchTheme();
       return true;
     } catch (error) {
       set({

--- a/src/stores/themeStore.ts
+++ b/src/stores/themeStore.ts
@@ -1,0 +1,129 @@
+/**
+ * Server-synced theme preferences store.
+ *
+ * State is initialised from localStorage (so the first render has the right
+ * colors instantly), then hydrated from the user's server-side settings blob
+ * after login.  Every change is written to localStorage immediately (for fast
+ * subsequent loads) and patched to the server in the background.
+ *
+ * The settings blob field is `stm_theme`.
+ */
+
+import { create } from 'zustand';
+import { settingsApi } from '../api/client';
+import {
+  type ThemeMode,
+  type ActivePreset,
+  type CustomTheme,
+  getThemeMode,
+  setThemeMode,
+  getActivePreset,
+  setActivePreset,
+  getCustomThemes,
+  saveCustomTheme as lsSave,
+  deleteCustomTheme as lsDelete,
+  replaceCustomThemes,
+  applyTheme,
+} from '../hooks/themePreferences';
+
+interface ThemeState {
+  mode: ThemeMode;
+  activePreset: ActivePreset;
+  customThemes: CustomTheme[];
+
+  /** Load theme from server after login and apply it. No-op if no server data yet. */
+  fetchTheme: () => Promise<void>;
+  setMode: (mode: ThemeMode) => void;
+  setPreset: (preset: ActivePreset) => void;
+  saveCustomTheme: (theme: CustomTheme) => void;
+  deleteCustomTheme: (id: string) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function getSettingsBlob(): Promise<Record<string, unknown>> {
+  const response = await settingsApi.getSettings();
+  if (typeof response.settings === 'string') {
+    try { return JSON.parse(response.settings); } catch { return {}; }
+  }
+  return (response.settings as Record<string, unknown>) || {};
+}
+
+async function patchServerTheme(patch: {
+  mode?: ThemeMode;
+  activePreset?: ActivePreset;
+  customThemes?: CustomTheme[];
+}): Promise<void> {
+  const settings = await getSettingsBlob();
+  const theme = (settings.stm_theme as Record<string, unknown>) || {};
+  if (patch.mode !== undefined) theme.mode = patch.mode;
+  if (patch.activePreset !== undefined) theme.activePreset = patch.activePreset;
+  if (patch.customThemes !== undefined) theme.customThemes = patch.customThemes;
+  settings.stm_theme = theme;
+  await settingsApi.saveSettings(settings);
+}
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+export const useThemeStore = create<ThemeState>((set, get) => ({
+  // Initialise from localStorage so there's no flash on first render.
+  mode: getThemeMode(),
+  activePreset: getActivePreset(),
+  customThemes: getCustomThemes(),
+
+  fetchTheme: async () => {
+    try {
+      const settings = await getSettingsBlob();
+      const theme = settings.stm_theme as Record<string, unknown> | undefined;
+      if (!theme) return; // No server preferences saved yet — keep localStorage values.
+
+      const mode = (theme.mode as ThemeMode) || get().mode;
+      const activePreset = (theme.activePreset as ActivePreset) || get().activePreset;
+      const customThemes = Array.isArray(theme.customThemes)
+        ? (theme.customThemes as CustomTheme[])
+        : get().customThemes;
+
+      // Write back to localStorage so the next cold load is still instant.
+      setThemeMode(mode);
+      setActivePreset(activePreset);
+      replaceCustomThemes(customThemes);
+
+      set({ mode, activePreset, customThemes });
+      applyTheme();
+    } catch { /* non-fatal — localStorage values remain active */ }
+  },
+
+  setMode: (mode: ThemeMode) => {
+    setThemeMode(mode);
+    set({ mode });
+    applyTheme();
+    patchServerTheme({ mode }).catch(() => {});
+  },
+
+  setPreset: (preset: ActivePreset) => {
+    setActivePreset(preset);
+    set({ activePreset: preset });
+    applyTheme();
+    patchServerTheme({ activePreset: preset }).catch(() => {});
+  },
+
+  saveCustomTheme: (theme: CustomTheme) => {
+    lsSave(theme);
+    const customThemes = getCustomThemes();
+    set({ customThemes });
+    patchServerTheme({ customThemes }).catch(() => {});
+  },
+
+  deleteCustomTheme: (id: string) => {
+    lsDelete(id);
+    const customThemes = getCustomThemes();
+    const activePreset = getActivePreset(); // lsDelete may have reverted this to 'cyberpunk'
+    set({ customThemes, activePreset });
+    applyTheme();
+    patchServerTheme({ customThemes, activePreset }).catch(() => {});
+  },
+}));


### PR DESCRIPTION
## Summary
- Mode, accent preset, and custom themes are now stored in the user's server-side settings blob (`stm_theme` key) so they follow each user across devices and browsers
- `localStorage` is retained as the fast-path for initial render (no color flash); server value is applied after login and written back so subsequent cold loads stay instant
- All writes (setMode, setPreset, saveCustomTheme, deleteCustomTheme) update localStorage synchronously then patch the server in the background — UI is always responsive

## Changes
- `src/stores/themeStore.ts` — new Zustand store wrapping localStorage + server sync
- `src/hooks/themePreferences.ts` — export `replaceCustomThemes` for bulk server→localStorage hydration
- `src/stores/authStore.ts` — call `fetchTheme()` after `checkAuth` and `login`
- `src/components/settings/SettingsPage.tsx` — use `useThemeStore` instead of local state + localStorage
- `src/components/settings/ThemeEditorPage.tsx` — use store for save/activate

## Test plan
- [ ] Log in as User A, set a theme — verify it persists after page reload
- [ ] Log in as User B on same browser — verify their own theme loads (not User A's)
- [ ] Set a custom theme, delete it — verify server blob updates
- [ ] Verify no color flash on cold load (localStorage fast-path still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)