### PR TITLE
fix(ui): prevent blank white page on auth redirect

### DIFF
--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -54,7 +54,13 @@ export function MainLayout() {
   }
 
   if (!isAuthenticated) {
-    return null;
+    // Navigation to /login is triggered by the effect above — show spinner
+    // while the router processes the redirect rather than flashing blank.
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-[var(--color-bg-primary)]">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-[var(--color-primary)]" />
+      </div>
+    );
   }
 
   return (

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,15 +1,37 @@
-import { StrictMode } from 'react';
+import { StrictMode, Component, type ReactNode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App';
 import { applyTheme } from './hooks/themePreferences';
+
+class RootErrorBoundary extends Component<{ children: ReactNode }, { hasError: boolean }> {
+  state = { hasError: false };
+  static getDerivedStateFromError() { return { hasError: true }; }
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div style={{ minHeight: '100svh', display: 'flex', alignItems: 'center', justifyContent: 'center', background: '#0f0f0f', color: '#fff', fontFamily: 'sans-serif', textAlign: 'center', padding: '2rem' }}>
+          <div>
+            <div style={{ fontSize: '1.25rem', marginBottom: '0.5rem' }}>Something went wrong</div>
+            <button onClick={() => window.location.reload()} style={{ padding: '0.5rem 1.25rem', borderRadius: '0.375rem', background: '#7c3aed', color: '#fff', border: 'none', cursor: 'pointer' }}>
+              Reload
+            </button>
+          </div>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
 
 // Apply theme before first render to avoid flash of wrong colors.
 applyTheme();
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <RootErrorBoundary>
+      <App />
+    </RootErrorBoundary>
   </StrictMode>
 );
 


### PR DESCRIPTION
## Summary
- `MainLayout` was returning `null` when auth check completed as unauthenticated, causing a blank white page during the render cycle before `navigate('/login')` fired from the effect
- Replaced `return null` with the loading spinner so there's never an empty screen during the redirect
- Added `RootErrorBoundary` in `main.tsx` so any future render crash shows a "Something went wrong" + Reload prompt instead of an empty `#root` div

## Test plan
- [ ] Visit site while logged out — should see spinner briefly then redirect to /login, never blank white
- [ ] Verify no regression on normal authenticated flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)