### PR TITLE
fix(sw): use network-first for HTML to prevent blank page after deploy

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,14 +1,16 @@
-const CACHE_NAME = 'st-mobile-v1';
-const APP_SHELL = ['/', '/index.html'];
+// Bump this version whenever you need to forcibly clear all cached assets.
+const CACHE_NAME = 'st-mobile-v2';
 
-self.addEventListener('install', (e) => {
-  e.waitUntil(
-    caches.open(CACHE_NAME).then((cache) => cache.addAll(APP_SHELL))
-  );
+// Matches Vite's hashed asset filenames: /assets/index-AbCdEf12.js
+const HASHED_ASSET = /\/assets\/.+\.[a-f0-9]{8,}\.(js|css)$/;
+
+self.addEventListener('install', () => {
+  // Take over immediately — don't wait for old SW to unload.
   self.skipWaiting();
 });
 
 self.addEventListener('activate', (e) => {
+  // Delete all caches from previous versions.
   e.waitUntil(
     caches.keys().then((keys) =>
       Promise.all(keys.filter((k) => k !== CACHE_NAME).map((k) => caches.delete(k)))
@@ -19,13 +21,54 @@ self.addEventListener('activate', (e) => {
 
 self.addEventListener('fetch', (e) => {
   const url = new URL(e.request.url);
-  // Network-only for API routes — never cache dynamic data.
-  if (url.pathname.startsWith('/api') ||
-      url.pathname.startsWith('/thumbnail') ||
-      url.pathname.startsWith('/characters') ||
-      url.pathname.startsWith('/csrf-token')) {
+
+  // Network-only for API / dynamic routes — never cache.
+  if (
+    url.pathname.startsWith('/api') ||
+    url.pathname.startsWith('/thumbnail') ||
+    url.pathname.startsWith('/characters') ||
+    url.pathname.startsWith('/csrf-token')
+  ) {
     return;
   }
+
+  // ── HTML (navigation requests) → network-first ─────────────────────────────
+  // Always fetch fresh HTML so users get the correct hashed asset filenames
+  // after a deploy. Fall back to cache only when completely offline.
+  if (
+    e.request.mode === 'navigate' ||
+    e.request.headers.get('accept')?.includes('text/html')
+  ) {
+    e.respondWith(
+      fetch(e.request)
+        .then((response) => {
+          const clone = response.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(e.request, clone));
+          return response;
+        })
+        .catch(() => caches.match(e.request))
+    );
+    return;
+  }
+
+  // ── Hashed JS/CSS assets → cache-first ─────────────────────────────────────
+  // These filenames are immutable (hash changes with content), so caching
+  // them forever is safe and makes repeat visits instant.
+  if (HASHED_ASSET.test(url.pathname)) {
+    e.respondWith(
+      caches.match(e.request).then((cached) => {
+        if (cached) return cached;
+        return fetch(e.request).then((response) => {
+          const clone = response.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(e.request, clone));
+          return response;
+        });
+      })
+    );
+    return;
+  }
+
+  // ── Everything else (icons, manifest, fonts…) → cache-first ────────────────
   e.respondWith(
     caches.match(e.request).then((cached) => cached || fetch(e.request))
   );


### PR DESCRIPTION
## Summary
- Root cause of the intermittent blank white page: the service worker cached `index.html` and served it cache-first forever. After each deploy, Vite generates new hashed asset filenames (`index-AbCd.js`). The SW served the **old** HTML pointing to the **old** hash → 404 → React never loaded → blank page.
- Worse on mobile because iOS Safari PWA mode and mobile browsers lean on the SW cache much harder than desktop Chrome.

## Fix
- HTML / navigation requests → **network-first**: always fetch fresh HTML so the correct asset hashes are used; fall back to cached HTML only when offline
- Hashed `/assets/*.js|css` → **cache-first**: these filenames are immutable (hash changes with content), so aggressive caching is safe
- Bumped cache to `v2` to immediately evict the stale `v1` HTML from all existing clients

## Test plan
- [ ] Hard refresh on mobile after deploy — no blank page
- [ ] Offline mode on mobile — app still loads from cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)