### PR TITLE
feat(stores): scope extension settings to individual users

### DIFF
--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -5,6 +5,10 @@ import { useChatStore } from './chatStore';
 import { useSettingsStore } from './settingsStore';
 import { useWorldInfoStore } from './worldInfoStore';
 import { useThemeStore } from './themeStore';
+import { useExtensionStore } from './extensionStore';
+import { useSummarizeStore } from './summarizeStore';
+import { useTranslateStore } from './translateStore';
+import { useQuickReplyStore } from './quickReplyStore';
 import type { UserRole, Permission } from '../types';
 
 interface CurrentUser {
@@ -50,6 +54,10 @@ export const useAuthStore = create<AuthState>((set) => ({
       const user = await api.getCurrentUser();
       if (user) {
         useWorldInfoStore.getState().initForUser(user.handle);
+        useExtensionStore.getState().initForUser(user.handle);
+        useSummarizeStore.getState().initForUser(user.handle);
+        useTranslateStore.getState().initForUser(user.handle);
+        useQuickReplyStore.getState().initForUser(user.handle);
         set({
           isAuthenticated: true,
           currentUser: {
@@ -96,6 +104,10 @@ export const useAuthStore = create<AuthState>((set) => ({
       // After successful registration, log the user in
       const loginResult = await api.login(result.handle, password);
       useWorldInfoStore.getState().initForUser(loginResult.handle);
+      useExtensionStore.getState().initForUser(loginResult.handle);
+      useSummarizeStore.getState().initForUser(loginResult.handle);
+      useTranslateStore.getState().initForUser(loginResult.handle);
+      useQuickReplyStore.getState().initForUser(loginResult.handle);
       set({
         isAuthenticated: true,
         currentUser: { handle: loginResult.handle, name, role: 'end_user' },
@@ -117,7 +129,12 @@ export const useAuthStore = create<AuthState>((set) => ({
       await api.login(handle, password);
       // Fetch real user data so role, permissions, and display name are correct.
       const user = await api.getCurrentUser();
-      useWorldInfoStore.getState().initForUser(user?.handle ?? handle);
+      const h = user?.handle ?? handle;
+      useWorldInfoStore.getState().initForUser(h);
+      useExtensionStore.getState().initForUser(h);
+      useSummarizeStore.getState().initForUser(h);
+      useTranslateStore.getState().initForUser(h);
+      useQuickReplyStore.getState().initForUser(h);
       set({
         isAuthenticated: true,
         currentUser: user
@@ -182,6 +199,10 @@ export const useAuthStore = create<AuthState>((set) => ({
         successMessage: null,
       });
       useWorldInfoStore.getState().resetUser();
+      useExtensionStore.getState().resetUser();
+      useSummarizeStore.getState().resetUser();
+      useTranslateStore.getState().resetUser();
+      useQuickReplyStore.getState().resetUser();
 
       // Clear persisted localStorage data
       localStorage.removeItem('sillytavern_group_chats');

--- a/src/stores/extensionStore.ts
+++ b/src/stores/extensionStore.ts
@@ -1,10 +1,29 @@
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
+import { persist, createJSONStorage } from 'zustand/middleware';
+
+let _currentHandle: string | null = null;
+
+const scopedLocalStorage = {
+  getItem: (name: string) => {
+    const key = _currentHandle ? `${name}_${_currentHandle}` : name;
+    return localStorage.getItem(key);
+  },
+  setItem: (name: string, value: string) => {
+    const key = _currentHandle ? `${name}_${_currentHandle}` : name;
+    localStorage.setItem(key, value);
+  },
+  removeItem: (name: string) => {
+    const key = _currentHandle ? `${name}_${_currentHandle}` : name;
+    localStorage.removeItem(key);
+  },
+};
 
 interface ExtensionState {
   /** Per-extension enabled state. Keys are extension IDs (e.g. 'tts', 'summarize'). */
   enabled: Record<string, boolean>;
   setEnabled: (id: string, on: boolean) => void;
+  initForUser: (handle: string) => void;
+  resetUser: () => void;
 }
 
 export const useExtensionStore = create<ExtensionState>()(
@@ -13,7 +32,18 @@ export const useExtensionStore = create<ExtensionState>()(
       enabled: {},
       setEnabled: (id, on) =>
         set((s) => ({ enabled: { ...s.enabled, [id]: on } })),
+      initForUser: (handle) => {
+        _currentHandle = handle;
+        useExtensionStore.persist.rehydrate();
+      },
+      resetUser: () => {
+        _currentHandle = null;
+        set({ enabled: {} });
+      },
     }),
-    { name: 'st-mobile-extensions' }
+    {
+      name: 'st-mobile-extensions',
+      storage: createJSONStorage(() => scopedLocalStorage),
+    }
   )
 );

--- a/src/stores/quickReplyStore.ts
+++ b/src/stores/quickReplyStore.ts
@@ -1,5 +1,22 @@
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
+import { persist, createJSONStorage } from 'zustand/middleware';
+
+let _currentHandle: string | null = null;
+
+const scopedLocalStorage = {
+  getItem: (name: string) => {
+    const key = _currentHandle ? `${name}_${_currentHandle}` : name;
+    return localStorage.getItem(key);
+  },
+  setItem: (name: string, value: string) => {
+    const key = _currentHandle ? `${name}_${_currentHandle}` : name;
+    localStorage.setItem(key, value);
+  },
+  removeItem: (name: string) => {
+    const key = _currentHandle ? `${name}_${_currentHandle}` : name;
+    localStorage.removeItem(key);
+  },
+};
 
 export interface QuickReplyEntry {
   id: string;
@@ -28,6 +45,8 @@ interface QuickReplyState {
   deleteEntry: (setId: string, entryId: string) => void;
   moveEntryUp: (setId: string, entryId: string) => void;
   moveEntryDown: (setId: string, entryId: string) => void;
+  initForUser: (handle: string) => void;
+  resetUser: () => void;
 }
 
 function uid(): string {
@@ -122,7 +141,18 @@ export const useQuickReplyStore = create<QuickReplyState>()(
             return { ...qs, entries };
           }),
         })),
+      initForUser: (handle) => {
+        _currentHandle = handle;
+        useQuickReplyStore.persist.rehydrate();
+      },
+      resetUser: () => {
+        _currentHandle = null;
+        set({ sets: [], activeSetId: null });
+      },
     }),
-    { name: 'quick-reply-store' }
+    {
+      name: 'quick-reply-store',
+      storage: createJSONStorage(() => scopedLocalStorage),
+    }
   )
 );

--- a/src/stores/summarizeStore.ts
+++ b/src/stores/summarizeStore.ts
@@ -1,7 +1,24 @@
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
+import { persist, createJSONStorage } from 'zustand/middleware';
 import { api } from '../api/client';
 import { useSettingsStore } from './settingsStore';
+
+let _currentHandle: string | null = null;
+
+const scopedLocalStorage = {
+  getItem: (name: string) => {
+    const key = _currentHandle ? `${name}_${_currentHandle}` : name;
+    return localStorage.getItem(key);
+  },
+  setItem: (name: string, value: string) => {
+    const key = _currentHandle ? `${name}_${_currentHandle}` : name;
+    localStorage.setItem(key, value);
+  },
+  removeItem: (name: string) => {
+    const key = _currentHandle ? `${name}_${_currentHandle}` : name;
+    localStorage.removeItem(key);
+  },
+};
 
 export interface ChatSummary {
   text: string;
@@ -35,6 +52,8 @@ interface SummarizeState {
   getSummary: (chatFile: string) => ChatSummary | null;
   clearSummary: (chatFile: string) => void;
   clearError: () => void;
+  initForUser: (handle: string) => void;
+  resetUser: () => void;
   generateSummary: (
     chatMessages: { name: string; isUser: boolean; isSystem: boolean; content: string }[],
     chatFile: string,
@@ -113,6 +132,15 @@ export const useSummarizeStore = create<SummarizeState>()(
 
       clearError: () => set({ error: null }),
 
+      initForUser: (handle) => {
+        _currentHandle = handle;
+        useSummarizeStore.persist.rehydrate();
+      },
+      resetUser: () => {
+        _currentHandle = null;
+        set({ autoSummarize: false, autoTriggerEvery: 20, injectionDepth: 999, injectionRole: 'system', summaries: {}, error: null });
+      },
+
       generateSummary: async (chatMessages, chatFile, characterName) => {
         if (get().isGenerating) return;
         set({ isGenerating: true, error: null });
@@ -181,6 +209,7 @@ export const useSummarizeStore = create<SummarizeState>()(
     }),
     {
       name: 'st-mobile-summarize',
+      storage: createJSONStorage(() => scopedLocalStorage),
       partialize: (s) => ({
         autoSummarize: s.autoSummarize,
         autoTriggerEvery: s.autoTriggerEvery,

--- a/src/stores/translateStore.ts
+++ b/src/stores/translateStore.ts
@@ -1,6 +1,23 @@
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
+import { persist, createJSONStorage } from 'zustand/middleware';
 import { translateText, type TranslateProvider } from '../api/translateApi';
+
+let _currentHandle: string | null = null;
+
+const scopedLocalStorage = {
+  getItem: (name: string) => {
+    const key = _currentHandle ? `${name}_${_currentHandle}` : name;
+    return localStorage.getItem(key);
+  },
+  setItem: (name: string, value: string) => {
+    const key = _currentHandle ? `${name}_${_currentHandle}` : name;
+    localStorage.setItem(key, value);
+  },
+  removeItem: (name: string) => {
+    const key = _currentHandle ? `${name}_${_currentHandle}` : name;
+    localStorage.removeItem(key);
+  },
+};
 
 interface TranslateState {
   // Persisted settings
@@ -16,6 +33,8 @@ interface TranslateState {
   setTargetLang: (l: string) => void;
   /** Toggle the translation panel for a message. Fetches from API if not cached. */
   toggleTranslation: (messageId: string, text: string) => Promise<void>;
+  initForUser: (handle: string) => void;
+  resetUser: () => void;
 }
 
 export const useTranslateStore = create<TranslateState>()(
@@ -83,9 +102,19 @@ export const useTranslateStore = create<TranslateState>()(
           set({ pending: newPending, visible: newVisible });
         }
       },
+
+      initForUser: (handle) => {
+        _currentHandle = handle;
+        useTranslateStore.persist.rehydrate();
+      },
+      resetUser: () => {
+        _currentHandle = null;
+        set({ provider: 'google', targetLang: 'en', cache: new Map(), pending: new Set(), visible: new Set() });
+      },
     }),
     {
       name: 'st-mobile-translate',
+      storage: createJSONStorage(() => scopedLocalStorage),
       partialize: (state) => ({
         provider: state.provider,
         targetLang: state.targetLang,


### PR DESCRIPTION
## Summary
- Extension enabled/disabled state, summarization config, translation settings, and quick replies were all stored under fixed localStorage keys — shared across all users on the same device/browser
- Each store now uses a user-handle-scoped key (e.g. `st-mobile-extensions_alice`) via a custom `createJSONStorage` wrapper
- `initForUser(handle)` rehydrates from the user's scoped key on login; `resetUser()` clears state on logout
- Follows the same pattern already used by `worldInfoStore`

## Stores changed
- `extensionStore` (`st-mobile-extensions`)
- `summarizeStore` (`st-mobile-summarize`)
- `translateStore` (`st-mobile-translate`)
- `quickReplyStore` (`quick-reply-store`)

## Test plan
- [ ] Log in as user A, enable Summarization → verify it's on
- [ ] Log out, log in as user B → verify Summarization is off (defaults)
- [ ] Log back in as user A → verify Summarization is still on

🤖 Generated with [Claude Code](https://claude.com/claude-code)