### PR TITLE
feat(providers): silently probe live /models endpoint in AI docs mode

### DIFF
--- a/src/components/settings/InstallProviderFromUrlModal.tsx
+++ b/src/components/settings/InstallProviderFromUrlModal.tsx
@@ -109,9 +109,18 @@ export function InstallProviderFromUrlModal({ isOpen, onClose }: Props) {
     const extracted = result.provider;
     setName(extracted.name || '');
     setUrl(extracted.baseUrl || '');
-    setModels(extracted.defaultModels || []);
     setDocsUrl(extracted.docsUrl || docsInput);
     setDescription(extracted.description || '');
+
+    // Try to probe the live /models endpoint for a complete list; fall back to
+    // whatever the docs extraction found if CORS or auth blocks the probe.
+    if (extracted.baseUrl) {
+      const probe = await probeProviderModels(extracted.baseUrl.replace(/\/+$/, ''));
+      setModels(probe.ok && probe.models.length > 0 ? probe.models : (extracted.defaultModels || []));
+    } else {
+      setModels(extracted.defaultModels || []);
+    }
+
     setPhase('preview');
   }
 


### PR DESCRIPTION
After AI extraction resolves `baseUrl`, probe the live `/models` endpoint for the complete model list. Falls back to docs-extracted models on failure (CORS, auth, network error).

This brings AI docs mode to parity with Probe mode — users get the full live catalog rather than only the models mentioned in docs.