### PR TITLE
feat(extensions): global mounting + react popup modal (tier 3 A+B)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,8 @@ import { ChatView } from './components/chat/ChatView';
 // Settings pages are now rendered inside the slide-in SettingsPanel (not routes).
 import { InviteAcceptPage } from './components/auth/InviteAcceptPage';
 import { ToastProvider } from './components/ui/Toast';
+import { GlobalExtensionHost } from './extensions/sandbox/GlobalExtensionHost';
+import { ExtensionPopupRoot } from './extensions/sandbox/ExtensionPopupRoot';
 
 // Phase 7.1: Register all built-in extensions at app startup.
 import './extensions';
@@ -27,6 +29,8 @@ function App() {
         </Route>
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
+      <GlobalExtensionHost />
+      <ExtensionPopupRoot />
     </ToastProvider>
     </BrowserRouter>
   );

--- a/src/extensions/sandbox/ExtensionFrame.tsx
+++ b/src/extensions/sandbox/ExtensionFrame.tsx
@@ -26,6 +26,12 @@ import { useChatStore } from '../../stores/chatStore';
 import { usePersonaStore } from '../../stores/personaStore';
 import { useAuthStore } from '../../stores/authStore';
 import { showToastGlobal } from '../../components/ui/Toast';
+import {
+  useExtensionPopupStore,
+  POPUP_TYPE,
+  type PopupType,
+  type PopupOptions,
+} from '../../stores/extensionPopupStore';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -172,6 +178,20 @@ export function ExtensionFrame({
       case 'sendSystemMessage':
         respond(null);
         break;
+      case 'callPopup': {
+        const [html, rawType, inputValue, options] = msg.args as [
+          string,
+          number | string,
+          string?,
+          PopupOptions?,
+        ];
+        const type = (Number(rawType) as PopupType) || POPUP_TYPE.TEXT;
+        useExtensionPopupStore
+          .getState()
+          .showPopup(String(html ?? ''), type, inputValue, options)
+          .then((result) => respond(result));
+        break;
+      }
       default:
         respond(null, `Unsupported RPC method: ${msg.method}`);
     }

--- a/src/extensions/sandbox/ExtensionPopupRoot.tsx
+++ b/src/extensions/sandbox/ExtensionPopupRoot.tsx
@@ -1,0 +1,77 @@
+import { useState } from 'react';
+import { Modal } from '../../components/ui/Modal';
+import { Button } from '../../components/ui/Button';
+import {
+  useExtensionPopupStore,
+  POPUP_TYPE,
+  type PopupRequest,
+} from '../../stores/extensionPopupStore';
+
+function SinglePopup({ popup }: { popup: PopupRequest }) {
+  const closePopup = useExtensionPopupStore((s) => s.closePopup);
+  const [inputVal, setInputVal] = useState(popup.inputValue ?? '');
+
+  const okLabel = popup.options?.okButton ?? 'OK';
+  const cancelLabel = popup.options?.cancelButton ?? 'Cancel';
+  const showCancel =
+    popup.type === POPUP_TYPE.CONFIRM || popup.type === POPUP_TYPE.INPUT;
+
+  function handleOk() {
+    switch (popup.type) {
+      case POPUP_TYPE.CONFIRM:
+        closePopup(popup.id, true);
+        break;
+      case POPUP_TYPE.INPUT:
+        closePopup(popup.id, inputVal);
+        break;
+      default:
+        closePopup(popup.id, true);
+    }
+  }
+
+  function handleCancel() {
+    const result = popup.type === POPUP_TYPE.CONFIRM ? false : null;
+    closePopup(popup.id, result);
+  }
+
+  const size = popup.options?.large ? 'lg' : popup.options?.wide ? 'md' : 'sm';
+
+  return (
+    <Modal isOpen onClose={handleCancel} title="Extension" size={size}>
+      <div
+        className="text-sm text-[var(--color-text-primary)] mb-4 max-h-[50vh] overflow-y-auto"
+        dangerouslySetInnerHTML={{ __html: popup.html }}
+      />
+      {popup.type === POPUP_TYPE.INPUT && (
+        <textarea
+          value={inputVal}
+          onChange={(e) => setInputVal(e.target.value)}
+          rows={popup.options?.rows ?? 1}
+          className="w-full mb-4 px-3 py-2 text-sm rounded border border-[var(--color-border)] bg-[var(--color-bg-primary)] text-[var(--color-text-primary)] focus:outline-none focus:ring-1 focus:ring-[var(--color-primary)]"
+          autoFocus
+        />
+      )}
+      <div className="flex justify-end gap-2">
+        {showCancel && (
+          <Button variant="ghost" size="sm" onClick={handleCancel}>
+            {cancelLabel}
+          </Button>
+        )}
+        <Button variant="primary" size="sm" onClick={handleOk}>
+          {okLabel}
+        </Button>
+      </div>
+    </Modal>
+  );
+}
+
+export function ExtensionPopupRoot() {
+  const popups = useExtensionPopupStore((s) => s.popups);
+  return (
+    <>
+      {popups.map((p) => (
+        <SinglePopup key={p.id} popup={p} />
+      ))}
+    </>
+  );
+}

--- a/src/extensions/sandbox/GlobalExtensionHost.tsx
+++ b/src/extensions/sandbox/GlobalExtensionHost.tsx
@@ -1,0 +1,54 @@
+import { useEffect } from 'react';
+import { ExtensionFrame } from './ExtensionFrame';
+import { useServerExtensionStore } from '../../stores/serverExtensionStore';
+import { useAuthStore } from '../../stores/authStore';
+
+function extensionScriptUrl(extName: string): string {
+  const base = extName.replace(/^third-party\//, '');
+  return `/scripts/extensions/third-party/${base}/index.js`;
+}
+
+/**
+ * Mounts one hidden, always-alive ExtensionFrame per installed server
+ * extension so their background work (WebSockets, timers, generation
+ * interceptors, lifecycle-event subscribers) keeps running even when the
+ * settings panel is closed.
+ *
+ * Caveat: the settings page still mounts its own visible ExtensionFrame, so
+ * each extension's index.js runs twice concurrently while settings are open.
+ * Extensions that own unique resources (e.g. a single WebSocket connection)
+ * should guard their init with their own singleton check.
+ */
+export function GlobalExtensionHost() {
+  const installed = useServerExtensionStore((s) => s.installed);
+  const fetchInstalled = useServerExtensionStore((s) => s.fetchInstalled);
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+
+  useEffect(() => {
+    if (isAuthenticated) fetchInstalled();
+  }, [isAuthenticated, fetchInstalled]);
+
+  if (!isAuthenticated) return null;
+
+  return (
+    <div
+      aria-hidden="true"
+      style={{
+        position: 'fixed',
+        width: 0,
+        height: 0,
+        overflow: 'hidden',
+        pointerEvents: 'none',
+        visibility: 'hidden',
+      }}
+    >
+      {installed.map((ext) => (
+        <ExtensionFrame
+          key={ext.name}
+          extensionName={ext.name}
+          scriptUrl={extensionScriptUrl(ext.name)}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/extensions/sandbox/index.ts
+++ b/src/extensions/sandbox/index.ts
@@ -2,3 +2,5 @@ export { ExtensionFrame } from './ExtensionFrame';
 export type { ExtensionFrameProps } from './ExtensionFrame';
 export { fireSandboxLifecycleEvent, subscribeToSandboxEvents } from './sandboxEventBus';
 export { SHIM_CODE } from './extensionShim';
+export { GlobalExtensionHost } from './GlobalExtensionHost';
+export { ExtensionPopupRoot } from './ExtensionPopupRoot';

--- a/src/stores/extensionPopupStore.ts
+++ b/src/stores/extensionPopupStore.ts
@@ -1,0 +1,63 @@
+import { create } from 'zustand';
+
+/**
+ * SillyTavern popup type constants — mirror the integer values upstream uses
+ * so extensions calling `callPopup(html, 2, ...)` keep working.
+ */
+export const POPUP_TYPE = {
+  TEXT: 1,
+  CONFIRM: 2,
+  INPUT: 3,
+  DISPLAY: 4,
+} as const;
+
+export type PopupType = 1 | 2 | 3 | 4;
+
+export interface PopupOptions {
+  okButton?: string;
+  cancelButton?: string;
+  wide?: boolean;
+  large?: boolean;
+  rows?: number;
+  allowVerticalScrolling?: boolean;
+}
+
+export interface PopupRequest {
+  id: string;
+  html: string;
+  type: PopupType;
+  inputValue?: string;
+  options?: PopupOptions;
+  resolve: (result: unknown) => void;
+}
+
+interface ExtensionPopupState {
+  popups: PopupRequest[];
+  showPopup: (
+    html: string,
+    type: PopupType,
+    inputValue?: string,
+    options?: PopupOptions,
+  ) => Promise<unknown>;
+  closePopup: (id: string, result: unknown) => void;
+}
+
+let _seq = 0;
+
+export const useExtensionPopupStore = create<ExtensionPopupState>((set, get) => ({
+  popups: [],
+  showPopup(html, type, inputValue, options) {
+    return new Promise((resolve) => {
+      const id = `popup_${++_seq}`;
+      set((s) => ({
+        popups: [...s.popups, { id, html, type, inputValue, options, resolve }],
+      }));
+    });
+  },
+  closePopup(id, result) {
+    const popup = get().popups.find((p) => p.id === id);
+    if (!popup) return;
+    popup.resolve(result);
+    set((s) => ({ popups: s.popups.filter((p) => p.id !== id) }));
+  },
+}));


### PR DESCRIPTION
## Summary
- `GlobalExtensionHost` mounts one hidden `ExtensionFrame` per installed extension at app root so background work (WebSockets, timers, generation interceptors) survives closing the settings panel.
- `callPopup` / `callGenericPopup` RPCs now resolve through a real React modal via `ExtensionPopupRoot` + `extensionPopupStore`. Supports TEXT, CONFIRM, INPUT, DISPLAY with OK/Cancel wiring.
- Fills 2 of 4 Tier 3 gaps documented in the extensions pickup memo. Message-action-bar slot and chat-input-extras slot (C + D) remain, pending a design decision between DOM projection and opt-in shim API.

## Test plan
- [x] `npm run build` green locally (matches CI)
- [x] Popup store + `ExtensionPopupRoot` verified end-to-end in dev: CONFIRM resolves to `true` on OK, store clears; INPUT prefills value and renders HTML via dangerouslySetInnerHTML.
- [x] `GlobalExtensionHost` renders at `position: fixed; visibility: hidden` with child count tracking `installed.length`.
- [ ] Post-deploy sanity check with a real installed extension on the droplet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)