### PR TITLE
fix(extensions): proxy /scripts, make shim awaitable, toggle chat menu

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -51,6 +51,17 @@ server {
         proxy_set_header X-Forwarded-For 127.0.0.1;
     }
 
+    # Serves third-party extension scripts loaded by the sandboxed
+    # ExtensionFrame iframes. Without this, /scripts/extensions/... falls
+    # through to the SPA index.html and the iframe silently gets HTML
+    # instead of JavaScript, leaving the extension's UI blank.
+    location /scripts/ {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For 127.0.0.1;
+    }
+
     # Allow uploads up to 20 MB (avatars, sprites, attachments)
     client_max_body_size 20M;
 }

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -1335,7 +1335,7 @@ export function ChatView() {
         droppedImagesNonce={droppedImagesNonce}
         onEditLast={lastUserMessageId && !isSending ? () => setEditLastNonce((n) => n + 1) : undefined}
         onImageGen={imageGenEnabled && !isGroupChatMode && selectedCharacter ? () => setIsImageGenOpen(true) : undefined}
-        onOpenChatMenu={selectedCharacter ? (anchor) => { setChatMenuAnchor(anchor); setIsChatMenuOpen(true); } : undefined}
+        onOpenChatMenu={selectedCharacter ? (anchor) => { setChatMenuAnchor(anchor); setIsChatMenuOpen((v) => !v); } : undefined}
       />
 
       {/* Phase 7.1: Image generation modal */}

--- a/src/extensions/sandbox/extensionShim.ts
+++ b/src/extensions/sandbox/extensionShim.ts
@@ -454,21 +454,49 @@ export const SHIM_CODE: string = /* javascript */ `
     return _jq(null);
   }
 
-  // Static jQuery helpers
+  // Static jQuery helpers — $.ajax returns a thenable jqXHR stand-in so
+  // extensions can both \`await $.get(url)\` and chain \`.done()/.fail()\`.
   jQuery.ajax = function (opts) {
     var method = ((opts.method || opts.type || 'GET')).toUpperCase();
-    var headers = Object.assign({ 'Content-Type': 'application/json' }, opts.headers || {});
+    var headers = Object.assign({}, opts.headers || {});
     var body;
-    if (method !== 'GET' && opts.data) {
-      body = typeof opts.data === 'string' ? opts.data : JSON.stringify(opts.data);
+    if (method !== 'GET' && opts.data != null) {
+      if (typeof opts.data === 'string') {
+        body = opts.data;
+      } else {
+        body = JSON.stringify(opts.data);
+        if (!headers['Content-Type']) headers['Content-Type'] = 'application/json';
+      }
     }
-    fetch(opts.url, { method: method, headers: headers, body: body, credentials: 'include' })
+
+    var doneCbs = [];
+    var failCbs = [];
+
+    var promise = fetch(opts.url, { method: method, headers: headers, body: body, credentials: 'include' })
       .then(function (r) {
-        return opts.dataType === 'text' ? r.text() : r.json();
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        var ctype = (r.headers.get('content-type') || '').toLowerCase();
+        if (opts.dataType === 'json' || (!opts.dataType && ctype.indexOf('json') >= 0)) return r.json();
+        return r.text();
       })
-      .then(function (data) { opts.success && opts.success(data); })
-      .catch(function (err) { opts.error && opts.error(null, null, err && err.message); });
-    return { fail: function (fn) { return this; }, done: function (fn) { return this; } };
+      .then(function (data) {
+        try { opts.success && opts.success(data); } catch (_) {}
+        doneCbs.forEach(function (fn) { try { fn(data); } catch (_) {} });
+        return data;
+      }, function (err) {
+        try { opts.error && opts.error(null, null, err && err.message); } catch (_) {}
+        failCbs.forEach(function (fn) { try { fn(null, null, err && err.message); } catch (_) {} });
+        throw err;
+      });
+
+    var jqXHR = {
+      then:    function (onFulfilled, onRejected) { return promise.then(onFulfilled, onRejected); },
+      catch:   function (onRejected) { return promise.catch(onRejected); },
+      done:    function (fn) { doneCbs.push(fn); return jqXHR; },
+      fail:    function (fn) { failCbs.push(fn); return jqXHR; },
+      always:  function (fn) { promise.finally(fn); return jqXHR; },
+    };
+    return jqXHR;
   };
 
   jQuery.get = function (url, data, cb) {
@@ -478,6 +506,10 @@ export const SHIM_CODE: string = /* javascript */ `
 
   jQuery.post = function (url, data, cb) {
     return jQuery.ajax({ url: url, method: 'POST', data: data, success: cb });
+  };
+
+  jQuery.getJSON = function (url, cb) {
+    return jQuery.ajax({ url: url, method: 'GET', dataType: 'json', success: cb });
   };
 
   jQuery.noop   = function () {};
@@ -602,6 +634,9 @@ export const SHIM_CODE: string = /* javascript */ `
         // Async write methods via RPC
         saveMetadataDebounced: function (data) {
           _rpc('saveMetadata', [data]).catch(function () {});
+        },
+        saveSettingsDebounced: function () {
+          _rpc('saveSettings', []).catch(function () {});
         },
         reloadCurrentChat: function () {
           return _rpc('reloadCurrentChat', []);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,6 +28,10 @@ export default defineConfig({
         target: BACKEND,
         changeOrigin: true,
       },
+      '/scripts': {
+        target: BACKEND,
+        changeOrigin: true,
+      },
     },
   },
 })


### PR DESCRIPTION
## Summary
Three pre-existing Tier 3 sandbox bugs that prevented third-party extensions from running at all, plus one chat-menu UX fix.

1. **`/scripts/*` proxy missing** in both `vite.config.ts` (dev) and `nginx.conf` (prod). The path fell through to the SPA `index.html`, so the iframe's `<script src=\"/scripts/extensions/third-party/NAME/index.js\">` loaded 700 bytes of HTML instead of the extension JS. Silent failure.
2. **`$.ajax` / `$.get` returned a stub `{fail, done}` object**, not a thenable. Real extensions do `await \$.get(url)` — currently got `[object Object]`. Replaced with a jqXHR-like thenable supporting await + `.done()`/`.fail()` + content-type auto-detection.
3. **`SillyTavern.getContext().saveSettingsDebounced` was missing.** Lovense and most settings-persisting extensions call it during init → unhandled rejection before any UI setup ran.
4. **Chat hamburger button toggles** (second click closes the menu) instead of only opening.

## Test plan
- [x] `npm run build` green
- [x] SillyTavern-Lovense-Cloud verified locally: script runs end-to-end, `#lovense-panel` lands in iframe DOM (previously never ran).
- [ ] Post-deploy: verify a settings-persisting extension's UI shows in the settings card.

## Known remaining limitation
Floating-panel extensions (Lovense, Live2d) that inject `position: fixed` elements onto `document.body` will now run correctly, but their UI is pinned to the iframe viewport and won't visibly surface in the page. Fixing that is Tier 3 gap C/D (DOM projection), deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)