### PR TITLE
fix(extensions): escape backslash-s in shim regex template literal

### DIFF
--- a/src/extensions/sandbox/extensionShim.ts
+++ b/src/extensions/sandbox/extensionShim.ts
@@ -228,7 +228,7 @@ export const SHIM_CODE: string = /* javascript */ `
       addClass: function (cls) {
         els.forEach(function (e) {
           if (!e) return;
-          cls.split(/\s+/).forEach(function (c) { if (c) e.classList.add(c); });
+          cls.split(/\\s+/).forEach(function (c) { if (c) e.classList.add(c); });
         });
         return jq;
       },
@@ -236,7 +236,7 @@ export const SHIM_CODE: string = /* javascript */ `
       removeClass: function (cls) {
         els.forEach(function (e) {
           if (!e) return;
-          cls.split(/\s+/).forEach(function (c) { if (c) e.classList.remove(c); });
+          cls.split(/\\s+/).forEach(function (c) { if (c) e.classList.remove(c); });
         });
         return jq;
       },
@@ -244,7 +244,7 @@ export const SHIM_CODE: string = /* javascript */ `
       toggleClass: function (cls, force) {
         els.forEach(function (e) {
           if (!e) return;
-          cls.split(/\s+/).forEach(function (c) {
+          cls.split(/\\s+/).forEach(function (c) {
             if (!c) return;
             if (force === undefined) e.classList.toggle(c);
             else if (force) e.classList.add(c);
@@ -288,7 +288,7 @@ export const SHIM_CODE: string = /* javascript */ `
         var delegate = (typeof selectorOrFn === 'string') ? selectorOrFn : null;
         els.forEach(function (e) {
           if (!e) return;
-          events.split(/\s+/).forEach(function (ev) {
+          events.split(/\\s+/).forEach(function (ev) {
             if (!ev) return;
             e.addEventListener(ev, delegate
               ? function (evObj) {


### PR DESCRIPTION
Template literal unescaped `\s` to `s`, making the runtime regex `/s+/` (matches literal 's') instead of `/\s+/` (whitespace). Lovense's `removeClass('lovense-dock-left lovense-dock-right')` then called `classList.remove('e-dock-left loven')`, throwing InvalidCharacterError and aborting the whole loadSettings flow.

Verified locally: Lovense panel now renders with correct classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)