### PR TITLE
feat(extensions): message action + chat input slot APIs

### DIFF
--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -1,7 +1,8 @@
 import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
-import { Send, Mic, Paperclip, Square, X, Image, Menu } from 'lucide-react';
+import { Send, Mic, Paperclip, Square, X, Image, Menu, Puzzle } from 'lucide-react';
 import { CommandAutocomplete } from './CommandAutocomplete';
 import { Button } from '../ui';
+import { useSlotItems, invokeSlotItem } from '../../extensions/sandbox/sandboxSlotRegistry';
 import {
   compressImageFiles,
   ACCEPTED_IMAGE_MIMES,
@@ -66,6 +67,9 @@ export function ChatInput({
   const [showAutocomplete, setShowAutocomplete] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Sandbox extension-contributed chat-input buttons
+  const inputExtras = useSlotItems('chatInputExtras');
 
   // Phase 8.7: derive autocomplete prefix from message
   const autocompletePrefix = useMemo<string | null>(() => {
@@ -477,6 +481,28 @@ export function ChatInput({
         >
           <Paperclip size={20} />
         </Button>
+
+        {/* Extension-contributed chat-input buttons */}
+        {inputExtras.map((item) => (
+          <Button
+            key={`${item.frameId}:${item.itemId}`}
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="p-2 flex-shrink-0"
+            aria-label={item.label}
+            title={item.tooltip ?? item.label}
+            onClick={() =>
+              invokeSlotItem(item.frameId, item.itemId, {
+                text: message,
+                hasImages: images.length > 0,
+              })
+            }
+            disabled={disabled || isListening}
+          >
+            <Puzzle size={20} />
+          </Button>
+        ))}
 
         {/* Image Generation Button */}
         {onImageGen && (

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -14,6 +14,7 @@ import { useRegexScriptStore } from '../../stores/regexScriptStore';
 import { applyRegexScripts, getActiveScripts } from '../../utils/regexScripts';
 import { useTranslateStore } from '../../stores/translateStore';
 import { useExtensionStore } from '../../stores/extensionStore';
+import { useSlotItems, invokeSlotItem } from '../../extensions/sandbox/sandboxSlotRegistry';
 
 interface ChatMessageProps {
   /** Unique message id — used as TTS tracking key. */
@@ -121,6 +122,27 @@ export function ChatMessage({
   // Phase 7.1: Extension gates
   const ttsEnabled = useExtensionStore((s) => s.enabled.tts);
   const translateEnabled = useExtensionStore((s) => s.enabled.translate);
+
+  // Sandbox extension-contributed message action buttons
+  const messageActionSlotItems = useSlotItems('messageActions');
+  const messageActionExtras = useMemo(
+    () =>
+      messageActionSlotItems.map((item) => ({
+        key: `${item.frameId}:${item.itemId}`,
+        label: item.label,
+        tooltip: item.tooltip,
+        onClick: () => {
+          invokeSlotItem(item.frameId, item.itemId, {
+            messageId,
+            name,
+            isUser,
+            content,
+            swipeId,
+          });
+        },
+      })),
+    [messageActionSlotItems, messageId, name, isUser, content, swipeId],
+  );
 
   // Phase 6.3: TTS — only wired for non-user, non-system messages.
   const { isSupported: ttsSupported, isSpeaking, speak, stop } = useSpeechSynthesis();
@@ -240,22 +262,26 @@ export function ChatMessage({
         <BottomSheet isOpen={showMenu} onClose={() => setShowMenu(false)} title="Message Actions">
           <div className="space-y-1">
             {[
-              { label: 'Edit', onClick: handleStartEdit },
-              { label: 'Copy', onClick: handleCopy },
-              ...(onCheckpoint ? [{ label: 'Checkpoint', onClick: onCheckpoint }] : []),
-              ...(!isUser && onRegenerate ? [{ label: 'Regenerate', onClick: onRegenerate }] : []),
-              { label: 'Delete', onClick: () => onDelete?.(), danger: true },
-            ].map((action) => (
-              <button
-                key={action.label}
-                onClick={() => { action.onClick(); setShowMenu(false); }}
-                className={`w-full text-left px-3 py-3 rounded-lg text-sm transition-colors hover:bg-[var(--color-bg-tertiary)] ${
-                  action.danger ? 'text-red-400' : 'text-[var(--color-text-primary)]'
-                }`}
-              >
-                {action.label}
-              </button>
-            ))}
+              { key: 'edit',   label: 'Edit',   onClick: handleStartEdit },
+              { key: 'copy',   label: 'Copy',   onClick: handleCopy },
+              ...(onCheckpoint ? [{ key: 'checkpoint', label: 'Checkpoint', onClick: onCheckpoint }] : []),
+              ...(!isUser && onRegenerate ? [{ key: 'regen', label: 'Regenerate', onClick: onRegenerate }] : []),
+              ...messageActionExtras.map((e) => ({ key: `ext_${e.key}`, label: e.label, onClick: e.onClick })),
+              { key: 'delete', label: 'Delete', onClick: () => onDelete?.(), danger: true },
+            ].map((action) => {
+              const isDanger = 'danger' in action && action.danger;
+              return (
+                <button
+                  key={action.key}
+                  onClick={() => { action.onClick(); setShowMenu(false); }}
+                  className={`w-full text-left px-3 py-3 rounded-lg text-sm transition-colors hover:bg-[var(--color-bg-tertiary)] ${
+                    isDanger ? 'text-red-400' : 'text-[var(--color-text-primary)]'
+                  }`}
+                >
+                  {action.label}
+                </button>
+              );
+            })}
           </div>
         </BottomSheet>
       ) : (
@@ -268,6 +294,7 @@ export function ChatMessage({
           onRegenerate={onRegenerate}
           showRegenerate={!isUser && !!onRegenerate}
           onCheckpoint={onCheckpoint}
+          extras={messageActionExtras}
           anchorRight={layoutMode === 'bubbles' && isUser}
         />
       )}

--- a/src/components/chat/MessageActionMenu.tsx
+++ b/src/components/chat/MessageActionMenu.tsx
@@ -1,5 +1,12 @@
 import { useEffect, useRef } from 'react';
-import { Pencil, Copy, Trash2, RefreshCw, GitFork } from 'lucide-react';
+import { Pencil, Copy, Trash2, RefreshCw, GitFork, Puzzle } from 'lucide-react';
+
+export interface MessageActionExtra {
+  key: string;
+  label: string;
+  tooltip?: string;
+  onClick: () => void;
+}
 
 interface MessageActionMenuProps {
   isOpen: boolean;
@@ -11,6 +18,8 @@ interface MessageActionMenuProps {
   showRegenerate?: boolean;
   /** Phase 8.6: create a checkpoint at this message. */
   onCheckpoint?: () => void;
+  /** Extension-contributed entries rendered before Delete. */
+  extras?: MessageActionExtra[];
   anchorRight?: boolean;
 }
 
@@ -23,6 +32,7 @@ export function MessageActionMenu({
   onRegenerate,
   showRegenerate,
   onCheckpoint,
+  extras,
   anchorRight,
 }: MessageActionMenuProps) {
   const menuRef = useRef<HTMLDivElement>(null);
@@ -52,15 +62,22 @@ export function MessageActionMenu({
   if (!isOpen) return null;
 
   const actions = [
-    { icon: Pencil, label: 'Edit', onClick: onEdit },
-    { icon: Copy, label: 'Copy', onClick: onCopy },
+    { key: 'edit',     icon: Pencil,    label: 'Edit',       onClick: onEdit },
+    { key: 'copy',     icon: Copy,      label: 'Copy',       onClick: onCopy },
     ...(onCheckpoint
-      ? [{ icon: GitFork, label: 'Checkpoint', onClick: onCheckpoint }]
+      ? [{ key: 'checkpoint', icon: GitFork, label: 'Checkpoint', onClick: onCheckpoint }]
       : []),
     ...(showRegenerate && onRegenerate
-      ? [{ icon: RefreshCw, label: 'Regenerate', onClick: onRegenerate }]
+      ? [{ key: 'regen', icon: RefreshCw, label: 'Regenerate', onClick: onRegenerate }]
       : []),
-    { icon: Trash2, label: 'Delete', onClick: onDelete, danger: true },
+    ...(extras ?? []).map((e) => ({
+      key: `ext_${e.key}`,
+      icon: Puzzle,
+      label: e.label,
+      onClick: e.onClick,
+      tooltip: e.tooltip,
+    })),
+    { key: 'delete', icon: Trash2, label: 'Delete', onClick: onDelete, danger: true },
   ];
 
   return (
@@ -76,17 +93,20 @@ export function MessageActionMenu({
     >
       {actions.map((action) => {
         const Icon = action.icon;
+        const isDanger = 'danger' in action && action.danger;
+        const tooltip = 'tooltip' in action ? action.tooltip : undefined;
         return (
           <button
-            key={action.label}
+            key={action.key}
             onClick={() => {
               action.onClick();
               onClose();
             }}
+            title={tooltip}
             className={`
               w-full flex items-center gap-3 px-3 py-2 text-sm text-left
               hover:bg-[var(--color-bg-tertiary)] transition-colors
-              ${action.danger ? 'text-red-400' : 'text-[var(--color-text-primary)]'}
+              ${isDanger ? 'text-red-400' : 'text-[var(--color-text-primary)]'}
             `}
           >
             <Icon size={14} />

--- a/src/extensions/sandbox/ExtensionFrame.tsx
+++ b/src/extensions/sandbox/ExtensionFrame.tsx
@@ -18,9 +18,16 @@
  *   appear and the iframe blends into the settings card.
  */
 
-import { useEffect, useRef, useCallback, useState } from 'react';
+import { useEffect, useMemo, useRef, useCallback, useState } from 'react';
 import { SHIM_CODE } from './extensionShim';
 import { subscribeToSandboxEvents } from './sandboxEventBus';
+import {
+  SLOT_KINDS,
+  useSandboxSlotStore,
+  setFrameInvoker,
+  clearFrameInvoker,
+  type SlotKind,
+} from './sandboxSlotRegistry';
 import { useCharacterStore } from '../../stores/characterStore';
 import { useChatStore } from '../../stores/chatStore';
 import { usePersonaStore } from '../../stores/personaStore';
@@ -32,6 +39,8 @@ import {
   type PopupType,
   type PopupOptions,
 } from '../../stores/extensionPopupStore';
+
+let _frameSeq = 0;
 
 // ---------------------------------------------------------------------------
 // Types
@@ -49,6 +58,15 @@ export interface ExtensionFrameProps {
   className?: string;
   /** Called with true the first time the iframe reports non-zero content. */
   onHasContent?: (hasContent: boolean) => void;
+  /**
+   * Whether this frame is the authoritative source for slot items
+   * (message-action buttons, chat-input extras). Only the global host should
+   * pass `true`; the settings-page preview frame leaves this false so slot
+   * registrations from its duplicate iframe are ignored — otherwise closing
+   * the settings page would yank a slot item that's also wired into the
+   * global frame.
+   */
+  allowSlots?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -140,11 +158,16 @@ export function ExtensionFrame({
   scriptUrl,
   className,
   onHasContent,
+  allowSlots = false,
 }: ExtensionFrameProps) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const [height, setHeight] = useState(0);
   const readyRef = useRef(false);
   const hasContentReportedRef = useRef(false);
+  const frameId = useMemo(
+    () => `frame_${extensionName.replace(/[^a-zA-Z0-9_]/g, '_')}_${++_frameSeq}`,
+    [extensionName],
+  );
 
   // Stable ref so the event bus subscription (useEffect with [] deps) always
   // calls the current version of pushContext without needing re-subscription.
@@ -231,13 +254,40 @@ export function ExtensionFrame({
           handleRpc(msg as { id: string; method: string; args: unknown[] });
           break;
 
+        case 'ST_REGISTER_SLOT': {
+          if (!allowSlots) break;
+          const slot = String(msg.slot ?? '') as SlotKind;
+          if (!SLOT_KINDS.includes(slot)) break;
+          const item = msg.item as
+            | { id?: string; label?: string; icon?: string; tooltip?: string }
+            | undefined;
+          if (!item || typeof item.id !== 'string') break;
+          useSandboxSlotStore.getState().register(frameId, extensionName, slot, {
+            id: item.id,
+            label: String(item.label ?? item.id),
+            icon: item.icon,
+            tooltip: item.tooltip,
+          });
+          break;
+        }
+
+        case 'ST_UNREGISTER_SLOT': {
+          if (!allowSlots) break;
+          const slot = String(msg.slot ?? '') as SlotKind;
+          if (!SLOT_KINDS.includes(slot)) break;
+          const itemId = typeof msg.itemId === 'string' ? msg.itemId : null;
+          if (!itemId) break;
+          useSandboxSlotStore.getState().unregister(frameId, slot, itemId);
+          break;
+        }
+
         // Extension emitted an event — re-broadcast to the bus if desired.
         // For now, just ignore (extensions can emit to themselves).
         case 'ST_EVENT_EMIT':
           break;
       }
     },
-    [onHasContent], // extensionName captured via closure, but doesn't change
+    [onHasContent, allowSlots, frameId, extensionName],
   );
 
   // ── Wire up postMessage listener ──────────────────────────────────────────
@@ -258,6 +308,21 @@ export function ExtensionFrame({
       pushContextRef.current();
     });
   }, []);
+
+  // ── Slot invoker: route slot clicks back to this iframe ──────────────────
+  useEffect(() => {
+    if (!allowSlots) return;
+    setFrameInvoker(frameId, (itemId, payload) => {
+      iframeRef.current?.contentWindow?.postMessage(
+        { type: 'ST_SLOT_INVOKE', itemId, payload },
+        '*',
+      );
+    });
+    return () => {
+      clearFrameInvoker(frameId);
+      useSandboxSlotStore.getState().unregisterFrame(frameId);
+    };
+  }, [allowSlots, frameId]);
 
   // ── Build srcdoc once ─────────────────────────────────────────────────────
   // We use a ref so the srcdoc doesn't change on re-renders (which would cause

--- a/src/extensions/sandbox/GlobalExtensionHost.tsx
+++ b/src/extensions/sandbox/GlobalExtensionHost.tsx
@@ -47,6 +47,7 @@ export function GlobalExtensionHost() {
           key={ext.name}
           extensionName={ext.name}
           scriptUrl={extensionScriptUrl(ext.name)}
+          allowSlots
         />
       ))}
     </div>

--- a/src/extensions/sandbox/extensionShim.ts
+++ b/src/extensions/sandbox/extensionShim.ts
@@ -42,6 +42,7 @@ export const SHIM_CODE: string = /* javascript */ `
 
   // ── RPC infrastructure ───────────────────────────────────────────────────
   var _pending = Object.create(null); // id → { resolve, reject }
+  var _slotCallbacks = Object.create(null); // itemId → fn
   var _seq = 0;
 
   function _post(msg) {
@@ -111,6 +112,13 @@ export const SHIM_CODE: string = /* javascript */ `
           delete _pending[msg.id];
           if (msg.error) p.reject(new Error(msg.error));
           else p.resolve(msg.result);
+        }
+        break;
+
+      case 'ST_SLOT_INVOKE':
+        var slotCb = _slotCallbacks[msg.itemId];
+        if (slotCb) {
+          try { slotCb(msg.payload); } catch (_) {}
         }
         break;
     }
@@ -605,6 +613,32 @@ export const SHIM_CODE: string = /* javascript */ `
   // ── callGenericPopup (newer ST API) ───────────────────────────────────────
   window.callGenericPopup = window.callPopup;
 
+  // ── registerSlotItem ──────────────────────────────────────────────────────
+  // slot: 'messageActions' | 'chatInputExtras'
+  // def:  { id, label, icon?, tooltip?, onClick }
+  // Returns an unregister function.
+  function _registerSlotItem(slot, def) {
+    if (!def || typeof def.onClick !== 'function') {
+      throw new Error('registerSlotItem: def.onClick must be a function');
+    }
+    var itemId = String(def.id || ('slot_' + (++_seq)));
+    _slotCallbacks[itemId] = def.onClick;
+    _post({
+      type: 'ST_REGISTER_SLOT',
+      slot: String(slot),
+      item: {
+        id: itemId,
+        label: String(def.label != null ? def.label : itemId),
+        icon: typeof def.icon === 'string' ? def.icon : undefined,
+        tooltip: typeof def.tooltip === 'string' ? def.tooltip : undefined,
+      },
+    });
+    return function unregister() {
+      delete _slotCallbacks[itemId];
+      _post({ type: 'ST_UNREGISTER_SLOT', slot: String(slot), itemId: itemId });
+    };
+  }
+
   // ── extension_settings ────────────────────────────────────────────────────
   window.extension_settings = _ctx.extensionSettings;
 
@@ -654,6 +688,7 @@ export const SHIM_CODE: string = /* javascript */ `
         },
       };
     },
+    registerSlotItem: _registerSlotItem,
   };
 
   // ── Legacy flat globals (some old extensions access these directly) ────────

--- a/src/extensions/sandbox/index.ts
+++ b/src/extensions/sandbox/index.ts
@@ -4,3 +4,11 @@ export { fireSandboxLifecycleEvent, subscribeToSandboxEvents } from './sandboxEv
 export { SHIM_CODE } from './extensionShim';
 export { GlobalExtensionHost } from './GlobalExtensionHost';
 export { ExtensionPopupRoot } from './ExtensionPopupRoot';
+export {
+  SLOT_KINDS,
+  useSandboxSlotStore,
+  useSlotItems,
+  invokeSlotItem,
+  type SlotKind,
+  type SlotItem,
+} from './sandboxSlotRegistry';

--- a/src/extensions/sandbox/sandboxSlotRegistry.ts
+++ b/src/extensions/sandbox/sandboxSlotRegistry.ts
@@ -1,0 +1,115 @@
+/**
+ * Sandbox Slot Registry
+ *
+ * Tracks UI slot items contributed by extensions (message action buttons,
+ * chat input extras). Each item is owned by one extension frame; unmounting
+ * the frame removes its items.
+ *
+ * Flow:
+ *   1. Extension calls SillyTavern.registerSlotItem('messageActions', {...}).
+ *   2. Shim posts ST_REGISTER_SLOT → ExtensionFrame.register().
+ *   3. React consumers read items via useSlotItems(slot).
+ *   4. User taps a rendered slot button → invoke(frameId, itemId, payload).
+ *   5. Registry calls the iframe-scoped invoker that posts ST_SLOT_INVOKE
+ *      back into the originating iframe.
+ */
+
+import { create } from 'zustand';
+
+export const SLOT_KINDS = ['messageActions', 'chatInputExtras'] as const;
+export type SlotKind = (typeof SLOT_KINDS)[number];
+
+export interface SlotItem {
+  frameId: string;
+  extensionName: string;
+  itemId: string;
+  label: string;
+  icon?: string;
+  tooltip?: string;
+}
+
+interface SlotRegistryState {
+  messageActions: SlotItem[];
+  chatInputExtras: SlotItem[];
+  register: (
+    frameId: string,
+    extensionName: string,
+    slot: SlotKind,
+    item: { id: string; label: string; icon?: string; tooltip?: string },
+  ) => void;
+  unregister: (frameId: string, slot: SlotKind, itemId: string) => void;
+  unregisterFrame: (frameId: string) => void;
+}
+
+export const useSandboxSlotStore = create<SlotRegistryState>((set) => ({
+  messageActions: [],
+  chatInputExtras: [],
+
+  register(frameId, extensionName, slot, item) {
+    set((s) => {
+      const existing = s[slot];
+      // Upsert by (frameId, itemId) so re-registrations replace in place.
+      const filtered = existing.filter(
+        (i) => !(i.frameId === frameId && i.itemId === item.id),
+      );
+      const next: SlotItem = {
+        frameId,
+        extensionName,
+        itemId: item.id,
+        label: String(item.label ?? item.id),
+        icon: typeof item.icon === 'string' ? item.icon : undefined,
+        tooltip: typeof item.tooltip === 'string' ? item.tooltip : undefined,
+      };
+      return { [slot]: [...filtered, next] } as Partial<SlotRegistryState>;
+    });
+  },
+
+  unregister(frameId, slot, itemId) {
+    set((s) => ({
+      [slot]: s[slot].filter(
+        (i) => !(i.frameId === frameId && i.itemId === itemId),
+      ),
+    }) as Partial<SlotRegistryState>);
+  },
+
+  unregisterFrame(frameId) {
+    set((s) => ({
+      messageActions: s.messageActions.filter((i) => i.frameId !== frameId),
+      chatInputExtras: s.chatInputExtras.filter((i) => i.frameId !== frameId),
+    }));
+  },
+}));
+
+// ── Invoker registry (module-level; not React state) ────────────────────────
+// Maps frameId → function that posts ST_SLOT_INVOKE into that iframe.
+
+type Invoker = (itemId: string, payload: unknown) => void;
+const frameInvokers = new Map<string, Invoker>();
+
+export function setFrameInvoker(frameId: string, invoker: Invoker): void {
+  frameInvokers.set(frameId, invoker);
+}
+
+export function clearFrameInvoker(frameId: string): void {
+  frameInvokers.delete(frameId);
+}
+
+export function invokeSlotItem(
+  frameId: string,
+  itemId: string,
+  payload: unknown,
+): void {
+  const fn = frameInvokers.get(frameId);
+  if (!fn) return; // frame unmounted between click and invoke — drop silently
+  try {
+    fn(itemId, payload);
+  } catch {
+    // ignore
+  }
+}
+
+// ── Hook ────────────────────────────────────────────────────────────────────
+
+export function useSlotItems(slot: SlotKind): SlotItem[] {
+  return useSandboxSlotStore((s) => s[slot]);
+}


### PR DESCRIPTION
## Summary
- Adds `SillyTavern.registerSlotItem(slot, {...})` so extensions can contribute buttons to two host-rendered slots: `messageActions` (per-message menu/sheet) and `chatInputExtras` (chat input row).
- Items are keyed by `(frameId, itemId)`, upserted on re-registration, and cleaned up on frame unmount.
- Only the global (always-alive) frame accepts slot registrations, so closing the settings page doesn't yank contributed items.

Wraps up Tier 3 — no extension work remaining on the roadmap.

## Test plan
- [x] `tsc -b && vite build` green
- [x] Browser smoke: registered a slot item → button rendered in chat input, click invoked callback with `{ text, hasImages }` payload, `unregisterFrame` cleaned store + DOM
- [ ] Post-deploy smoke on droplet

🤖 Generated with [Claude Code](https://claude.com/claude-code)