### PR TITLE
fix(characters): alt greetings, import UX, list reactivity

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -69,6 +69,35 @@ export async function apiRequestText(
   return response.text();
 }
 
+/**
+ * Append character-create/edit fields to a multipart FormData body.
+ *
+ * Arrays are appended as repeated same-key entries (which Express parses
+ * back into an array), NOT as a JSON-stringified blob — the backend's
+ * getAlternateGreetings() treats a string as a single-element array, so
+ * stringifying would collapse N alternates into one giant JSON string.
+ */
+function appendCharacterFields(
+  formData: FormData,
+  data: object
+): void {
+  Object.entries(data as Record<string, unknown>).forEach(([key, value]) => {
+    if (value === undefined || value === null) return;
+    if (Array.isArray(value)) {
+      // Skip entirely when empty — form-data can't express an empty array
+      // and the backend treats a missing field as [].
+      if (value.length === 0) return;
+      for (const item of value) {
+        formData.append(key, typeof item === 'string' ? item : JSON.stringify(item));
+      }
+    } else if (typeof value === 'number' || typeof value === 'boolean') {
+      formData.append(key, String(value));
+    } else {
+      formData.append(key, String(value));
+    }
+  });
+}
+
 export interface UserInfo {
   handle: string;
   name: string;
@@ -341,28 +370,13 @@ export const api = {
     // Returns avatar filename like "CharacterName.png" as plain text
     const token = await getCsrfToken();
 
-    // Serialize arrays/numbers properly for backend
-    const serializedData: Record<string, string> = {};
-    Object.entries(data).forEach(([key, value]) => {
-      if (value === undefined) return;
-      if (Array.isArray(value)) {
-        serializedData[key] = JSON.stringify(value);
-      } else if (typeof value === 'number' || typeof value === 'boolean') {
-        serializedData[key] = String(value);
-      } else {
-        serializedData[key] = String(value);
-      }
-    });
-
     let response: Response;
 
     if (avatarFile) {
       // Use multipart form data when uploading an image
       const formData = new FormData();
       formData.append('avatar', avatarFile);
-      Object.entries(serializedData).forEach(([key, value]) => {
-        formData.append(key, value);
-      });
+      appendCharacterFields(formData, data);
 
       response = await fetch('/api/characters/create', {
         method: 'POST',
@@ -395,7 +409,9 @@ export const api = {
   },
 
   async deleteCharacter(avatarUrl: string, deleteChats: boolean = true): Promise<void> {
-    await apiRequest('/api/characters/delete', {
+    // Server responds with a plain-text body (e.g. "OK"), not JSON.
+    // Use apiRequestText so a non-JSON success body isn't treated as a failure.
+    await apiRequestText('/api/characters/delete', {
       method: 'POST',
       body: JSON.stringify({ avatar_url: avatarUrl, delete_chats: deleteChats }),
     });
@@ -405,28 +421,13 @@ export const api = {
     // Backend returns plain text "OK", not JSON
     const token = await getCsrfToken();
 
-    // Serialize arrays/numbers properly for backend
-    const serializedData: Record<string, string> = {};
-    Object.entries(data).forEach(([key, value]) => {
-      if (value === undefined) return;
-      if (Array.isArray(value)) {
-        serializedData[key] = JSON.stringify(value);
-      } else if (typeof value === 'number' || typeof value === 'boolean') {
-        serializedData[key] = String(value);
-      } else {
-        serializedData[key] = String(value);
-      }
-    });
-
     let response: Response;
 
     if (avatarFile) {
       // Use multipart form data when uploading an image
       const formData = new FormData();
       formData.append('avatar', avatarFile);
-      Object.entries(serializedData).forEach(([key, value]) => {
-        formData.append(key, value);
-      });
+      appendCharacterFields(formData, data);
 
       response = await fetch('/api/characters/edit', {
         method: 'POST',

--- a/src/components/character/CharacterImport.tsx
+++ b/src/components/character/CharacterImport.tsx
@@ -3,6 +3,7 @@ import { Upload, FileImage, FileJson, X, BookOpen } from 'lucide-react';
 import { useCharacterStore } from '../../stores/characterStore';
 import { useWorldInfoStore } from '../../stores/worldInfoStore';
 import { Modal, Button, Input, TextArea, ImageUpload, TagInput } from '../ui';
+import { AlternateGreetingsEditor } from './AlternateGreetingsEditor';
 import type { CharacterInfo } from '../../api/client';
 import type { CharacterBookV2 } from '../../utils/characterCard';
 
@@ -54,6 +55,7 @@ export function CharacterImport({ isOpen, onClose, onImported }: CharacterImport
     creator: '',
     tags: [],
   });
+  const [alternateGreetings, setAlternateGreetings] = useState<string[]>([]);
 
   const processFiles = async (files: File[]) => {
     const result = await importCharacter(files);
@@ -77,6 +79,11 @@ export function CharacterImport({ isOpen, onClose, onImported }: CharacterImport
         creator: result.data.data?.creator || '',
         tags: result.data.tags || result.data.data?.tags || [],
       });
+      setAlternateGreetings(
+        result.data.alternate_greetings ||
+          result.data.data?.alternate_greetings ||
+          []
+      );
     } else if (files.length === 1) {
       // Single file that failed character parsing — check if it's a standalone lorebook JSON
       const file = files[0];
@@ -146,6 +153,12 @@ export function CharacterImport({ isOpen, onClose, onImported }: CharacterImport
       return;
     }
 
+    const altGreetings = alternateGreetings.filter(
+      (g) => typeof g === 'string' && g.trim()
+    );
+    const depthPrompt = importedData?.data?.extensions?.depth_prompt;
+    const talkativenessRaw = importedData?.data?.extensions?.talkativeness;
+
     const avatarUrl = await createCharacter(
       {
         ch_name: formData.name.trim(),
@@ -157,6 +170,23 @@ export function CharacterImport({ isOpen, onClose, onImported }: CharacterImport
         creator_notes: formData.creatorNotes.trim(),
         creator: formData.creator.trim(),
         tags: formData.tags.join(', '),
+        alternate_greetings: altGreetings.length > 0 ? altGreetings : undefined,
+        system_prompt:
+          importedData?.system_prompt || importedData?.data?.system_prompt || undefined,
+        post_history_instructions:
+          importedData?.post_history_instructions ||
+          importedData?.data?.post_history_instructions ||
+          undefined,
+        character_version:
+          importedData?.character_version ||
+          importedData?.data?.character_version ||
+          undefined,
+        depth_prompt_prompt: depthPrompt?.prompt?.trim() || undefined,
+        depth_prompt_depth: depthPrompt?.prompt?.trim() ? depthPrompt.depth ?? 4 : undefined,
+        depth_prompt_role: depthPrompt?.prompt?.trim()
+          ? (depthPrompt.role as string | undefined) || 'system'
+          : undefined,
+        talkativeness: typeof talkativenessRaw === 'string' ? talkativenessRaw : undefined,
       },
       avatarFile || undefined
     );
@@ -206,6 +236,7 @@ export function CharacterImport({ isOpen, onClose, onImported }: CharacterImport
       creator: '',
       tags: [],
     });
+    setAlternateGreetings([]);
     clearError();
     onClose();
   };
@@ -340,6 +371,7 @@ export function CharacterImport({ isOpen, onClose, onImported }: CharacterImport
                   URL.revokeObjectURL(avatarPreview);
                 }
                 setAvatarPreview(null);
+                setAlternateGreetings([]);
               }}
               className="p-1 hover:bg-green-500/20 rounded"
             >
@@ -405,6 +437,13 @@ export function CharacterImport({ isOpen, onClose, onImported }: CharacterImport
             value={formData.firstMessage}
             onChange={handleChange('firstMessage')}
             rows={4}
+          />
+
+          {/* Alternate Greetings — additional opening messages the user can
+              swipe between. Pre-populated from the imported card. */}
+          <AlternateGreetingsEditor
+            greetings={alternateGreetings}
+            onChange={setAlternateGreetings}
           />
 
           {/* Scenario */}

--- a/src/stores/characterStore.ts
+++ b/src/stores/characterStore.ts
@@ -214,8 +214,24 @@ export const useCharacterStore = create<CharacterState>((set, get) => ({
       // Ownership is recorded server-side when a character is flipped to
       // global. Newly-created characters start personal with no metadata
       // entry, which is the correct default.
-      // Refresh the character list (also refetches ownership).
-      await get().fetchCharacters();
+
+      // Fetch the new character directly by its avatar url and push it into
+      // the local list so the UI updates instantly, regardless of any
+      // server-side listing cache. No background list refetch: the list
+      // endpoint can briefly omit the just-created character, which would
+      // race the direct push and make the new character vanish until the
+      // next pull-to-refresh. Fall back to a full refetch if the direct get
+      // itself fails.
+      try {
+        const newChar = await api.getCharacter(avatarUrl);
+        const { characters } = get();
+        if (!characters.some((c) => c.avatar === avatarUrl)) {
+          set({ characters: [...characters, newChar] });
+        }
+      } catch {
+        await get().fetchCharacters();
+      }
+
       set({ isCreating: false });
       return avatarUrl;
     } catch (error) {
@@ -251,14 +267,26 @@ export const useCharacterStore = create<CharacterState>((set, get) => ({
   },
 
   deleteCharacter: async (avatar: string) => {
-    set({ isLoading: true, error: null });
+    const {
+      characters: previousCharacters,
+      selectedCharacter,
+      favorites,
+      linkedBookIdsByAvatar,
+    } = get();
+
+    // Optimistic update: remove from the local list immediately so the UI
+    // reflects the deletion without waiting for the server roundtrip. If the
+    // server call fails we roll back below.
+    set({
+      characters: previousCharacters.filter((c) => c.avatar !== avatar),
+      selectedCharacter:
+        selectedCharacter?.avatar === avatar ? null : selectedCharacter,
+      error: null,
+    });
+
     try {
       await api.deleteCharacter(avatar);
-      // Clear selection if deleting the selected character
-      const { selectedCharacter, favorites, linkedBookIdsByAvatar } = get();
-      if (selectedCharacter?.avatar === avatar) {
-        set({ selectedCharacter: null });
-      }
+
       // Also remove from favorites
       if (favorites.has(avatar)) {
         const newFavorites = new Set(favorites);
@@ -277,12 +305,17 @@ export const useCharacterStore = create<CharacterState>((set, get) => ({
         saveLinkedBooks(nextLinks);
         set({ linkedBookIdsByAvatar: nextLinks });
       }
-      // Refresh the character list
-      await get().fetchCharacters();
+      // No post-delete refetch: the server's character list endpoint can
+      // briefly still include the just-deleted character (filesystem/cache
+      // lag). A background refetch here would race the optimistic removal
+      // and make the character pop back into the list until the next
+      // pull-to-refresh. The optimistic update is authoritative.
       return true;
     } catch (error) {
+      // Roll back the optimistic removal on server failure
       set({
-        isLoading: false,
+        characters: previousCharacters,
+        selectedCharacter,
         error: error instanceof Error ? error.message : 'Failed to delete character',
       });
       return false;

--- a/src/utils/characterCard.ts
+++ b/src/utils/characterCard.ts
@@ -345,7 +345,12 @@ export async function extractCharacterFromPNG(
         const base64String = String.fromCharCode(...textData);
 
         try {
-          const jsonString = atob(base64String);
+          // atob() returns a binary string; decode as UTF-8 so non-ASCII
+          // characters (em-dashes, smart quotes, emoji) survive import.
+          const binary = atob(base64String);
+          const bytes = new Uint8Array(binary.length);
+          for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+          const jsonString = new TextDecoder('utf-8').decode(bytes);
           const charData = JSON.parse(jsonString);
 
           // Check if it's V2/V3 format


### PR DESCRIPTION
## Summary

- Fix UTF-8 mojibake when importing Character Card PNGs (em-dashes, smart quotes)
- Show alternate greetings editor on the import screen so users can review/edit them before confirming
- Fix array serialization in multipart form-data so N alternates are stored as N entries, not one JSON blob
- Fix delete silently failing because \`api.deleteCharacter\` tried to \`JSON.parse\` the plain-text \`"OK"\` response
- Make character list updates optimistic on create/delete so the sidebar repaints instantly without a refresh

## Test plan
- [x] Import a PNG card with alternate greetings → editor shows N greetings, preserved after import
- [x] Start chat with imported character → all N+1 greetings appear as swipes with correct text (not JSON dump)
- [x] Delete a character → disappears from sidebar and Character Management immediately
- [x] \`npm run build\` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)