### PR TITLE
fix(permissions): honor character:edit and character:set_global for contributors

### DIFF
--- a/src/components/settings/CharacterManagementPage.tsx
+++ b/src/components/settings/CharacterManagementPage.tsx
@@ -13,10 +13,10 @@ import {
 } from 'lucide-react';
 import { useCharacterStore } from '../../stores/characterStore';
 import { useCharacterOwnershipStore, type CharacterOwnershipState } from '../../stores/characterOwnershipStore';
-import type { UserRole } from '../../types';
+import type { User, UserRole } from '../../types';
 import { useAuthStore } from '../../stores/authStore';
 import { useSettingsPanelStore } from '../../stores/settingsPanelStore';
-import { can } from '../../utils/permissions';
+import { can, hasPermission } from '../../utils/permissions';
 import { api, type CharacterInfo } from '../../api/client';
 import { Button, ConfirmDialog } from '../ui';
 import { CharacterEdit } from '../character/CharacterEdit';
@@ -221,6 +221,7 @@ export function CharacterManagementPage() {
               <CharacterRow
                 key={char.avatar}
                 character={char}
+                currentUser={currentUser}
                 userHandle={userHandle}
                 userRole={userRole}
                 ownershipStore={ownershipStore}
@@ -280,6 +281,7 @@ export function CharacterManagementPage() {
 
 interface CharacterRowProps {
   character: CharacterInfo;
+  currentUser: User | null;
   userHandle: string;
   userRole: UserRole | undefined;
   ownershipStore: CharacterOwnershipState;
@@ -294,6 +296,7 @@ interface CharacterRowProps {
 
 function CharacterRow({
   character,
+  currentUser,
   userHandle,
   userRole,
   ownershipStore,
@@ -310,9 +313,12 @@ function CharacterRow({
   const isOwned = ownershipStore.isOwnedBy(avatar, userHandle);
   const ownerHandle = ownershipStore.getOwner(avatar);
 
-  const canEdit = ownershipStore.canEditCharacter(avatar, userHandle, userRole);
+  const canEdit =
+    hasPermission(currentUser, 'character:edit') ||
+    ownershipStore.canEditCharacter(avatar, userHandle, userRole);
   const canDelete = ownershipStore.canDeleteCharacter(avatar, userHandle, userRole);
   const canDuplicate = can(userRole, 'character:create');
+  const canSetGlobal = hasPermission(currentUser, 'character:set_global');
 
   const creator = character.creator || character.data?.creator || null;
   const thumbnailUrl = `/thumbnail?type=avatar&file=${encodeURIComponent(avatar)}`;
@@ -414,7 +420,7 @@ function CharacterRow({
               <Copy size={14} />
             </button>
           )}
-          {userRole === 'owner' && (
+          {canSetGlobal && (
             <button
               onClick={() => onToggleVisibility(avatar)}
               disabled={isVisibilityBusy}


### PR DESCRIPTION
## Summary

- Contributors with `character:edit` and/or `character:set_global` checked in their permission group were still locked out of those actions in the UI.
- `CharacterManagementPage` was using the legacy role-level shim (`userRole === 'owner'` for make-global, ownership-only for edit) instead of `hasPermission` against the actual server-returned permissions array.
- Switch both gates to `hasPermission`. Edit retains the ownership fallback so end-users can still edit their own characters.

## Test plan

- [ ] Log in as a contributor whose permission group has `character:edit` checked — Edit button appears on all characters.
- [ ] Log in as a contributor whose permission group has `character:set_global` checked — Globe/Lock toggle appears.
- [ ] Log in as an end-user with neither permission — can still edit characters they own (ownership fallback).
- [ ] Owner role unchanged.

⚠️ Backend note: `/api/characters/set-visibility` may still be owner-only on the server (see `client.ts:505`). If so, the button will appear for contributors but the API call will 403 — follow-up to the backend needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)