### PR TITLE
feat(lorebooks): per-persona + per-chat linking, character visibility toggle

### DIFF
--- a/src/components/character/CharacterEdit.tsx
+++ b/src/components/character/CharacterEdit.tsx
@@ -1,6 +1,9 @@
 import { useState, useEffect } from 'react';
-import { Download, FileImage, FileJson, Copy, UserCircle } from 'lucide-react';
+import { Download, FileImage, FileJson, Copy, UserCircle, Globe, Lock, Loader2 } from 'lucide-react';
 import { useCharacterStore } from '../../stores/characterStore';
+import { useCharacterOwnershipStore } from '../../stores/characterOwnershipStore';
+import { useAuthStore } from '../../stores/authStore';
+import { hasPermission } from '../../utils/permissions';
 import { spritesApi, type CharacterInfo } from '../../api/client';
 import { Modal, Button, Input, TextArea, ImageUpload, ExpressionUpload, TagInput } from '../ui';
 import { AlternateGreetingsEditor } from './AlternateGreetingsEditor';
@@ -37,6 +40,11 @@ export function CharacterEdit({
     setLinkedBookIds,
     getAllTags,
   } = useCharacterStore();
+  const ownershipStore = useCharacterOwnershipStore();
+  const currentUser = useAuthStore((s) => s.currentUser);
+  const canSetGlobal = hasPermission(currentUser, 'character:set_global');
+  const visibility = ownershipStore.getVisibility(character.avatar);
+  const [isTogglingVisibility, setIsTogglingVisibility] = useState(false);
   const [showExportMenu, setShowExportMenu] = useState(false);
 
   const [avatarFile, setAvatarFile] = useState<File | null>(null);
@@ -225,6 +233,21 @@ export function CharacterEdit({
     onConvertToPersona?.(character);
   };
 
+  const handleToggleVisibility = async () => {
+    const next = visibility === 'global' ? 'personal' : 'global';
+    setIsTogglingVisibility(true);
+    try {
+      await ownershipStore.setVisibility(character.avatar, next);
+      // Server physically moved the file between directories — refresh the
+      // character list so subsequent API calls target the right scope.
+      await useCharacterStore.getState().fetchCharacters();
+    } catch (err) {
+      console.error('Failed to change character visibility', err);
+    } finally {
+      setIsTogglingVisibility(false);
+    }
+  };
+
   return (
     <Modal isOpen={isOpen} onClose={handleClose} title={`Edit ${character.name}`} size="lg">
       <form onSubmit={handleSubmit} className="space-y-4">
@@ -309,6 +332,39 @@ export function CharacterEdit({
           </div>
         </div>
 
+        {/* Visibility (global vs personal) — gated on character:set_global */}
+        {canSetGlobal && (
+          <div className="flex items-center justify-between rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-tertiary)] px-3 py-2">
+            <div className="min-w-0">
+              <p className="text-sm font-medium text-[var(--color-text-primary)]">
+                Visibility: {visibility === 'global' ? 'Global' : 'Personal'}
+              </p>
+              <p className="text-xs text-[var(--color-text-secondary)]">
+                {visibility === 'global'
+                  ? 'Shared with all users on this server.'
+                  : 'Only visible to you.'}
+              </p>
+            </div>
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              onClick={handleToggleVisibility}
+              disabled={isTogglingVisibility}
+              className="shrink-0"
+            >
+              {isTogglingVisibility ? (
+                <Loader2 size={14} className="animate-spin mr-1.5" />
+              ) : visibility === 'global' ? (
+                <Lock size={14} className="mr-1.5" />
+              ) : (
+                <Globe size={14} className="mr-1.5" />
+              )}
+              {visibility === 'global' ? 'Make Personal' : 'Make Global'}
+            </Button>
+          </div>
+        )}
+
         {/* Name - Required */}
         <Input
           label="Name *"
@@ -370,6 +426,7 @@ export function CharacterEdit({
         {/* Phase 4.3: Character lorebooks */}
         <CharacterLorebookSection
           avatar={character.avatar}
+          characterName={formData.name || character.name}
           linkedBookIds={linkedBookIds}
           onLinkedBookIdsChange={setLinkedBookIdsLocal}
         />

--- a/src/components/character/CharacterLorebookSection.tsx
+++ b/src/components/character/CharacterLorebookSection.tsx
@@ -1,11 +1,13 @@
 import { useState } from 'react';
-import { BookOpen, Edit2 } from 'lucide-react';
+import { BookOpen, Edit2, Plus, Trash2 } from 'lucide-react';
 import { useWorldInfoStore } from '../../stores/worldInfoStore';
 import { WorldInfoBookEditor } from '../worldinfo/WorldInfoBookEditor';
 
 interface CharacterLorebookSectionProps {
   /** The character's avatar filename (unique id). */
   avatar: string;
+  /** Human-readable character name, used when creating a new embedded book. */
+  characterName?: string;
   /** Currently-linked extra book ids (staged). */
   linkedBookIds: string[];
   /** Called with the new full list whenever the user toggles a checkbox. */
@@ -19,11 +21,15 @@ interface CharacterLorebookSectionProps {
  */
 export function CharacterLorebookSection({
   avatar,
+  characterName,
   linkedBookIds,
   onLinkedBookIdsChange,
 }: CharacterLorebookSectionProps) {
   const books = useWorldInfoStore((s) => s.books);
+  const createCharacterBook = useWorldInfoStore((s) => s.createCharacterBook);
+  const deleteCharacterBook = useWorldInfoStore((s) => s.deleteCharacterBook);
   const [editingEmbedded, setEditingEmbedded] = useState(false);
+  const [confirmRemove, setConfirmRemove] = useState(false);
 
   const embeddedBook = books.find((b) => b.ownerCharacterAvatar === avatar);
   // Only non-character-owned books are eligible to be linked as extras
@@ -73,12 +79,61 @@ export function CharacterLorebookSection({
               <Edit2 size={13} />
               Edit
             </button>
+            <button
+              type="button"
+              onClick={() => setConfirmRemove(true)}
+              className="shrink-0 flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-xs text-red-400 hover:text-red-300 hover:bg-red-500/10 border border-[var(--color-border)]"
+              aria-label="Remove embedded lorebook"
+            >
+              <Trash2 size={13} />
+              Remove
+            </button>
           </div>
         ) : (
-          <p className="text-sm text-[var(--color-text-secondary)]">
-            No embedded lorebook. One will be created automatically if you
-            import a character card that contains one.
-          </p>
+          <div className="flex items-center gap-2">
+            <p className="flex-1 text-sm text-[var(--color-text-secondary)]">
+              No embedded lorebook yet.
+            </p>
+            <button
+              type="button"
+              onClick={() => {
+                const fallback = characterName
+                  ? `${characterName}'s Lorebook`
+                  : 'Character Lorebook';
+                createCharacterBook(avatar, fallback);
+                setEditingEmbedded(true);
+              }}
+              className="shrink-0 flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-xs text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-secondary)] border border-[var(--color-border)]"
+              aria-label="Add embedded lorebook"
+            >
+              <Plus size={13} />
+              Add Lorebook
+            </button>
+          </div>
+        )}
+        {confirmRemove && embeddedBook && (
+          <div className="mt-2 rounded-md border border-red-500/40 bg-red-500/10 p-2 text-xs text-[var(--color-text-primary)]">
+            <p>Remove the embedded lorebook and all its entries? This cannot be undone.</p>
+            <div className="mt-2 flex gap-2 justify-end">
+              <button
+                type="button"
+                onClick={() => setConfirmRemove(false)}
+                className="px-2 py-1 rounded border border-[var(--color-border)] hover:bg-[var(--color-bg-secondary)]"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  deleteCharacterBook(avatar);
+                  setConfirmRemove(false);
+                }}
+                className="px-2 py-1 rounded bg-red-500/80 text-white hover:bg-red-500"
+              >
+                Remove
+              </button>
+            </div>
+          </div>
         )}
       </div>
 

--- a/src/components/chat/ChatLorebookModal.tsx
+++ b/src/components/chat/ChatLorebookModal.tsx
@@ -1,0 +1,84 @@
+import { BookOpen } from 'lucide-react';
+import { useWorldInfoStore } from '../../stores/worldInfoStore';
+import { Modal } from '../ui';
+
+interface ChatLorebookModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  /** Chat file name — same key persona locks use. */
+  chatFile: string;
+}
+
+/**
+ * Per-chat lorebook picker. Picked books are auto-activated whenever this
+ * chat is open, stacked on top of the globally-active list, the character's
+ * embedded/linked books, and the active persona's linked books.
+ *
+ * This is the "chat memories" bucket — dedicate one or more lorebooks to a
+ * chat for running notes, plot state, etc.
+ */
+export function ChatLorebookModal({ isOpen, onClose, chatFile }: ChatLorebookModalProps) {
+  const books = useWorldInfoStore((s) => s.books);
+  const linkedBookIds = useWorldInfoStore((s) =>
+    s.chatLinkedBookIds[chatFile] || []
+  );
+  const setChatLinkedBookIds = useWorldInfoStore((s) => s.setChatLinkedBookIds);
+
+  // Only non-character-owned books are eligible.
+  const candidateBooks = books.filter((b) => b.ownerCharacterAvatar == null);
+
+  const toggle = (bookId: string) => {
+    if (linkedBookIds.includes(bookId)) {
+      setChatLinkedBookIds(
+        chatFile,
+        linkedBookIds.filter((id) => id !== bookId)
+      );
+    } else {
+      setChatLinkedBookIds(chatFile, [...linkedBookIds, bookId]);
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Chat Lorebooks" size="md">
+      <div className="space-y-3">
+        <div className="flex items-start gap-2 text-xs text-[var(--color-text-secondary)]">
+          <BookOpen size={14} className="shrink-0 mt-0.5" />
+          <p>
+            Books linked here are auto-activated for this chat only — useful
+            for chat-specific notes, running plot state, or memories.
+          </p>
+        </div>
+
+        {candidateBooks.length === 0 ? (
+          <p className="text-sm text-[var(--color-text-secondary)] py-4 text-center">
+            No global lorebooks exist yet. Create some in Settings → World Info.
+          </p>
+        ) : (
+          <ul className="space-y-1 max-h-[60vh] overflow-y-auto">
+            {candidateBooks.map((book) => {
+              const checked = linkedBookIds.includes(book.id);
+              return (
+                <li key={book.id}>
+                  <label className="flex items-center gap-2.5 cursor-pointer rounded-md px-2 py-1.5 hover:bg-[var(--color-bg-tertiary)]">
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      onChange={() => toggle(book.id)}
+                      className="w-4 h-4 accent-[var(--color-primary)]"
+                    />
+                    <span className="flex-1 min-w-0 text-sm text-[var(--color-text-primary)] truncate">
+                      {book.name}
+                    </span>
+                    <span className="text-xs text-[var(--color-text-secondary)]">
+                      {book.entries.length}
+                    </span>
+                  </label>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/chat/ChatOptionsMenu.tsx
+++ b/src/components/chat/ChatOptionsMenu.tsx
@@ -9,7 +9,7 @@
  */
 import { useEffect, useRef } from 'react';
 import {
-  BookOpen, FileText, GitFork, MessageSquare, FolderOpen,
+  BookOpen, FileText, GitFork, Library, MessageSquare, FolderOpen,
   Trash2, RefreshCw, ArrowRight, User, Flag, Users,
 } from 'lucide-react';
 import { BottomSheet } from '../ui/BottomSheet';
@@ -33,6 +33,7 @@ interface ChatOptionsMenuProps {
   authorNote: ChatPanelState;
   summary: ChatPanelState & { enabled: boolean };
   branches: ChatPanelState & { count: number };
+  lorebook: ChatPanelState & { count: number };
 
   onStartNewChat: () => void;
   onManageChatFiles: () => void;
@@ -254,6 +255,7 @@ export function ChatOptionsMenu({
   authorNote,
   summary,
   branches,
+  lorebook,
   onStartNewChat,
   onManageChatFiles,
   onSaveCheckpoint,
@@ -291,6 +293,14 @@ export function ChatOptionsMenu({
       isOpen: branches.isOpen,
       hasContent: branches.count > 0,
       onToggle: wrap(branches.onToggle),
+    },
+    {
+      id: 'lorebook',
+      icon: Library,
+      label: `Lorebook${lorebook.count > 0 ? ` (${lorebook.count})` : ''}`,
+      isOpen: lorebook.isOpen,
+      hasContent: lorebook.count > 0,
+      onToggle: wrap(lorebook.onToggle),
     },
   ];
 

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -12,6 +12,8 @@ import { ChatInput } from './ChatInput';
 import { ChatActionBar } from './ChatActionBar';
 import { ChatOptionsMenu } from './ChatOptionsMenu';
 import { ChatHistoryPanel } from './ChatHistoryPanel';
+import { ChatLorebookModal } from './ChatLorebookModal';
+import { useWorldInfoStore } from '../../stores/worldInfoStore';
 import { GroupChatControls } from './GroupChatControls';
 import { AuthorNote } from './AuthorNote';
 import { SummaryPanel } from './SummaryPanel';
@@ -176,6 +178,10 @@ export function ChatView() {
   const [authorNoteOpen, setAuthorNoteOpen] = useState(false);
   const [summaryOpen, setSummaryOpen] = useState(false);
   const [branchOpen, setBranchOpen] = useState(false);
+  const [chatLorebookOpen, setChatLorebookOpen] = useState(false);
+  const chatLorebookCount = useWorldInfoStore((s) =>
+    currentChatFile ? (s.chatLinkedBookIds[currentChatFile]?.length ?? 0) : 0
+  );
 
   // Phase 6.4: VN mode — background image and costume
   const [vnBg, setVnBgState] = useState<string | null>(null);
@@ -1493,6 +1499,12 @@ export function ChatView() {
             count: branchCount,
             onToggle: () => setBranchOpen((v) => !v),
           }}
+          lorebook={{
+            isOpen: chatLorebookOpen,
+            hasContent: chatLorebookCount > 0,
+            count: chatLorebookCount,
+            onToggle: () => setChatLorebookOpen((v) => !v),
+          }}
           onStartNewChat={() => startNewChat(selectedCharacter)}
           onManageChatFiles={() => setIsHistoryPanelOpen(true)}
           onSaveCheckpoint={currentChatFile && lastAiMessageId ? () => handleCheckpoint(lastAiMessageId) : undefined}
@@ -1509,6 +1521,15 @@ export function ChatView() {
         isOpen={isHistoryPanelOpen}
         onClose={() => setIsHistoryPanelOpen(false)}
       />
+
+      {/* Chat Lorebooks modal (opened from chat options menu) */}
+      {currentChatFile && (
+        <ChatLorebookModal
+          isOpen={chatLorebookOpen}
+          onClose={() => setChatLorebookOpen(false)}
+          chatFile={currentChatFile}
+        />
+      )}
 
       </div>{/* end VN content wrapper */}
     </div>

--- a/src/components/persona/PersonaForm.tsx
+++ b/src/components/persona/PersonaForm.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
-import { User } from 'lucide-react';
+import { BookOpen, User } from 'lucide-react';
 import { usePersonaStore, type PersonaDescriptionPosition, type PersonaDescriptionRole, type Persona } from '../../stores/personaStore';
+import { useWorldInfoStore } from '../../stores/worldInfoStore';
 import { Button, Input, TextArea, ImageUpload } from '../ui';
 
 interface PersonaFormProps {
@@ -24,6 +25,12 @@ export function PersonaForm({ persona, onClose, onSaved, initialValues }: Person
   const [descriptionDepth, setDescriptionDepth] = useState(4);
   const [descriptionRole, setDescriptionRole] = useState<PersonaDescriptionRole>('system');
   const [isDefault, setIsDefault] = useState(false);
+  const [linkedBookIds, setLinkedBookIds] = useState<string[]>([]);
+
+  const books = useWorldInfoStore((s) => s.books);
+  // Only global (non-character-owned) books are picker-eligible — linking
+  // another character's embedded book from a persona would be surprising.
+  const candidateBooks = books.filter((b) => b.ownerCharacterAvatar == null);
 
   useEffect(() => {
     if (persona) {
@@ -34,6 +41,7 @@ export function PersonaForm({ persona, onClose, onSaved, initialValues }: Person
       setDescriptionDepth(persona.descriptionDepth);
       setDescriptionRole(persona.descriptionRole);
       setIsDefault(!!persona.isDefault);
+      setLinkedBookIds(persona.linkedBookIds ?? []);
     } else {
       setName(initialValues?.name || '');
       setDescription(initialValues?.description || '');
@@ -42,6 +50,7 @@ export function PersonaForm({ persona, onClose, onSaved, initialValues }: Person
       setDescriptionDepth(4);
       setDescriptionRole('system');
       setIsDefault(false);
+      setLinkedBookIds([]);
     }
   }, [persona, initialValues]);
 
@@ -71,6 +80,7 @@ export function PersonaForm({ persona, onClose, onSaved, initialValues }: Person
       descriptionDepth,
       descriptionRole,
       isDefault,
+      linkedBookIds,
     };
 
     if (persona) {
@@ -179,6 +189,56 @@ export function PersonaForm({ persona, onClose, onSaved, initialValues }: Person
         />
         Set as default persona
       </label>
+
+      {/* Persona lorebooks — auto-activated whenever this persona is active */}
+      <section className="space-y-2">
+        <div className="flex items-center gap-2">
+          <BookOpen size={16} className="text-[var(--color-text-secondary)]" />
+          <h3 className="text-sm font-medium text-[var(--color-text-primary)]">
+            Lorebooks
+          </h3>
+        </div>
+        <div className="rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-tertiary)] p-3">
+          {candidateBooks.length === 0 ? (
+            <p className="text-sm text-[var(--color-text-secondary)]">
+              No global lorebooks exist yet. Create some in Settings → World Info.
+            </p>
+          ) : (
+            <ul className="space-y-1.5">
+              {candidateBooks.map((book) => {
+                const checked = linkedBookIds.includes(book.id);
+                return (
+                  <li key={book.id}>
+                    <label className="flex items-center gap-2.5 cursor-pointer rounded-md px-1.5 py-1 hover:bg-[var(--color-bg-secondary)]">
+                      <input
+                        type="checkbox"
+                        checked={checked}
+                        onChange={() =>
+                          setLinkedBookIds(
+                            checked
+                              ? linkedBookIds.filter((id) => id !== book.id)
+                              : [...linkedBookIds, book.id]
+                          )
+                        }
+                        className="w-4 h-4 accent-[var(--color-primary)]"
+                      />
+                      <span className="flex-1 min-w-0 text-sm text-[var(--color-text-primary)] truncate">
+                        {book.name}
+                      </span>
+                      <span className="text-xs text-[var(--color-text-secondary)]">
+                        {book.entries.length}
+                      </span>
+                    </label>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+          <p className="mt-2 text-xs text-[var(--color-text-secondary)]">
+            Linked books are auto-activated whenever this persona is active.
+          </p>
+        </div>
+      </section>
 
       <div className="flex gap-3 pt-4 border-t border-[var(--color-border)]">
         <Button type="button" variant="secondary" onClick={onClose} className="flex-1">

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -676,12 +676,23 @@ function buildConversationContext(
   // The character's embedded book + per-character linked books are
   // auto-activated at scan time (scoped to this call), leaving the global
   // `activeBookIds` list untouched as the user navigates between characters.
+  // Persona-linked and chat-linked books are unioned in on top of that so
+  // each scope contributes its own bucket.
   const wiState = useWorldInfoStore.getState();
   const charBookIds = useCharacterStore
     .getState()
     .getActiveBookIdsForCharacter(character.avatar || '');
+  const personaBookIds = persona?.linkedBookIds ?? [];
+  const chatBookIds = ctxChatFile
+    ? wiState.chatLinkedBookIds[ctxChatFile] ?? []
+    : [];
   const scanBookIds = Array.from(
-    new Set([...wiState.activeBookIds, ...charBookIds])
+    new Set([
+      ...wiState.activeBookIds,
+      ...charBookIds,
+      ...personaBookIds,
+      ...chatBookIds,
+    ])
   );
   const tokenProfile = profileForProvider(activeProvider);
   const matchedEntries = scanMessagesForEntries(

--- a/src/stores/personaStore.ts
+++ b/src/stores/personaStore.ts
@@ -18,6 +18,12 @@ export interface Persona {
   descriptionDepth: number; // only used when position = 'at_depth'
   descriptionRole: PersonaDescriptionRole;
   isDefault?: boolean;
+  /**
+   * World info books to auto-activate whenever this persona is the active
+   * one. Union'd with character-embedded + character-linked + chat-linked
+   * books at scan time. Ids reference `WorldInfoBook.id`.
+   */
+  linkedBookIds?: string[];
   createdAt: number;
   updatedAt: number;
 }

--- a/src/stores/worldInfoStore.ts
+++ b/src/stores/worldInfoStore.ts
@@ -92,6 +92,7 @@ const SCAN_DEPTH_KEY = 'sillytavern_worldinfo_scan_depth_v1';
 const MAX_RECURSION_KEY = 'sillytavern_worldinfo_max_recursion_v1';
 const TOKEN_BUDGET_KEY = 'sillytavern_worldinfo_token_budget_v1';
 const WI_TIMERS_KEY = 'sillytavern_wi_timers_v1';
+const CHAT_LINKED_BOOKS_KEY = 'sillytavern_worldinfo_chat_linked_books_v1';
 
 // Module-level handle tracking so save functions stay signature-compatible.
 // Set by initForUser, cleared by resetUser.
@@ -206,6 +207,36 @@ function loadActiveBooks(handle?: string | null): string[] {
 function saveActiveBooks(ids: string[]) {
   try {
     localStorage.setItem(scopedKey(ACTIVE_BOOKS_KEY), JSON.stringify(ids));
+  } catch {
+    // ignore
+  }
+}
+
+function loadChatLinkedBooks(
+  handle?: string | null
+): Record<string, string[]> {
+  const h = handle !== undefined ? handle : _currentHandle;
+  try {
+    const raw = localStorage.getItem(scopedKey(CHAT_LINKED_BOOKS_KEY, h));
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as Record<string, string[]>;
+    if (!parsed || typeof parsed !== 'object') return {};
+    const clean: Record<string, string[]> = {};
+    for (const [k, v] of Object.entries(parsed)) {
+      if (Array.isArray(v)) clean[k] = v.filter((id) => typeof id === 'string');
+    }
+    return clean;
+  } catch {
+    return {};
+  }
+}
+
+function saveChatLinkedBooks(map: Record<string, string[]>) {
+  try {
+    localStorage.setItem(
+      scopedKey(CHAT_LINKED_BOOKS_KEY),
+      JSON.stringify(map)
+    );
   } catch {
     // ignore
   }
@@ -1003,6 +1034,12 @@ export function scanMessagesForEntries(
 interface WorldInfoState {
   books: WorldInfoBook[];
   activeBookIds: string[];
+  /**
+   * Per-chat extra lorebooks to auto-activate, keyed by chat file name
+   * (matches the key persona locks use). These stack on top of the
+   * globally-active list and the character's own embedded/linked books.
+   */
+  chatLinkedBookIds: Record<string, string[]>;
   scanDepth: number;
   maxRecursionSteps: number;
   tokenBudget: number;
@@ -1044,8 +1081,14 @@ interface WorldInfoState {
     raw: CharacterBookV2,
     fallbackName: string
   ) => WorldInfoBook;
+  /** Creates a fresh empty book already owned by the given character. */
+  createCharacterBook: (ownerAvatar: string, name: string) => WorldInfoBook;
   getCharacterBook: (ownerAvatar: string) => WorldInfoBook | null;
   deleteCharacterBook: (ownerAvatar: string) => void;
+
+  // Chat-scoped lorebooks
+  getChatLinkedBookIds: (chatFileName: string) => string[];
+  setChatLinkedBookIds: (chatFileName: string, ids: string[]) => void;
 
   clearError: () => void;
 
@@ -1059,6 +1102,7 @@ export const useWorldInfoStore = create<WorldInfoState>((set, get) => ({
   // Start empty; populated by initForUser once the authenticated user is known.
   books: [],
   activeBookIds: [],
+  chatLinkedBookIds: loadChatLinkedBooks(),
   scanDepth: DEFAULT_SCAN_DEPTH,
   maxRecursionSteps: DEFAULT_MAX_RECURSION,
   tokenBudget: DEFAULT_TOKEN_BUDGET,
@@ -1094,9 +1138,19 @@ export const useWorldInfoStore = create<WorldInfoState>((set, get) => ({
   deleteBook: (bookId) => {
     const next = get().books.filter((b) => b.id !== bookId);
     const activeNext = get().activeBookIds.filter((id) => id !== bookId);
+    const chatNext: Record<string, string[]> = {};
+    for (const [k, ids] of Object.entries(get().chatLinkedBookIds)) {
+      const filtered = ids.filter((id) => id !== bookId);
+      if (filtered.length > 0) chatNext[k] = filtered;
+    }
     saveBooks(next);
     saveActiveBooks(activeNext);
-    set({ books: next, activeBookIds: activeNext });
+    saveChatLinkedBooks(chatNext);
+    set({
+      books: next,
+      activeBookIds: activeNext,
+      chatLinkedBookIds: chatNext,
+    });
   },
 
   duplicateBook: (bookId) => {
@@ -1283,6 +1337,29 @@ export const useWorldInfoStore = create<WorldInfoState>((set, get) => ({
     return book;
   },
 
+  createCharacterBook: (ownerAvatar, name) => {
+    // If a book already owned by this character exists, return it rather than
+    // creating a second — the model is one embedded book per character.
+    const existing = get().books.find(
+      (b) => b.ownerCharacterAvatar === ownerAvatar
+    );
+    if (existing) return existing;
+    const trimmed = name.trim() || 'Character Lorebook';
+    const now = Date.now();
+    const book: WorldInfoBook = {
+      id: generateId('wibook'),
+      name: trimmed,
+      entries: [],
+      ownerCharacterAvatar: ownerAvatar,
+      createdAt: now,
+      updatedAt: now,
+    };
+    const next = [...get().books, book];
+    saveBooks(next);
+    set({ books: next });
+    return book;
+  },
+
   getCharacterBook: (ownerAvatar) => {
     return (
       get().books.find((b) => b.ownerCharacterAvatar === ownerAvatar) || null
@@ -1301,6 +1378,23 @@ export const useWorldInfoStore = create<WorldInfoState>((set, get) => ({
     set({ books: next, activeBookIds: activeNext });
   },
 
+  getChatLinkedBookIds: (chatFileName) => {
+    return get().chatLinkedBookIds[chatFileName] || [];
+  },
+
+  setChatLinkedBookIds: (chatFileName, ids) => {
+    const allBookIds = new Set(get().books.map((b) => b.id));
+    const deduped = Array.from(new Set(ids.filter((id) => allBookIds.has(id))));
+    const next = { ...get().chatLinkedBookIds };
+    if (deduped.length === 0) {
+      delete next[chatFileName];
+    } else {
+      next[chatFileName] = deduped;
+    }
+    saveChatLinkedBooks(next);
+    set({ chatLinkedBookIds: next });
+  },
+
   clearError: () => set({ error: null }),
 
   initForUser: (handle) => {
@@ -1308,6 +1402,7 @@ export const useWorldInfoStore = create<WorldInfoState>((set, get) => ({
     set({
       books: loadBooks(handle),
       activeBookIds: loadActiveBooks(handle),
+      chatLinkedBookIds: loadChatLinkedBooks(handle),
       scanDepth: loadScanDepth(handle),
       maxRecursionSteps: loadMaxRecursion(handle),
       tokenBudget: loadTokenBudget(handle),
@@ -1320,6 +1415,7 @@ export const useWorldInfoStore = create<WorldInfoState>((set, get) => ({
     set({
       books: [],
       activeBookIds: [],
+      chatLinkedBookIds: {},
       scanDepth: DEFAULT_SCAN_DEPTH,
       maxRecursionSteps: DEFAULT_MAX_RECURSION,
       tokenBudget: DEFAULT_TOKEN_BUDGET,


### PR DESCRIPTION
## Summary

Adds two new scopes for auto-activating world info books (on top of the existing global and character-scoped links) and surfaces two character actions in the editor.

**Character editor**
- Make Global / Make Personal toggle, gated on `character:set_global`.
- Add/Remove buttons for the embedded lorebook (edit was already there).

**Persona lorebooks**
- `Persona.linkedBookIds` — auto-activated whenever the persona is active.
- Checkbox picker in PersonaForm.

**Chat lorebooks (\"memories\")**
- New `chatLinkedBookIds` map on worldInfoStore, per-user scoped.
- \"Lorebook\" pill in the chat hamburger menu opens a modal picker.

**Generation integration**
- `chatStore` scan-set unions persona + chat linked IDs on top of globals and character books at build-context time.

## Test plan

- [ ] Character editor: Make Global / Make Personal toggles only appear when user has `character:set_global`; toggling moves the file between dirs and refreshes the list.
- [ ] Character editor: with no embedded lorebook, \"Add Lorebook\" creates one owned by the character and opens the editor.
- [ ] Character editor: \"Remove\" deletes the embedded book with confirmation.
- [ ] Persona form: checkbox list hydrates on edit, saves on submit, re-hydrates after reload.
- [ ] Chat hamburger → Lorebook pill opens a modal; picks persist across reloads, book count shown on pill.
- [ ] Generation path: picked persona/chat books show up in the WI scan (smoke check: add a keyword-only entry, say the keyword, verify it fires).

🤖 Generated with [Claude Code](https://claude.com/claude-code)