### PR TITLE
fix(chat): stop ChatLorebookModal from crashing chat view

### DIFF
--- a/src/components/chat/ChatLorebookModal.tsx
+++ b/src/components/chat/ChatLorebookModal.tsx
@@ -9,6 +9,10 @@ interface ChatLorebookModalProps {
   chatFile: string;
 }
 
+// Stable fallback so the zustand selector never returns a fresh array reference.
+// Fresh `[]` per call destabilizes useSyncExternalStore and trips React #185.
+const EMPTY_IDS: string[] = [];
+
 /**
  * Per-chat lorebook picker. Picked books are auto-activated whenever this
  * chat is open, stacked on top of the globally-active list, the character's
@@ -20,7 +24,7 @@ interface ChatLorebookModalProps {
 export function ChatLorebookModal({ isOpen, onClose, chatFile }: ChatLorebookModalProps) {
   const books = useWorldInfoStore((s) => s.books);
   const linkedBookIds = useWorldInfoStore((s) =>
-    s.chatLinkedBookIds[chatFile] || []
+    s.chatLinkedBookIds[chatFile] ?? EMPTY_IDS
   );
   const setChatLinkedBookIds = useWorldInfoStore((s) => s.setChatLinkedBookIds);
 


### PR DESCRIPTION
## Summary
- Selecting any character crashed the chat view into the root error boundary with React #185 ("Maximum update depth exceeded").
- Root cause: the zustand selector in `ChatLorebookModal` returned a fresh `[]` whenever the chat had no linked books. React 19's `useSyncExternalStore` retries on unstable snapshots and eventually throws #185. The modal is mounted as soon as `currentChatFile` is set, so the crash fired immediately on chat load.
- Fix: module-level `EMPTY_IDS` constant as the stable fallback.

## Test plan
- [x] `npm run build` green
- [x] Repro in dev: clicking Mina Hope loaded the chat view with no errors (verified via preview snapshot + console logs)