### PR TITLE
feat(memory): summary compaction + chat-history RAG + auto-extracted lorebook

### DIFF
--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -27,6 +27,7 @@ import { useIsMobile } from '../../hooks/useIsMobile';
 import { useOrientation } from '../../hooks/useOrientation';
 import { useKeyboardHeight } from '../../hooks/useKeyboardHeight';
 import { useSummarizeStore } from '../../stores/summarizeStore';
+import { useAutoMemoryStore } from '../../stores/autoMemoryStore';
 import { useCharacterSprites } from '../../hooks/useCharacterSprites';
 import {
   getExpressionThumbnailUrl,
@@ -491,14 +492,30 @@ export function ChatView() {
     wasSendingRef.current = false;
 
     const sumStore = useSummarizeStore.getState();
-    if (!sumStore.autoSummarize) return;
+    const memStore = useAutoMemoryStore.getState();
     if (!currentChatFile || !selectedCharacter) return;
 
     const nonSystemCount = messages.filter((m) => !m.isSystem).length;
-    const existing = sumStore.getSummary(currentChatFile);
-    const lastCount = existing?.messageCount ?? 0;
-    if (nonSystemCount - lastCount >= sumStore.autoTriggerEvery) {
-      sumStore.generateSummary(messages, currentChatFile, selectedCharacter.name);
+
+    if (sumStore.autoSummarize) {
+      const existing = sumStore.getSummary(currentChatFile);
+      const lastCount = existing?.messageCount ?? 0;
+      if (nonSystemCount - lastCount >= sumStore.autoTriggerEvery) {
+        sumStore.generateSummary(messages, currentChatFile, selectedCharacter.name);
+      }
+    }
+
+    if (memStore.shouldTrigger(currentChatFile, nonSystemCount)) {
+      void memStore.extractFacts(
+        currentChatFile,
+        selectedCharacter,
+        messages.map((m) => ({
+          name: m.name,
+          isUser: m.isUser,
+          isSystem: m.isSystem,
+          content: m.content,
+        }))
+      );
     }
   }, [isSending, messages, currentChatFile, selectedCharacter]);
 

--- a/src/components/settings/DataBankPage.tsx
+++ b/src/components/settings/DataBankPage.tsx
@@ -24,6 +24,7 @@ import {
 } from 'lucide-react';
 import { useSettingsPanelStore } from '../../stores/settingsPanelStore';
 import { useDataBankStore, type DataBankDocument } from '../../stores/dataBankStore';
+import { useChatHistoryRagStore } from '../../stores/chatHistoryRagStore';
 import { useCharacterStore } from '../../stores/characterStore';
 import { Button } from '../ui';
 
@@ -387,6 +388,9 @@ export function DataBankPage(_props?: { params?: Record<string, string> }) {
           )}
         </section>
 
+        {/* Chat memory — semantic retrieval over past chat turns */}
+        <ChatHistoryRagSection />
+
         {/* Embed error */}
         {embedError && (
           <div className="p-3 bg-red-500/10 border border-red-500/30 rounded-lg text-sm text-red-400">
@@ -438,5 +442,64 @@ export function DataBankPage(_props?: { params?: Record<string, string> }) {
         </section>
       </div>
     </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Chat-history RAG settings — embeds older chat turns so the model can
+// recall specific past moments by relevance, instead of carrying everything
+// in raw history. Shares the OpenAI embeddings key with the Data Bank.
+// ---------------------------------------------------------------------------
+
+function ChatHistoryRagSection() {
+  const enabled = useChatHistoryRagStore((s) => s.enabled);
+  const setEnabled = useChatHistoryRagStore((s) => s.setEnabled);
+  const embeddingsByChat = useChatHistoryRagStore((s) => s.embeddingsByChat);
+  const apiKey = useDataBankStore((s) => s.embeddingsApiKey);
+
+  const totalChats = Object.keys(embeddingsByChat).length;
+  const totalEmbeddings = Object.values(embeddingsByChat).reduce(
+    (sum, arr) => sum + arr.length,
+    0
+  );
+
+  return (
+    <section className="bg-[var(--color-bg-secondary)] rounded-lg p-4 space-y-3">
+      <div className="flex items-center justify-between">
+        <h2 className="text-sm font-semibold text-[var(--color-text-primary)]">
+          Chat memory (semantic recall)
+        </h2>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={enabled}
+          onClick={() => setEnabled(!enabled)}
+          className={`relative w-9 h-5 rounded-full transition-colors ${
+            enabled ? 'bg-[var(--color-primary)]' : 'bg-[var(--color-bg-tertiary)]'
+          }`}
+        >
+          <span
+            className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform ${
+              enabled ? 'translate-x-4' : 'translate-x-0'
+            }`}
+          />
+        </button>
+      </div>
+      <p className="text-xs text-[var(--color-text-secondary)]">
+        Embeds older chat turns so the AI can recall past moments by relevance
+        — pairs well with summary compaction. Costs one OpenAI embedding call
+        per new message and uses the API key above.
+      </p>
+      {enabled && !apiKey && (
+        <p className="text-xs text-amber-400">
+          No OpenAI embeddings key set — chat memory is inactive until you save one above.
+        </p>
+      )}
+      {enabled && apiKey && totalEmbeddings > 0 && (
+        <p className="text-xs text-[var(--color-text-secondary)]">
+          {totalEmbeddings} message{totalEmbeddings === 1 ? '' : 's'} embedded across {totalChats} chat{totalChats === 1 ? '' : 's'}.
+        </p>
+      )}
+    </section>
   );
 }

--- a/src/extensions/builtins/autoMemory.tsx
+++ b/src/extensions/builtins/autoMemory.tsx
@@ -1,0 +1,92 @@
+/**
+ * Auto-Memory extension — periodic LLM extraction of canonical facts
+ * appended to a per-character auto-memory lorebook.
+ *
+ * Settings UI lives here; trigger logic lives in ChatView (mirrors the
+ * summarize extension).
+ */
+import { Brain, Loader2 } from 'lucide-react';
+import { extensionRegistry } from '../registry';
+import { useAutoMemoryStore } from '../../stores/autoMemoryStore';
+import type { ExtensionManifest } from '../types';
+
+function AutoMemorySettings() {
+  const enabled = useAutoMemoryStore((s) => s.enabled);
+  const triggerEvery = useAutoMemoryStore((s) => s.triggerEvery);
+  const isExtracting = useAutoMemoryStore((s) => s.isExtracting);
+  const error = useAutoMemoryStore((s) => s.error);
+  const setEnabled = useAutoMemoryStore((s) => s.setEnabled);
+  const setTriggerEvery = useAutoMemoryStore((s) => s.setTriggerEvery);
+
+  const inputClass =
+    'px-2 py-1 text-xs rounded border border-[var(--color-border)] bg-[var(--color-bg-primary)] text-[var(--color-text-primary)] focus:outline-none focus:ring-1 focus:ring-[var(--color-primary)]';
+  const labelClass =
+    'flex items-center justify-between text-xs text-[var(--color-text-secondary)] mb-2';
+
+  return (
+    <div className="space-y-3">
+      <div className={labelClass}>
+        <span>Auto-extract facts</span>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={enabled}
+          onClick={() => setEnabled(!enabled)}
+          disabled={isExtracting}
+          className={`relative w-9 h-5 rounded-full transition-colors ${
+            enabled ? 'bg-[var(--color-primary)]' : 'bg-[var(--color-bg-tertiary)]'
+          }`}
+        >
+          <span
+            className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform ${
+              enabled ? 'translate-x-4' : 'translate-x-0'
+            }`}
+          />
+        </button>
+      </div>
+
+      <div className={labelClass}>
+        <span>Trigger every N messages</span>
+        <input
+          type="number"
+          min={10}
+          max={200}
+          value={triggerEvery}
+          onChange={(e) => setTriggerEvery(parseInt(e.target.value, 10))}
+          className={`${inputClass} w-16 text-center`}
+        />
+      </div>
+
+      <p className="text-[10px] text-[var(--color-text-secondary)]/70 leading-relaxed">
+        Periodically asks the active model to extract canonical facts from
+        recent chat turns and appends them to a per-character lorebook
+        (named "{'{Character} — Auto Memory'}"). Costs one LLM call per
+        trigger; uses your active provider/model.
+      </p>
+
+      {isExtracting && (
+        <div className="flex items-center gap-2 text-xs text-[var(--color-text-secondary)]">
+          <Loader2 size={12} className="animate-spin" />
+          <span>Extracting facts...</span>
+        </div>
+      )}
+
+      {error && (
+        <p className="text-xs text-red-400">{error}</p>
+      )}
+    </div>
+  );
+}
+
+const manifest: ExtensionManifest = {
+  id: 'autoMemory',
+  displayName: 'Auto-Memory',
+  description:
+    'Periodically extract canonical facts from chat into a per-character lorebook, growing persistent memory automatically.',
+  version: '1.0.0',
+  icon: Brain,
+  defaultEnabled: false,
+  settingsPanel: AutoMemorySettings,
+};
+
+extensionRegistry.register(manifest);

--- a/src/extensions/builtins/summarize.tsx
+++ b/src/extensions/builtins/summarize.tsx
@@ -12,11 +12,13 @@ function SummarizeSettings() {
   const autoTriggerEvery = useSummarizeStore((s) => s.autoTriggerEvery);
   const injectionDepth = useSummarizeStore((s) => s.injectionDepth);
   const injectionRole = useSummarizeStore((s) => s.injectionRole);
+  const compactWhenSummarized = useSummarizeStore((s) => s.compactWhenSummarized);
   const isGenerating = useSummarizeStore((s) => s.isGenerating);
   const setAutoSummarize = useSummarizeStore((s) => s.setAutoSummarize);
   const setAutoTriggerEvery = useSummarizeStore((s) => s.setAutoTriggerEvery);
   const setInjectionDepth = useSummarizeStore((s) => s.setInjectionDepth);
   const setInjectionRole = useSummarizeStore((s) => s.setInjectionRole);
+  const setCompactWhenSummarized = useSummarizeStore((s) => s.setCompactWhenSummarized);
 
   const inputClass =
     'px-2 py-1 text-xs rounded border border-[var(--color-border)] bg-[var(--color-bg-primary)] text-[var(--color-text-primary)] focus:outline-none focus:ring-1 focus:ring-[var(--color-primary)]';
@@ -84,6 +86,30 @@ function SummarizeSettings() {
           <option value="system">System</option>
           <option value="user">User</option>
         </select>
+      </div>
+
+      <div className={labelClass}>
+        <span>
+          Compact history when summarized
+          <span className="block text-[10px] text-[var(--color-text-secondary)]/60">
+            Drop turns covered by the summary from the prompt to save tokens
+          </span>
+        </span>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={compactWhenSummarized}
+          onClick={() => setCompactWhenSummarized(!compactWhenSummarized)}
+          className={`relative w-9 h-5 rounded-full transition-colors ${
+            compactWhenSummarized ? 'bg-[var(--color-primary)]' : 'bg-[var(--color-bg-tertiary)]'
+          }`}
+        >
+          <span
+            className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform ${
+              compactWhenSummarized ? 'translate-x-4' : 'translate-x-0'
+            }`}
+          />
+        </button>
       </div>
 
       {isGenerating && (

--- a/src/extensions/index.ts
+++ b/src/extensions/index.ts
@@ -4,6 +4,7 @@ import './builtins/tts';
 import './builtins/imageGen';
 import './builtins/translate';
 import './builtins/summarize';
+import './builtins/autoMemory';
 
 // Re-export for external consumption.
 export { extensionRegistry } from './registry';

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -7,6 +7,7 @@ import { useWorldInfoStore } from './worldInfoStore';
 import { useThemeStore } from './themeStore';
 import { useExtensionStore } from './extensionStore';
 import { useSummarizeStore } from './summarizeStore';
+import { useAutoMemoryStore } from './autoMemoryStore';
 import { useTranslateStore } from './translateStore';
 import { useQuickReplyStore } from './quickReplyStore';
 import type { UserRole, Permission } from '../types';
@@ -56,6 +57,7 @@ export const useAuthStore = create<AuthState>((set) => ({
         useWorldInfoStore.getState().initForUser(user.handle);
         useExtensionStore.getState().initForUser(user.handle);
         useSummarizeStore.getState().initForUser(user.handle);
+        useAutoMemoryStore.getState().initForUser(user.handle);
         useTranslateStore.getState().initForUser(user.handle);
         useQuickReplyStore.getState().initForUser(user.handle);
         set({
@@ -106,6 +108,7 @@ export const useAuthStore = create<AuthState>((set) => ({
       useWorldInfoStore.getState().initForUser(loginResult.handle);
       useExtensionStore.getState().initForUser(loginResult.handle);
       useSummarizeStore.getState().initForUser(loginResult.handle);
+      useAutoMemoryStore.getState().initForUser(loginResult.handle);
       useTranslateStore.getState().initForUser(loginResult.handle);
       useQuickReplyStore.getState().initForUser(loginResult.handle);
       set({
@@ -133,6 +136,7 @@ export const useAuthStore = create<AuthState>((set) => ({
       useWorldInfoStore.getState().initForUser(h);
       useExtensionStore.getState().initForUser(h);
       useSummarizeStore.getState().initForUser(h);
+      useAutoMemoryStore.getState().initForUser(h);
       useTranslateStore.getState().initForUser(h);
       useQuickReplyStore.getState().initForUser(h);
       set({
@@ -201,6 +205,7 @@ export const useAuthStore = create<AuthState>((set) => ({
       useWorldInfoStore.getState().resetUser();
       useExtensionStore.getState().resetUser();
       useSummarizeStore.getState().resetUser();
+      useAutoMemoryStore.getState().resetUser();
       useTranslateStore.getState().resetUser();
       useQuickReplyStore.getState().resetUser();
 

--- a/src/stores/autoMemoryStore.ts
+++ b/src/stores/autoMemoryStore.ts
@@ -1,0 +1,351 @@
+/**
+ * Auto-Memory — periodic LLM extraction of canonical facts from a chat,
+ * appended to a per-character "auto-memory" lorebook.
+ *
+ * Why: lorebooks are great for keyword-triggered persistent memory, but
+ * curating them by hand is tedious. This runs an extraction prompt every
+ * N messages, dedupes against what's already in the book, and writes new
+ * keyword-tagged entries automatically.
+ *
+ * Trigger lifecycle (mirrors summarize):
+ *   1. ChatView watches message count; when (count - lastTriggered) crosses
+ *      `triggerEvery`, calls `extractFacts(chatFile, character, messages)`.
+ *   2. The store sends recent messages + currently-known entries to the LLM,
+ *      asks for new canonical facts as JSON, and appends survivors as new
+ *      entries on the character's auto-memory book (creating the book on
+ *      first run via `createCharacterBook` + the `autoExtracted` flag).
+ *
+ * The extraction prompt uses the same active provider/model as chat
+ * generation. There's no separate model setting — if the user changes
+ * models, extractions follow.
+ */
+
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+import { api } from '../api/client';
+import { useSettingsStore } from './settingsStore';
+import { useWorldInfoStore } from './worldInfoStore';
+import type { CharacterInfo } from '../api/client';
+
+let _currentHandle: string | null = null;
+
+const scopedLocalStorage = {
+  getItem: (name: string) => {
+    const key = _currentHandle ? `${name}_${_currentHandle}` : name;
+    return localStorage.getItem(key);
+  },
+  setItem: (name: string, value: string) => {
+    const key = _currentHandle ? `${name}_${_currentHandle}` : name;
+    localStorage.setItem(key, value);
+  },
+  removeItem: (name: string) => {
+    const key = _currentHandle ? `${name}_${_currentHandle}` : name;
+    localStorage.removeItem(key);
+  },
+};
+
+interface AutoMemoryState {
+  // --- persisted settings ---
+  enabled: boolean;
+  /** Trigger an extraction every N non-system messages since the last run. */
+  triggerEvery: number;
+  /**
+   * Per-chat counter — message count at last successful extraction. Used
+   * to gate the next trigger so the same window isn't extracted twice.
+   */
+  lastByChatFile: Record<string, number>;
+
+  // --- session state ---
+  isExtracting: boolean;
+  error: string | null;
+
+  // --- actions ---
+  setEnabled: (on: boolean) => void;
+  setTriggerEvery: (n: number) => void;
+  shouldTrigger: (chatFile: string, currentNonSystemCount: number) => boolean;
+  extractFacts: (
+    chatFile: string,
+    character: CharacterInfo,
+    messages: { name: string; isUser: boolean; isSystem: boolean; content: string }[]
+  ) => Promise<{ added: number }>;
+  clearError: () => void;
+  initForUser: (handle: string) => void;
+  resetUser: () => void;
+}
+
+// Reuse the SSE parser from summarize — duplicated locally to avoid an
+// awkward export from another store file. Both stores share the same
+// generateMessage stream shape so the parser behavior is identical.
+async function* parseSSEStream(
+  stream: ReadableStream<Uint8Array>
+): AsyncGenerator<string> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop() || '';
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed === 'data: [DONE]') continue;
+        if (trimmed.startsWith('data: ')) {
+          const data = trimmed.slice(6);
+          if (!data || data === '[DONE]') continue;
+          try {
+            const json = JSON.parse(data);
+            const content =
+              json.choices?.[0]?.delta?.content ||
+              json.choices?.[0]?.text ||
+              json.delta?.text ||
+              (json.type === 'content_block_delta' ? json.delta?.text : null) ||
+              json.content ||
+              json.message?.content?.[0]?.text ||
+              '';
+            if (content) yield content;
+          } catch {
+            if (data.length > 0 && data !== 'undefined') yield data;
+          }
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+interface ExtractedFact {
+  keys: string[];
+  content: string;
+}
+
+function parseFactsFromResponse(text: string): ExtractedFact[] {
+  // The LLM may wrap JSON in fences or add prose. Find the first JSON array.
+  const arrayMatch = text.match(/\[[\s\S]*\]/);
+  if (!arrayMatch) return [];
+  try {
+    const parsed = JSON.parse(arrayMatch[0]) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    const out: ExtractedFact[] = [];
+    for (const item of parsed) {
+      if (!item || typeof item !== 'object') continue;
+      const obj = item as Record<string, unknown>;
+      const rawKeys = Array.isArray(obj.keys)
+        ? obj.keys.filter((k): k is string => typeof k === 'string')
+        : typeof obj.keys === 'string'
+          ? [obj.keys]
+          : [];
+      const content = typeof obj.content === 'string' ? obj.content.trim() : '';
+      if (rawKeys.length === 0 || !content) continue;
+      out.push({
+        keys: rawKeys.map((k) => k.trim()).filter(Boolean),
+        content,
+      });
+    }
+    return out;
+  } catch {
+    return [];
+  }
+}
+
+const AUTO_MEMORY_BOOK_SUFFIX = ' — Auto Memory';
+
+export const useAutoMemoryStore = create<AutoMemoryState>()(
+  persist(
+    (set, get) => ({
+      enabled: false,
+      triggerEvery: 30,
+      lastByChatFile: {},
+      isExtracting: false,
+      error: null,
+
+      setEnabled: (on) => set({ enabled: on }),
+      setTriggerEvery: (n) =>
+        set({ triggerEvery: Math.max(10, Math.min(200, Math.round(n))) }),
+
+      shouldTrigger: (chatFile, currentNonSystemCount) => {
+        const { enabled, triggerEvery, lastByChatFile, isExtracting } = get();
+        if (!enabled || isExtracting) return false;
+        const last = lastByChatFile[chatFile] ?? 0;
+        return currentNonSystemCount - last >= triggerEvery;
+      },
+
+      clearError: () => set({ error: null }),
+
+      initForUser: (handle) => {
+        _currentHandle = handle;
+        useAutoMemoryStore.persist.rehydrate();
+      },
+      resetUser: () => {
+        _currentHandle = null;
+        set({
+          enabled: false,
+          triggerEvery: 30,
+          lastByChatFile: {},
+          isExtracting: false,
+          error: null,
+        });
+      },
+
+      extractFacts: async (chatFile, character, messages) => {
+        if (get().isExtracting) return { added: 0 };
+        set({ isExtracting: true, error: null });
+
+        try {
+          const { activeProvider, activeModel } = useSettingsStore.getState();
+          const wiStore = useWorldInfoStore.getState();
+          const avatar = character.avatar || '';
+          if (!avatar) {
+            set({ isExtracting: false });
+            return { added: 0 };
+          }
+
+          // Find or create the auto-memory book for this character. We
+          // can't reuse the embedded book because users may want to keep
+          // hand-curated character lore separate from machine-extracted
+          // notes. The naming convention + `autoExtracted` flag together
+          // make this unambiguous.
+          const allBooks = wiStore.books;
+          let book = allBooks.find(
+            (b) => b.ownerCharacterAvatar === avatar && b.autoExtracted
+          );
+          if (!book) {
+            // First run for this character — create the auto-memory book.
+            // If the character already has an embedded book, this returns
+            // the existing one and we write into it (v1 model: at most one
+            // character-owned book; auto-extracted entries coexist with
+            // hand-curated ones, distinguished by their `Auto-extracted`
+            // comment field).
+            const created = wiStore.createCharacterBook(
+              avatar,
+              `${character.name}${AUTO_MEMORY_BOOK_SUFFIX}`
+            );
+            useWorldInfoStore.setState((s) => ({
+              books: s.books.map((b) =>
+                b.id === created.id ? { ...b, autoExtracted: true } : b
+              ),
+            }));
+            book = { ...created, autoExtracted: true };
+          }
+
+          // Build "already known" digest so the LLM doesn't repeat itself.
+          const knownDigest = book.entries
+            .slice(-30)
+            .map((e) => `- (${e.keys.join(', ')}) ${e.content}`)
+            .join('\n');
+
+          // Use the last 30 non-system messages as the extraction window.
+          const sample = messages.filter((m) => !m.isSystem).slice(-30);
+          if (sample.length < 4) {
+            set({ isExtracting: false });
+            return { added: 0 };
+          }
+
+          const transcript = sample
+            .map((m) => `${m.isUser ? 'User' : character.name}: ${m.content}`)
+            .join('\n');
+
+          const sys = `You are an information-extraction assistant. Read a roleplay chat excerpt and produce CANONICAL FACTS worth remembering across future sessions — names, places, relationships, possessions, decisions, established traits.
+
+Output rules:
+- Return ONLY a JSON array. No prose.
+- Each item: {"keys": ["keyword1", "keyword2"], "content": "fact in one sentence"}.
+- Keys are short trigger words a future scan would look for to surface this fact.
+- Skip facts already covered by the "Already known" list.
+- Skip transient stuff (greetings, weather flavor, repeated ideas).
+- If nothing new is worth recording, return [].`;
+
+          const user = `Already known:
+${knownDigest || '(none)'}
+
+Chat excerpt:
+${transcript}
+
+New canonical facts (JSON array):`;
+
+          const stream = await api.generateMessage(
+            [
+              { role: 'system', content: sys },
+              { role: 'user', content: user },
+            ],
+            character.name,
+            activeProvider,
+            activeModel
+          );
+
+          if (!stream) {
+            set({
+              isExtracting: false,
+              error: 'No response from API during extraction',
+            });
+            return { added: 0 };
+          }
+
+          let raw = '';
+          for await (const token of parseSSEStream(stream)) {
+            raw += token;
+          }
+
+          const facts = parseFactsFromResponse(raw);
+          if (facts.length === 0) {
+            // Mark this window as processed even on empty result so we
+            // don't immediately retry on the next message.
+            const total = messages.filter((m) => !m.isSystem).length;
+            set((s) => ({
+              lastByChatFile: { ...s.lastByChatFile, [chatFile]: total },
+              isExtracting: false,
+            }));
+            return { added: 0 };
+          }
+
+          // Dedupe: drop any fact whose content substring-matches an
+          // existing entry (case-insensitive prefix). Cheap and good
+          // enough for v1; semantic dedup is a follow-up.
+          const existingNorm = new Set(
+            book.entries.map((e) => e.content.trim().toLowerCase().slice(0, 80))
+          );
+          let added = 0;
+          for (const fact of facts) {
+            const norm = fact.content.trim().toLowerCase().slice(0, 80);
+            if (existingNorm.has(norm)) continue;
+            existingNorm.add(norm);
+            useWorldInfoStore.getState().createEntry(book.id, {
+              keys: fact.keys,
+              content: fact.content,
+              comment: 'Auto-extracted',
+            });
+            added++;
+          }
+
+          const total = messages.filter((m) => !m.isSystem).length;
+          set((s) => ({
+            lastByChatFile: { ...s.lastByChatFile, [chatFile]: total },
+            isExtracting: false,
+          }));
+          return { added };
+        } catch (err) {
+          set({
+            error: err instanceof Error ? err.message : 'Extraction failed',
+            isExtracting: false,
+          });
+          return { added: 0 };
+        }
+      },
+    }),
+    {
+      name: 'st-mobile-auto-memory',
+      storage: createJSONStorage(() => scopedLocalStorage),
+      partialize: (s) => ({
+        enabled: s.enabled,
+        triggerEvery: s.triggerEvery,
+        lastByChatFile: s.lastByChatFile,
+      }),
+    }
+  )
+);

--- a/src/stores/chatHistoryRagStore.ts
+++ b/src/stores/chatHistoryRagStore.ts
@@ -1,0 +1,234 @@
+/**
+ * Chat-history RAG — embeddings over the user's own past chat turns.
+ *
+ * Companion to dataBankStore: same embeddings API + cosine search, but the
+ * source is the live chat instead of user-uploaded docs. The point is to
+ * recall specific past moments by semantic relevance instead of paying to
+ * keep them in raw history every turn.
+ *
+ * Lifecycle:
+ *   - The chat generation path calls `ensureEmbedded(chatFile, messages)`
+ *     before building context. Any messages that don't yet have an embedding
+ *     are embedded one-by-one and persisted.
+ *   - At query time, `queryTopK(chatFile, query, k)` returns the top-K most
+ *     relevant past messages by cosine similarity.
+ *   - `clearChat(chatFile)` wipes a chat's stored embeddings (e.g. after a
+ *     "Start new chat" reset).
+ *
+ * Cost: each new message costs one OpenAI embedding call. Opt-in only.
+ * Storage: ~6 KB per message vector. 1 000 messages ≈ 6 MB localStorage.
+ */
+
+import { create } from 'zustand';
+import { useDataBankStore } from './dataBankStore';
+import { cosineSimilarity, getEmbedding } from '../utils/embeddings';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ChatMessageEmbedding {
+  /** Stable id — `${chatFile}#${index}` so re-embedding the same slot is idempotent. */
+  id: string;
+  /** Original message text (the slice we embedded). */
+  text: string;
+  /** Speaker label, kept for the retrieval-context preamble. */
+  speaker: 'user' | 'assistant';
+  embedding: number[];
+}
+
+interface ChatHistoryRagState {
+  /** Master switch — when off, no embedding calls and no retrieval. */
+  enabled: boolean;
+  /** Per-message embeddings keyed by chat file name. */
+  embeddingsByChat: Record<string, ChatMessageEmbedding[]>;
+  /** Whether an embedding pass is currently running for a given chat. */
+  embeddingChats: Set<string>;
+
+  setEnabled: (on: boolean) => void;
+
+  /**
+   * Make sure every non-system message in `messages` has an embedding stored
+   * for `chatFile`. New messages are embedded sequentially using the Data
+   * Bank's OpenAI key. If no key is set, this is a no-op.
+   */
+  ensureEmbedded: (
+    chatFile: string,
+    messages: { content: string; isUser: boolean; isSystem: boolean }[]
+  ) => Promise<void>;
+
+  /**
+   * Return the top-K past messages most relevant to `query`. Results carry
+   * the speaker label so callers can render a useful preamble.
+   */
+  queryTopK: (
+    chatFile: string,
+    query: string,
+    k?: number
+  ) => Promise<Array<{ text: string; speaker: 'user' | 'assistant'; score: number }>>;
+
+  clearChat: (chatFile: string) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Persistence
+// ---------------------------------------------------------------------------
+
+const STORAGE_KEY = 'stm:chat-history-rag';
+const ENABLED_KEY = 'stm:chat-history-rag-enabled';
+
+interface PersistedShape {
+  embeddingsByChat: Record<string, ChatMessageEmbedding[]>;
+}
+
+function loadFromStorage(): Record<string, ChatMessageEmbedding[]> {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw) as PersistedShape;
+      return parsed.embeddingsByChat ?? {};
+    }
+  } catch {
+    /* ignore */
+  }
+  return {};
+}
+
+function saveToStorage(embeddingsByChat: Record<string, ChatMessageEmbedding[]>) {
+  try {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ embeddingsByChat } satisfies PersistedShape)
+    );
+  } catch {
+    /* ignore */
+  }
+}
+
+function loadEnabled(): boolean {
+  try {
+    return localStorage.getItem(ENABLED_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+function saveEnabled(on: boolean) {
+  try {
+    localStorage.setItem(ENABLED_KEY, on ? 'true' : 'false');
+  } catch {
+    /* ignore */
+  }
+}
+
+// Cap how many short trailing messages we skip embedding — those are likely
+// already in the raw history window. Anything older needs embeddings to be
+// retrievable after compaction.
+const TAIL_SKIP = 4;
+
+// Don't bother embedding messages shorter than this — too little signal for
+// cosine similarity to do anything useful, and they're cheap to keep raw.
+const MIN_CHARS = 40;
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+export const useChatHistoryRagStore = create<ChatHistoryRagState>((set, get) => ({
+  enabled: loadEnabled(),
+  embeddingsByChat: loadFromStorage(),
+  embeddingChats: new Set(),
+
+  setEnabled: (on) => {
+    saveEnabled(on);
+    set({ enabled: on });
+  },
+
+  ensureEmbedded: async (chatFile, messages) => {
+    const state = get();
+    if (!state.enabled) return;
+    if (state.embeddingChats.has(chatFile)) return; // already embedding this chat
+
+    const apiKey = useDataBankStore.getState().embeddingsApiKey;
+    if (!apiKey) return;
+
+    const existing = state.embeddingsByChat[chatFile] ?? [];
+    const existingIds = new Set(existing.map((e) => e.id));
+
+    // Build the candidate list: every non-system message, capped to leave
+    // the live tail alone (no need to embed what's already in raw history).
+    const nonSystem = messages.filter((m) => !m.isSystem);
+    const sliceEnd = Math.max(0, nonSystem.length - TAIL_SKIP);
+    const toCheck = nonSystem.slice(0, sliceEnd);
+
+    const todo: { id: string; text: string; speaker: 'user' | 'assistant' }[] = [];
+    for (let i = 0; i < toCheck.length; i++) {
+      const msg = toCheck[i];
+      const text = msg.content.trim();
+      if (text.length < MIN_CHARS) continue;
+      const id = `${chatFile}#${i}`;
+      if (existingIds.has(id)) continue;
+      todo.push({ id, text, speaker: msg.isUser ? 'user' : 'assistant' });
+    }
+    if (todo.length === 0) return;
+
+    set((s) => ({ embeddingChats: new Set([...s.embeddingChats, chatFile]) }));
+    try {
+      const fresh: ChatMessageEmbedding[] = [];
+      for (const item of todo) {
+        try {
+          const embedding = await getEmbedding(item.text, apiKey);
+          fresh.push({ ...item, embedding });
+        } catch {
+          // Skip individual failures — partial coverage is still useful.
+        }
+      }
+      if (fresh.length > 0) {
+        const next = {
+          ...get().embeddingsByChat,
+          [chatFile]: [...existing, ...fresh],
+        };
+        saveToStorage(next);
+        set({ embeddingsByChat: next });
+      }
+    } finally {
+      set((s) => {
+        const remaining = new Set(s.embeddingChats);
+        remaining.delete(chatFile);
+        return { embeddingChats: remaining };
+      });
+    }
+  },
+
+  queryTopK: async (chatFile, query, k = 3) => {
+    const state = get();
+    if (!state.enabled) return [];
+    const apiKey = useDataBankStore.getState().embeddingsApiKey;
+    if (!apiKey) return [];
+
+    const stored = state.embeddingsByChat[chatFile] ?? [];
+    if (stored.length === 0) return [];
+
+    try {
+      const queryEmbedding = await getEmbedding(query, apiKey);
+      return stored
+        .map((m) => ({
+          text: m.text,
+          speaker: m.speaker,
+          score: cosineSimilarity(queryEmbedding, m.embedding),
+        }))
+        .filter((m) => m.score > 0.3)
+        .sort((a, b) => b.score - a.score)
+        .slice(0, k);
+    } catch {
+      return [];
+    }
+  },
+
+  clearChat: (chatFile) => {
+    const next = { ...get().embeddingsByChat };
+    delete next[chatFile];
+    saveToStorage(next);
+    set({ embeddingsByChat: next });
+  },
+}));

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -34,6 +34,8 @@ import { getInstructTemplate, formatInstructPrompt } from '../utils/instructTemp
 import { useRegexScriptStore } from './regexScriptStore';
 import { applyRegexScripts, getActiveScripts } from '../utils/regexScripts';
 import { useDataBankStore } from './dataBankStore';
+import { useSummarizeStore } from './summarizeStore';
+import { useChatHistoryRagStore } from './chatHistoryRagStore';
 import { extensionRegistry } from '../extensions/registry';
 import type { ContextContribution } from '../extensions/types';
 import { useAuthStore } from './authStore';
@@ -607,28 +609,57 @@ function buildMacroContext(
 
 /**
  * Phase 8.5 — RAG helper.
- * Extracts the last user message from `messages`, queries the Data Bank for
- * relevant chunks scoped to `characterAvatar`, and returns a formatted string
- * to inject into the system prompt. Each chunk is prefixed with its source
- * document name (e.g. `[From: ember_lore]`) so the model can cite passages
- * and users can debug which document a chunk came from. Returns null when
- * no relevant chunks are found or RAG is inactive.
+ * Extracts the last user message from `messages` and queries two sources
+ * for relevant context, run in parallel:
+ *   1. The Data Bank (user-uploaded docs, scoped to `characterAvatar`)
+ *   2. Chat-history embeddings for `chatFile` (older turns indexed
+ *      semantically — recalls specific past moments without keeping them
+ *      in raw history)
+ *
+ * Both sources are gated on the user's settings and an OpenAI embeddings
+ * key. Each chunk is prefixed with provenance so the model can cite. Also
+ * lazily ensures any new turns have been embedded before querying.
  */
 async function resolveRagContext(
   messages: ChatMessage[],
-  characterAvatar: string
+  characterAvatar: string,
+  chatFile?: string
 ): Promise<string | null> {
   const lastUser = [...messages].reverse().find((m) => m.isUser && !m.isSystem);
   if (!lastUser?.content.trim()) return null;
 
-  const chunks = await useDataBankStore
-    .getState()
-    .queryRelevantChunks(lastUser.content, characterAvatar);
+  // Kick off chat-history embedding for any messages that don't have one
+  // yet. Don't block generation on it — the next turn will benefit.
+  if (chatFile) {
+    void useChatHistoryRagStore.getState().ensureEmbedded(
+      chatFile,
+      messages.map((m) => ({
+        content: m.content,
+        isUser: m.isUser,
+        isSystem: m.isSystem,
+      }))
+    );
+  }
 
-  if (chunks.length === 0) return null;
-  return chunks
-    .map((c) => `[From: ${c.docName}]\n${c.text}`)
-    .join('\n\n---\n\n');
+  const [dataBankChunks, historyChunks] = await Promise.all([
+    useDataBankStore
+      .getState()
+      .queryRelevantChunks(lastUser.content, characterAvatar),
+    chatFile
+      ? useChatHistoryRagStore.getState().queryTopK(chatFile, lastUser.content)
+      : Promise.resolve([] as Array<{ text: string; speaker: 'user' | 'assistant'; score: number }>),
+  ]);
+
+  const parts: string[] = [];
+  for (const c of dataBankChunks) {
+    parts.push(`[From: ${c.docName}]\n${c.text}`);
+  }
+  for (const m of historyChunks) {
+    const who = m.speaker === 'user' ? 'User' : 'Character';
+    parts.push(`[Earlier in chat — ${who}]\n${m.text}`);
+  }
+  if (parts.length === 0) return null;
+  return parts.join('\n\n---\n\n');
 }
 
 // Build conversation context for AI
@@ -870,7 +901,16 @@ Choose the emotion that best matches how ${character.name} would feel based on t
   const historyPool = ctxConfig.tokenAware
     ? messages.filter((m) => !m.isSystem)
     : messages.slice(-ctxConfig.messageCount).filter((m) => !m.isSystem);
-  const recentMessages = historyPool;
+  // Summary compaction: when a summary covers the first N non-system turns,
+  // drop those turns from the prompt — the summary is already injected
+  // separately by the summarize extension. Big token win on long chats.
+  const sumState = useSummarizeStore.getState();
+  const sumForChat = ctxChatFile ? sumState.getSummary(ctxChatFile) : null;
+  const compactedHistory =
+    sumState.compactWhenSummarized && sumForChat && sumForChat.messageCount > 0
+      ? historyPool.slice(Math.min(sumForChat.messageCount, historyPool.length))
+      : historyPool;
+  const recentMessages = compactedHistory;
 
   // Character's Note (depth prompt): inject at configurable depth from the END of the history
   const depthPrompt = getDepthPrompt(character);
@@ -1225,7 +1265,7 @@ async function generateGroupTurn(
   // Phase 8.5: resolve Data Bank / RAG chunks scoped to the current speaker.
   // In a group turn this means Seraphina's character-scoped docs only fire
   // on Seraphina's turn, which matches how solo chats scope per-character.
-  const ragCtx = await resolveRagContext(updatedMessages, character.avatar || '');
+  const ragCtx = await resolveRagContext(updatedMessages, character.avatar || '', get().currentChatFile || undefined);
   // Phase 5.3: look up the group's card-handling mode so the builder knows
   // whether to produce a swap-style flat bullet list or a full per-member
   // block layout for join mode.
@@ -2113,7 +2153,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
       const { currentChatFile } = get();
       const currentTurn = contextMessages.filter((m) => !m.isUser && !m.isSystem).length;
       const wiTimerActivated = new Set<string>();
-      const ragCtx = await resolveRagContext(contextMessages, character.avatar || '');
+      const ragCtx = await resolveRagContext(contextMessages, character.avatar || '', currentChatFile || undefined);
       const context = buildConversationContext(contextMessages, character, availableEmotions, {
         currentTurn,
         timers: loadWiTimers(currentChatFile || ''),
@@ -2205,7 +2245,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
 
     try {
       // Build context including the current AI message
-      const ragCtx = await resolveRagContext(messages, character.avatar || '');
+      const ragCtx = await resolveRagContext(messages, character.avatar || '', get().currentChatFile || undefined);
       const context = buildConversationContext(messages, character, availableEmotions, undefined, ragCtx ?? undefined);
       // Add a system instruction to continue
       context.push({
@@ -2279,7 +2319,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
     set({ isSending: true, isStreaming: false, error: null, abortController });
 
     try {
-      const ragCtx = await resolveRagContext(messages, character.avatar || '');
+      const ragCtx = await resolveRagContext(messages, character.avatar || '', get().currentChatFile || undefined);
       const context = buildConversationContext(messages, character, availableEmotions, undefined, ragCtx ?? undefined);
       // Replace the system prompt's last line to instruct impersonation
       context.push({
@@ -2426,7 +2466,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
       const { currentChatFile } = get();
       const currentTurn = updatedMessages.filter((m) => !m.isUser && !m.isSystem).length;
       const wiTimerActivated = new Set<string>();
-      const ragCtx = await resolveRagContext(updatedMessages, character.avatar || '');
+      const ragCtx = await resolveRagContext(updatedMessages, character.avatar || '', currentChatFile || undefined);
       const context = buildConversationContext(updatedMessages, character, availableEmotions, {
         currentTurn,
         timers: loadWiTimers(currentChatFile || ''),
@@ -2762,7 +2802,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
       const { currentChatFile } = get();
       const currentTurn = updatedMessages.filter((m) => !m.isUser && !m.isSystem).length;
       const wiTimerActivated = new Set<string>();
-      const ragCtx = await resolveRagContext(updatedMessages, character.avatar || '');
+      const ragCtx = await resolveRagContext(updatedMessages, character.avatar || '', currentChatFile || undefined);
       const context = buildConversationContext(updatedMessages, character, availableEmotions, {
         currentTurn,
         timers: loadWiTimers(currentChatFile || ''),

--- a/src/stores/summarizeStore.ts
+++ b/src/stores/summarizeStore.ts
@@ -35,6 +35,12 @@ interface SummarizeState {
   /** Depth from the END of history to inject the summary (999 = before all history). */
   injectionDepth: number;
   injectionRole: 'system' | 'user';
+  /**
+   * When true, drop messages already covered by the summary from the prompt
+   * history. Saves tokens by keeping ONLY the summary + post-summary turns,
+   * instead of duplicating coverage between summary and raw history.
+   */
+  compactWhenSummarized: boolean;
 
   // --- persisted data ---
   /** Keyed by chat file name (e.g. "character_2024-01-01@12:00:00.jsonl"). */
@@ -49,6 +55,7 @@ interface SummarizeState {
   setAutoTriggerEvery: (n: number) => void;
   setInjectionDepth: (d: number) => void;
   setInjectionRole: (r: 'system' | 'user') => void;
+  setCompactWhenSummarized: (on: boolean) => void;
   getSummary: (chatFile: string) => ChatSummary | null;
   clearSummary: (chatFile: string) => void;
   clearError: () => void;
@@ -112,6 +119,7 @@ export const useSummarizeStore = create<SummarizeState>()(
       autoTriggerEvery: 20,
       injectionDepth: 999,
       injectionRole: 'system',
+      compactWhenSummarized: true,
       summaries: {},
       isGenerating: false,
       error: null,
@@ -121,6 +129,7 @@ export const useSummarizeStore = create<SummarizeState>()(
         set({ autoTriggerEvery: Math.max(5, Math.min(100, Math.round(n))) }),
       setInjectionDepth: (d) => set({ injectionDepth: Math.max(0, Math.round(d)) }),
       setInjectionRole: (r) => set({ injectionRole: r }),
+      setCompactWhenSummarized: (on) => set({ compactWhenSummarized: on }),
 
       getSummary: (chatFile) => get().summaries[chatFile] ?? null,
 
@@ -138,7 +147,7 @@ export const useSummarizeStore = create<SummarizeState>()(
       },
       resetUser: () => {
         _currentHandle = null;
-        set({ autoSummarize: false, autoTriggerEvery: 20, injectionDepth: 999, injectionRole: 'system', summaries: {}, error: null });
+        set({ autoSummarize: false, autoTriggerEvery: 20, injectionDepth: 999, injectionRole: 'system', compactWhenSummarized: true, summaries: {}, error: null });
       },
 
       generateSummary: async (chatMessages, chatFile, characterName) => {
@@ -215,6 +224,7 @@ export const useSummarizeStore = create<SummarizeState>()(
         autoTriggerEvery: s.autoTriggerEvery,
         injectionDepth: s.injectionDepth,
         injectionRole: s.injectionRole,
+        compactWhenSummarized: s.compactWhenSummarized,
         summaries: s.summaries,
       }),
     }

--- a/src/stores/worldInfoStore.ts
+++ b/src/stores/worldInfoStore.ts
@@ -82,6 +82,12 @@ export interface WorldInfoBook {
    * selected. Null = a normal global book.
    */
   ownerCharacterAvatar: string | null;
+  /**
+   * True when entries are appended automatically by the auto-memory
+   * extraction pass. Surfaced in the editor so the user can tell
+   * hand-curated lore from machine-extracted notes.
+   */
+  autoExtracted?: boolean;
   createdAt: number;
   updatedAt: number;
 }


### PR DESCRIPTION
## Summary

Three stacking features that reduce token usage in long chats while keeping the model informed. Each is opt-in.

**1. Summary compaction** — when a chat already has a generated summary, drop the messages that summary covers from the prompt history. Replace N raw turns with the 2-4 sentence summary already injected by the summarize extension. Toggle in summarize settings (default ON when summary exists).

**2. Chat-history RAG** — new \`chatHistoryRagStore\` embeds older non-tail chat turns using the existing OpenAI embeddings key. \`resolveRagContext\` now queries Data Bank + chat history in parallel. Lets the model recall specific past moments by relevance. Toggle in DataBankPage (default OFF — costs API calls).

**3. Auto-extracted facts to lorebook** — new \`autoMemoryStore\` + \`autoMemory\` extension. Every N messages the active model extracts canonical facts as JSON; new facts are appended to a per-character \"{Name} — Auto Memory\" lorebook. Dedup is content-prefix based for v1. Default OFF.

The three stack: compaction collapses bulk history → RAG retrieves specific past moments by relevance → auto-memory grows persistent lorebook over time.

## Test plan

- [ ] **Compaction**: generate a summary on a long chat (15+ turns); verify pre-summary turns disappear from the LLM context (check network tab payload). Toggle off → raw history returns.
- [ ] **Chat-history RAG**: enable in DataBankPage with API key set; play a chat past 10+ messages; verify embeddings counter rises. Send a query referencing an older turn → check \`[Earlier in chat]\` block appears in injected ragContext.
- [ ] **Auto-memory**: enable extension + setting; play 30+ messages with named entities/decisions; check that a \"{Char} — Auto Memory\" lorebook is created with extracted entries.
- [ ] **Stacking**: all three on simultaneously — confirm no double-counting; summary covers early, RAG picks specific moments, auto-memory grows.
- [ ] **Defaults**: fresh user sees nothing different — all three features default OFF (compaction defaults ON only kicks in once summary exists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)