### PR TITLE
feat(image-gen): dynamic Pollinations models + AI Horde backend

### DIFF
--- a/src/api/imageGenApi.ts
+++ b/src/api/imageGenApi.ts
@@ -2,7 +2,17 @@ import { apiRequest } from './client';
 import { api } from './client';
 import { useSettingsStore } from '../stores/settingsStore';
 
-export type ImageGenBackend = 'pollinations' | 'sdwebui' | 'dalle';
+export type ImageGenBackend = 'pollinations' | 'horde' | 'sdwebui' | 'dalle';
+
+export interface HordeModelInfo {
+  name: string;
+  /** Number of workers currently serving this model. */
+  count: number;
+  /** Pending jobs queued for this model. */
+  queued: number;
+  /** Estimated wait time in seconds. */
+  eta: number;
+}
 
 export interface ImageGenResult {
   /** Raw base64 string — no data URI prefix. */
@@ -88,13 +98,86 @@ export const imageGenApi = {
       body: JSON.stringify({
         prompt: opts.prompt,
         negative_prompt: opts.negativePrompt,
-        model: opts.model ?? 'flux',
+        // 'sana' is the only model the legacy anonymous endpoint serves
+        // as of 2026-04 — Pollinations silently downgrades anything else.
+        // Caller can still override via the Settings dropdown if a model
+        // name returned by the live /models endpoint changes.
+        model: opts.model ?? 'sana',
         width: opts.width ?? 1024,
         height: opts.height ?? 1024,
         seed: -1,
       }),
     });
     return { base64: result.image, format: 'jpg' };
+  },
+
+  /**
+   * Fetch the live list of Pollinations model names. Returns a fallback
+   * single-element array on failure so the UI dropdown is never empty.
+   */
+  async getPollinationsModels(): Promise<string[]> {
+    try {
+      const result = await apiRequest<unknown>('/api/sd/pollinations/models', {
+        method: 'POST',
+        body: '{}',
+      });
+      if (Array.isArray(result)) {
+        const names = result.filter((m): m is string => typeof m === 'string');
+        if (names.length > 0) return names;
+      }
+    } catch {
+      // fall through to fallback
+    }
+    return ['sana'];
+  },
+
+  /**
+   * Fetch popular AI Horde image models, sorted by worker count.
+   * Returns [] on failure — caller falls back to a hardcoded default.
+   */
+  async getHordeModels(): Promise<HordeModelInfo[]> {
+    try {
+      const result = await apiRequest<HordeModelInfo[]>('/api/sd/horde/models', {
+        method: 'POST',
+        body: '{}',
+      });
+      return Array.isArray(result) ? result : [];
+    } catch {
+      return [];
+    }
+  },
+
+  /**
+   * Generate via AI Horde. Backend handles the async enqueue + poll dance
+   * and returns the final base64 image. Anonymous key (0000000000) works
+   * but is slow; users can supply their own free key for higher priority.
+   */
+  async generateHorde(opts: {
+    prompt: string;
+    negativePrompt?: string;
+    model?: string;
+    width?: number;
+    height?: number;
+    steps?: number;
+    cfgScale?: number;
+    apiKey?: string;
+    nsfw?: boolean;
+  }): Promise<ImageGenResult> {
+    const result = await apiRequest<{ image: string }>('/api/sd/horde/generate', {
+      method: 'POST',
+      body: JSON.stringify({
+        prompt: opts.prompt,
+        negative_prompt: opts.negativePrompt,
+        model: opts.model ?? 'stable_diffusion',
+        width: opts.width ?? 512,
+        height: opts.height ?? 512,
+        steps: opts.steps ?? 25,
+        cfg_scale: opts.cfgScale ?? 7,
+        api_key: opts.apiKey || undefined,
+        nsfw: !!opts.nsfw,
+      }),
+    });
+    return { base64: result.image, format: 'webp' };
   },
 
   async generateSdWebui(opts: {

--- a/src/components/chat/ImageGenModal.tsx
+++ b/src/components/chat/ImageGenModal.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect } from 'react';
 import { X, Image, Settings2, ChevronDown, ChevronUp, Loader2, RefreshCw, Sparkles } from 'lucide-react';
 import { useImageGenStore } from '../../stores/imageGenStore';
-import { imageGenApi } from '../../api/imageGenApi';
+import { imageGenApi, type HordeModelInfo } from '../../api/imageGenApi';
 import { Button } from '../ui';
 import type { ImageGenBackend } from '../../api/imageGenApi';
 
@@ -18,13 +18,16 @@ interface ImageGenModalProps {
   characterName?: string;
 }
 
-const POLLINATIONS_MODELS = [
-  'flux',
-  'flux-realism',
-  'flux-cablyai',
-  'flux-anime',
-  'flux-3d',
-  'turbo',
+// Fallback used until the live /models fetch resolves (or if it errors).
+// Pollinations' anonymous endpoint really only serves "sana" today; the
+// dropdown will repopulate from the server-side list as soon as it loads.
+const POLLINATIONS_FALLBACK_MODELS = ['sana'];
+
+// Horde fallback when the dynamic models call hasn't returned yet — these
+// are a few perennial high-worker-count entries. Real list overrides as
+// soon as the fetch completes.
+const HORDE_FALLBACK_MODELS: HordeModelInfo[] = [
+  { name: 'stable_diffusion', count: 0, queued: 0, eta: 0 },
 ];
 
 const SIZE_PRESETS = [
@@ -61,6 +64,8 @@ export function ImageGenModal({
     sdUrl,
     sdAuth,
     pollinationsModel,
+    hordeModel,
+    hordeApiKey,
     dalleModel,
     dalleQuality,
     width,
@@ -80,6 +85,12 @@ export function ImageGenModal({
   const [showSettings, setShowSettings] = useState(false);
   const [result, setResult] = useState<string | null>(null);
   const [isGeneratingPrompt, setIsGeneratingPrompt] = useState(false);
+  const [pollinationsModels, setPollinationsModels] = useState<string[]>(
+    POLLINATIONS_FALLBACK_MODELS
+  );
+  const [hordeModels, setHordeModels] = useState<HordeModelInfo[]>(
+    HORDE_FALLBACK_MODELS
+  );
   const promptRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {
@@ -92,6 +103,22 @@ export function ImageGenModal({
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen]);
+
+  // Lazy-load model lists when their backend is selected. Both endpoints
+  // are cheap, but the calls are skipped entirely until the user actually
+  // visits Pollinations or Horde.
+  useEffect(() => {
+    if (!isOpen) return;
+    if (backend === 'pollinations') {
+      void imageGenApi.getPollinationsModels().then((models) => {
+        if (models.length > 0) setPollinationsModels(models);
+      });
+    } else if (backend === 'horde') {
+      void imageGenApi.getHordeModels().then((models) => {
+        if (models.length > 0) setHordeModels(models);
+      });
+    }
+  }, [isOpen, backend]);
 
   if (!isOpen) return null;
 
@@ -265,6 +292,7 @@ export function ImageGenModal({
                   className="w-full bg-[var(--color-bg-secondary)] border border-[var(--color-border)] rounded-lg px-2 py-1.5 text-sm text-[var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]/40"
                 >
                   <option value="pollinations">Pollinations (free, no setup)</option>
+                  <option value="horde">AI Horde (free, distributed)</option>
                   <option value="sdwebui">SD WebUI (local)</option>
                   <option value="dalle">OpenAI DALL-E (requires API key)</option>
                 </select>
@@ -281,11 +309,102 @@ export function ImageGenModal({
                     onChange={(e) => setConfig({ pollinationsModel: e.target.value })}
                     className="w-full bg-[var(--color-bg-secondary)] border border-[var(--color-border)] rounded-lg px-2 py-1.5 text-sm text-[var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]/40"
                   >
-                    {POLLINATIONS_MODELS.map((m) => (
+                    {pollinationsModels.map((m) => (
                       <option key={m} value={m}>{m}</option>
                     ))}
+                    {!pollinationsModels.includes(pollinationsModel) && (
+                      <option value={pollinationsModel}>{pollinationsModel} (custom)</option>
+                    )}
                   </select>
                 </div>
+              )}
+
+              {/* Horde settings */}
+              {backend === 'horde' && (
+                <>
+                  <div>
+                    <label className="block text-xs font-medium text-[var(--color-text-secondary)] mb-1">
+                      Model
+                      <span className="ml-1 text-[10px] text-zinc-500 font-normal">
+                        (sorted by available workers)
+                      </span>
+                    </label>
+                    <select
+                      value={hordeModel}
+                      onChange={(e) => setConfig({ hordeModel: e.target.value })}
+                      className="w-full bg-[var(--color-bg-secondary)] border border-[var(--color-border)] rounded-lg px-2 py-1.5 text-sm text-[var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]/40"
+                    >
+                      {hordeModels.map((m) => (
+                        <option key={m.name} value={m.name}>
+                          {m.name}{m.count > 0 ? ` — ${m.count} worker${m.count === 1 ? '' : 's'}` : ''}
+                        </option>
+                      ))}
+                      {!hordeModels.find((m) => m.name === hordeModel) && (
+                        <option value={hordeModel}>{hordeModel} (custom)</option>
+                      )}
+                    </select>
+                  </div>
+                  <div>
+                    <label className="block text-xs font-medium text-[var(--color-text-secondary)] mb-1">
+                      API Key
+                      <span className="ml-1 text-[10px] text-zinc-500 font-normal">
+                        (optional — leave blank for anonymous)
+                      </span>
+                    </label>
+                    <input
+                      type="password"
+                      value={hordeApiKey}
+                      onChange={(e) => setConfig({ hordeApiKey: e.target.value })}
+                      placeholder="0000000000 (anonymous)"
+                      className="w-full bg-[var(--color-bg-secondary)] border border-[var(--color-border)] rounded-lg px-2 py-1.5 text-sm text-[var(--color-text-primary)] placeholder-zinc-500 focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]/40"
+                    />
+                    <p className="text-[10px] text-zinc-500 mt-1 leading-snug">
+                      Free key registration at{' '}
+                      <a
+                        href="https://aihorde.net"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-[var(--color-primary)] hover:underline"
+                      >
+                        aihorde.net
+                      </a>
+                      {' '}— gives you priority over anonymous requests.
+                    </p>
+                  </div>
+                  <div className="grid grid-cols-2 gap-2">
+                    <div>
+                      <label className="block text-xs font-medium text-[var(--color-text-secondary)] mb-1">
+                        Steps
+                      </label>
+                      <input
+                        type="number"
+                        min={1}
+                        max={50}
+                        value={steps}
+                        onChange={(e) =>
+                          setConfig({ steps: Math.max(1, Math.min(50, parseInt(e.target.value) || 25)) })
+                        }
+                        className="w-full bg-[var(--color-bg-secondary)] border border-[var(--color-border)] rounded-lg px-2 py-1.5 text-sm text-[var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]/40"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-xs font-medium text-[var(--color-text-secondary)] mb-1">
+                        CFG Scale
+                      </label>
+                      <input
+                        type="number"
+                        min={1}
+                        max={30}
+                        step={0.5}
+                        value={cfgScale}
+                        onChange={(e) =>
+                          setConfig({ cfgScale: Math.max(1, Math.min(30, parseFloat(e.target.value) || 7)) })
+                        }
+                        className="w-full bg-[var(--color-bg-secondary)] border border-[var(--color-border)] rounded-lg px-2 py-1.5 text-sm text-[var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]/40"
+                      />
+                    </div>
+                  </div>
+                </>
               )}
 
               {/* DALL-E settings */}

--- a/src/components/settings/GalleryPage.tsx
+++ b/src/components/settings/GalleryPage.tsx
@@ -13,6 +13,7 @@ function formatDate(ts: number): string {
 function backendLabel(backend: string): string {
   switch (backend) {
     case 'pollinations': return 'Pollinations';
+    case 'horde': return 'AI Horde';
     case 'sdwebui': return 'SD WebUI';
     case 'dalle': return 'DALL-E';
     default: return backend;

--- a/src/stores/imageGenStore.ts
+++ b/src/stores/imageGenStore.ts
@@ -25,6 +25,10 @@ interface ImageGenConfig {
   sdUrl: string;
   sdAuth: string;
   pollinationsModel: string;
+  /** Selected AI Horde model (e.g. "Flux.1-Schnell fp8 (Compact)"). */
+  hordeModel: string;
+  /** Optional Horde API key — empty string falls back to the anonymous key. */
+  hordeApiKey: string;
   dalleModel: 'dall-e-3' | 'dall-e-2';
   dalleQuality: 'standard' | 'hd';
   width: number;
@@ -37,7 +41,11 @@ const DEFAULT_CONFIG: ImageGenConfig = {
   backend: 'pollinations',
   sdUrl: 'http://localhost:7860',
   sdAuth: '',
-  pollinationsModel: 'flux',
+  // 'sana' is what Pollinations' anonymous endpoint actually serves now;
+  // older 'flux*' values get silently downgraded but render the same.
+  pollinationsModel: 'sana',
+  hordeModel: 'stable_diffusion',
+  hordeApiKey: '',
   dalleModel: 'dall-e-3',
   dalleQuality: 'standard',
   width: 1024,
@@ -130,6 +138,8 @@ export const useImageGenStore = create<ImageGenState>((set, get) => ({
         sdUrl: next.sdUrl,
         sdAuth: next.sdAuth,
         pollinationsModel: next.pollinationsModel,
+        hordeModel: next.hordeModel,
+        hordeApiKey: next.hordeApiKey,
         dalleModel: next.dalleModel,
         dalleQuality: next.dalleQuality,
         width: next.width,
@@ -144,7 +154,7 @@ export const useImageGenStore = create<ImageGenState>((set, get) => ({
 
   generate: async (prompt, negativePrompt) => {
     const {
-      backend, sdUrl, sdAuth, pollinationsModel,
+      backend, sdUrl, sdAuth, pollinationsModel, hordeModel, hordeApiKey,
       dalleModel, dalleQuality, width, height, steps, cfgScale,
     } = get();
     set({ isGenerating: true, error: null });
@@ -160,6 +170,17 @@ export const useImageGenStore = create<ImageGenState>((set, get) => ({
           height,
           steps,
           cfgScale,
+        });
+      } else if (backend === 'horde') {
+        result = await imageGenApi.generateHorde({
+          prompt,
+          negativePrompt: negativePrompt || undefined,
+          model: hordeModel,
+          width,
+          height,
+          steps,
+          cfgScale,
+          apiKey: hordeApiKey || undefined,
         });
       } else if (backend === 'dalle') {
         const size = nearestDalleSize(width, height, dalleModel);


### PR DESCRIPTION
## Summary

Pairs with [SillyTavern fork PR #17](https://github.com/sammygallo/SillyTavern/pull/17) which fixes Pollinations and adds AI Horde routes.

- **Pollinations:** replace hardcoded 6-model list with a live fetch from \`/api/sd/pollinations/models\` (their anonymous endpoint only serves \`sana\` now; the dropdown adapts as their list changes). Default model bumped from \`flux\` to \`sana\` so existing users don't keep an invalid selection.
- **AI Horde:** new \"Free, distributed\" option in the backend dropdown. Settings panel shows a model picker (sorted by worker count, fetched live), optional API key (anonymous works), steps, and CFG scale.
- **Gallery badge:** added \"AI Horde\" label.

## Test plan

- [ ] Pollinations: select backend, generate \"a cat\" → image returns
- [ ] Pollinations: model dropdown populates from live fetch
- [ ] AI Horde: select backend, no API key, generate \"a cat\" → image returns within ~30-90s (anonymous queue is slow)
- [ ] AI Horde: paste a real key from aihorde.net → faster turnaround
- [ ] AI Horde: model picker shows worker counts
- [ ] Gallery: Horde-generated images get \"AI Horde\" badge
- [ ] Existing users with old \`flux\` selection continue to work (Pollinations silently downgrades to \`sana\` server-side)

🤖 Generated with [Claude Code](https://claude.com/claude-code)