### PR TITLE
fix(extensions): load manifests via static path; honor js/css fields

### DIFF
--- a/src/api/extensionsApi.ts
+++ b/src/api/extensionsApi.ts
@@ -26,6 +26,13 @@ export interface ExtensionManifestData {
   slash_commands?: SlashCommandDeclaration[];
   /** When true, the extension exposes a POST /api/plugins/<name>/generate-interceptors endpoint. */
   generate_interceptor?: boolean;
+  /**
+   * Entry script(s) loaded into the iframe sandbox, relative to the extension folder.
+   * String or array. Defaults to "index.js" when omitted.
+   */
+  js?: string | string[];
+  /** Stylesheet(s) loaded into the iframe sandbox, relative to the extension folder. */
+  css?: string | string[];
 }
 
 /** Entry shape from the SillyTavern-Content extensions.json registry. */
@@ -128,10 +135,22 @@ export const extensionsApi = {
     });
   },
 
-  /** Fetch the manifest.json for an installed extension. */
-  async getManifest(extensionName: string, global?: boolean): Promise<ExtensionManifestData> {
-    const params = new URLSearchParams({ extensionName });
-    if (global) params.set('global', 'true');
-    return apiRequest<ExtensionManifestData>(`/api/extensions/manifest?${params}`);
+  /**
+   * Fetch the manifest.json for an installed extension.
+   *
+   * The upstream SillyTavern backend doesn't expose a JSON API for manifests —
+   * it only serves the raw file via its static-files mount at
+   * `/scripts/extensions/third-party/{name}/manifest.json`. We fetch that
+   * directly. The `global` flag is accepted for forward compatibility but
+   * unused: both local and global third-party extensions are served from the
+   * same URL prefix on the backend.
+   */
+  async getManifest(extensionName: string, _global?: boolean): Promise<ExtensionManifestData> {
+    const url = `/scripts/extensions/third-party/${extensionName}/manifest.json`;
+    const response = await fetch(url, { credentials: 'include' });
+    if (!response.ok) {
+      throw new Error(`manifest.json not found (HTTP ${response.status})`);
+    }
+    return response.json();
   },
 };

--- a/src/components/settings/ServerExtensionsSection.tsx
+++ b/src/components/settings/ServerExtensionsSection.tsx
@@ -248,6 +248,7 @@ function InstalledCard({
             <ExtensionFrame
               extensionName={ext.name}
               scriptUrl={scriptUrl}
+              manifest={manifest}
               onHasContent={(yes) => setHasUi(yes)}
             />
           </div>

--- a/src/extensions/sandbox/ExtensionFrame.tsx
+++ b/src/extensions/sandbox/ExtensionFrame.tsx
@@ -39,6 +39,7 @@ import {
   type PopupType,
   type PopupOptions,
 } from '../../stores/extensionPopupStore';
+import type { ExtensionManifestData } from '../../api/extensionsApi';
 
 let _frameSeq = 0;
 
@@ -50,10 +51,17 @@ export interface ExtensionFrameProps {
   /** Extension name as returned by the discovery API, e.g. "third-party/my-ext". */
   extensionName: string;
   /**
-   * URL of the extension's index.js served by the ST backend.
-   * Typically /scripts/extensions/third-party/{name}/index.js
+   * URL of the extension's default entry script served by the ST backend.
+   * Typically /scripts/extensions/third-party/{name}/index.js. Used as a
+   * fallback when the manifest doesn't declare a `js` field.
    */
   scriptUrl: string;
+  /**
+   * Parsed manifest.json for this extension. When provided, `js` and `css`
+   * fields are honored to load additional scripts and stylesheets into the
+   * sandbox iframe. When omitted, only `scriptUrl` runs.
+   */
+  manifest?: ExtensionManifestData;
   /** Optional extra CSS classes on the iframe wrapper div. */
   className?: string;
   /** Called with true the first time the iframe reports non-zero content. */
@@ -114,9 +122,49 @@ function buildContextSnapshot() {
 // srcdoc builder
 // ---------------------------------------------------------------------------
 
-function buildSrcdoc(scriptUrl: string): string {
-  // Escape the URL for safe insertion into an HTML attribute
-  const safeUrl = scriptUrl.replace(/"/g, '%22').replace(/</g, '%3C').replace(/>/g, '%3E');
+/** Escape a URL for safe use inside an HTML attribute. */
+function escapeAttrUrl(url: string): string {
+  return url.replace(/"/g, '%22').replace(/</g, '%3C').replace(/>/g, '%3E');
+}
+
+/** Coerce a manifest field that may be string | string[] | undefined into an array. */
+function asArray(v: string | string[] | undefined): string[] {
+  if (!v) return [];
+  return Array.isArray(v) ? v : [v];
+}
+
+/** Resolve a manifest-relative asset path to a backend-served URL. */
+function resolveAssetUrl(extensionName: string, assetPath: string): string {
+  if (/^https?:\/\//i.test(assetPath) || assetPath.startsWith('/')) return assetPath;
+  const base = extensionName.replace(/^third-party\//, '');
+  return `/scripts/extensions/third-party/${base}/${assetPath.replace(/^\.\/+/, '')}`;
+}
+
+/**
+ * Build the iframe srcdoc.
+ *
+ * Script load order:
+ *   1. shim (inline)
+ *   2. manifest.js scripts in declared order — OR fallbackScriptUrl if manifest.js is empty
+ *
+ * Stylesheet load order:
+ *   1. base iframe styles (inline)
+ *   2. manifest.css stylesheets in declared order
+ */
+function buildSrcdoc(
+  extensionName: string,
+  fallbackScriptUrl: string,
+  manifest?: ExtensionManifestData,
+): string {
+  const jsList = asArray(manifest?.js);
+  const cssList = asArray(manifest?.css);
+
+  const scriptUrls = (jsList.length > 0 ? jsList.map((p) => resolveAssetUrl(extensionName, p)) : [fallbackScriptUrl])
+    .map(escapeAttrUrl);
+  const styleUrls = cssList.map((p) => escapeAttrUrl(resolveAssetUrl(extensionName, p)));
+
+  const scriptTags = scriptUrls.map((u) => `<script src="${u}"></script>`).join('\n');
+  const styleTags = styleUrls.map((u) => `<link rel="stylesheet" href="${u}">`).join('\n');
 
   return `<!DOCTYPE html>
 <html>
@@ -138,13 +186,14 @@ function buildSrcdoc(scriptUrl: string): string {
     font-size: inherit;
   }
 </style>
+${styleTags}
 <script>${SHIM_CODE}</script>
 </head>
 <body>
 <div id="extensions_settings" class="extensions_settings"></div>
 <div id="send_form" style="display:none"></div>
 <div id="chat" style="display:none"></div>
-<script src="${safeUrl}"></script>
+${scriptTags}
 </body>
 </html>`;
 }
@@ -156,6 +205,7 @@ function buildSrcdoc(scriptUrl: string): string {
 export function ExtensionFrame({
   extensionName,
   scriptUrl,
+  manifest,
   className,
   onHasContent,
   allowSlots = false,
@@ -326,10 +376,12 @@ export function ExtensionFrame({
 
   // ── Build srcdoc once ─────────────────────────────────────────────────────
   // We use a ref so the srcdoc doesn't change on re-renders (which would cause
-  // the iframe to reload).
+  // the iframe to reload). Callers that need to react to a late-arriving
+  // manifest should remount this component via a key change rather than
+  // mutating the manifest prop after first render.
   const srcdocRef = useRef<string | null>(null);
   if (srcdocRef.current === null) {
-    srcdocRef.current = buildSrcdoc(scriptUrl);
+    srcdocRef.current = buildSrcdoc(extensionName, scriptUrl, manifest);
   }
 
   return (

--- a/src/extensions/sandbox/GlobalExtensionHost.tsx
+++ b/src/extensions/sandbox/GlobalExtensionHost.tsx
@@ -21,6 +21,8 @@ function extensionScriptUrl(extName: string): string {
  */
 export function GlobalExtensionHost() {
   const installed = useServerExtensionStore((s) => s.installed);
+  const manifests = useServerExtensionStore((s) => s.manifests);
+  const noManifestExtensions = useServerExtensionStore((s) => s.noManifestExtensions);
   const fetchInstalled = useServerExtensionStore((s) => s.fetchInstalled);
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
 
@@ -29,6 +31,13 @@ export function GlobalExtensionHost() {
   }, [isAuthenticated, fetchInstalled]);
 
   if (!isAuthenticated) return null;
+
+  // Wait until manifest fetch has resolved (loaded or confirmed missing) before
+  // mounting an iframe. Mounting earlier and then re-keying when the manifest
+  // arrives would tear down any background state the extension built up.
+  const readyExtensions = installed.filter(
+    (ext) => manifests[ext.name] !== undefined || noManifestExtensions.has(ext.name),
+  );
 
   return (
     <div
@@ -42,11 +51,12 @@ export function GlobalExtensionHost() {
         visibility: 'hidden',
       }}
     >
-      {installed.map((ext) => (
+      {readyExtensions.map((ext) => (
         <ExtensionFrame
           key={ext.name}
           extensionName={ext.name}
           scriptUrl={extensionScriptUrl(ext.name)}
+          manifest={manifests[ext.name]}
           allowSlots
         />
       ))}


### PR DESCRIPTION
## Summary
- The mobile app's `extensionsApi.getManifest()` called `GET /api/extensions/manifest`, which doesn't exist in upstream SillyTavern's backend — every call 404'd, so `manifests[ext.name]` was permanently empty for every installed third-party extension. Switched to fetching the static `manifest.json` file the backend already serves at `/scripts/extensions/third-party/{name}/manifest.json`.
- With manifests actually loading, the iframe sandbox now also honors the upstream `js` and `css` manifest fields: declared stylesheets are injected as `<link>` tags and additional entry scripts as `<script>` tags. Classic-script extensions like Lovense Cloud now render with their styling instead of unstyled.
- `GlobalExtensionHost` now waits for manifest readiness (loaded **or** confirmed missing) before mounting each iframe, so an iframe doesn't get torn down a tick later when the manifest arrives — that would have killed any background state the extension built up.

## What this does NOT fix

ES-module-based extensions (Live2D, expressions, gallery, etc.) still don't run. Their `index.js` files start with `import` statements pointing at upstream's monolithic `script.js` / `extensions.js` / `slash-commands.js`. Loading them as classic scripts makes the imports a syntax error and the script silently never executes. Fix needs `type="module"` on the entry tag plus an import map redirecting upstream specifiers to mobile-fork shim modules — tracked as a separate task.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Dev preview boots without console or server errors
- [x] Verified manifest fetch: store now populates `manifests['third-party/Extension-Live2d']` with the real `{js, css, display_name, ...}` payload
- [x] Verified network: iframe requests `/scripts/extensions/third-party/Extension-Live2d/style.css` (200 OK) on mount
- [x] Verified Lovense Cloud iframe still loads and logs `[Lovense] UI Loaded Successfully.`
- [ ] Manual smoke test on a deployed environment with a logged-in user, confirming the Lovense Cloud settings panel is now styled