### PR TITLE
feat(extensions): ES-module sandbox compat for upstream extensions

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -51,6 +51,37 @@ server {
         proxy_set_header X-Forwarded-For 127.0.0.1;
     }
 
+    # Upstream-compat shim modules — these MUST take precedence over the
+    # generic /scripts/ proxy below. They shadow the canonical upstream
+    # filenames so ES-module-based extensions can `import { ... } from
+    # '../../../extensions.js'` and resolve to the mobile-fork shim instead
+    # of dragging in upstream SillyTavern's monolithic frontend.
+    # `location =` is an exact-match rule and beats prefix matches.
+    location = /scripts/extensions.js {
+        try_files $uri =404;
+        types { application/javascript js; }
+        default_type application/javascript;
+    }
+    location = /scripts/slash-commands.js {
+        try_files $uri =404;
+        types { application/javascript js; }
+        default_type application/javascript;
+    }
+    location = /scripts/utils.js {
+        try_files $uri =404;
+        types { application/javascript js; }
+        default_type application/javascript;
+    }
+    # /script.js (singular) is at the root, not under /scripts/, so it
+    # already falls through to static + the SPA fallback. The exact-match
+    # rule below disables the SPA fallback so the public/script.js shim is
+    # actually served instead of getting rewritten to index.html.
+    location = /script.js {
+        try_files $uri =404;
+        types { application/javascript js; }
+        default_type application/javascript;
+    }
+
     # Serves third-party extension scripts loaded by the sandboxed
     # ExtensionFrame iframes. Without this, /scripts/extensions/... falls
     # through to the SPA index.html and the iframe silently gets HTML

--- a/public/script.js
+++ b/public/script.js
@@ -1,0 +1,28 @@
+// Upstream-compat shim — served at /script.js for ES-module-style upstream
+// extensions whose imports resolve to this path (e.g.
+// `import { eventSource } from '../../../../script.js'`). Backed by the
+// iframe-window globals injected by extensionShim.ts.
+//
+// This file is loaded ONLY inside the sandboxed extension iframe, where the
+// shim has already populated `window.eventSource`, `window.event_types`, etc.
+// before any module is fetched. Outside the iframe (i.e. if a parent-page
+// script were to import this), the exports would be undefined, which is
+// expected — nothing in the mobile app should reach for these.
+const w = window;
+
+export const eventSource = w.eventSource;
+export const event_types = w.event_types;
+export const getCharacters = w.getCharacters;
+export const saveSettingsDebounced = w.saveSettingsDebounced;
+export const saveSettings = w.saveSettings;
+export const getRequestHeaders = w.getRequestHeaders;
+export const callPopup = w.callPopup;
+export const callGenericPopup = w.callGenericPopup;
+export const sendMessageAsUser = w.sendMessageAsUser;
+
+// Legacy direct-name globals some extensions read instead of getCharacters().
+export const characters = w.characters;
+export const name1 = w.name1;
+export const name2 = w.name2;
+export const this_chid = w.this_chid;
+export const chat = w.chat;

--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -1,0 +1,21 @@
+// Upstream-compat shim — served at /scripts/extensions.js for ES-module-style
+// upstream extensions whose imports resolve to this path. Backed by globals
+// injected into the iframe by extensionShim.ts.
+const w = window;
+
+export const extension_settings = w.extension_settings;
+export const ModuleWorkerWrapper = w.ModuleWorkerWrapper;
+export const renderExtensionTemplate = w.renderExtensionTemplate;
+export const renderExtensionTemplateAsync = w.renderExtensionTemplateAsync;
+
+// Extras (the python sidecar) is not implemented on mobile — extensions that
+// rely on doExtrasFetch/getApiUrl will get clear runtime errors when they try.
+export const getApiUrl = w.getApiUrl;
+export const doExtrasFetch = w.doExtrasFetch;
+export const modules = w.modules;
+
+// getContext is a function (not a snapshot) — re-export the live binding so
+// each call returns the iframe's current context.
+export function getContext() {
+  return w.SillyTavern.getContext();
+}

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -1,0 +1,6 @@
+// Upstream-compat shim — served at /scripts/slash-commands.js for
+// ES-module-style upstream extensions whose imports resolve to this path.
+// Backed by the iframe-window registerSlashCommand helper from extensionShim.ts.
+const w = window;
+
+export const registerSlashCommand = w.registerSlashCommand;

--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -1,0 +1,9 @@
+// Upstream-compat shim — served at /scripts/utils.js for ES-module-style
+// upstream extensions whose imports resolve to this path. Backed by the
+// iframe-window helpers from extensionShim.ts (loadFileToDocument and the
+// trim utilities ported from upstream public/scripts/utils.js).
+const w = window;
+
+export const loadFileToDocument = w.loadFileToDocument;
+export const trimToEndSentence = w.trimToEndSentence;
+export const trimToStartSentence = w.trimToStartSentence;

--- a/src/extensions/sandbox/ExtensionFrame.tsx
+++ b/src/extensions/sandbox/ExtensionFrame.tsx
@@ -140,6 +140,42 @@ function resolveAssetUrl(extensionName: string, assetPath: string): string {
   return `/scripts/extensions/third-party/${base}/${assetPath.replace(/^\.\/+/, '')}`;
 }
 
+type ScriptType = 'classic' | 'module';
+
+/**
+ * Detect whether an entry script is an ES module by fetching its source and
+ * looking for top-level `import` / `export` statements. Cached per URL across
+ * the session because the answer is stable for the lifetime of an extension
+ * install — repeat detection would just waste a network round-trip.
+ *
+ * Falls back to 'classic' on any fetch error so a misbehaving network can't
+ * permanently lock an extension out of mounting.
+ */
+const _scriptTypeCache = new Map<string, ScriptType>();
+
+async function detectScriptType(url: string): Promise<ScriptType> {
+  const cached = _scriptTypeCache.get(url);
+  if (cached) return cached;
+  try {
+    const response = await fetch(url, { credentials: 'include' });
+    if (!response.ok) {
+      _scriptTypeCache.set(url, 'classic');
+      return 'classic';
+    }
+    const source = await response.text();
+    // Multiline mode: match `import` / `export` at the start of any line,
+    // followed by a non-identifier character so we don't false-positive on
+    // identifiers like `importantThing`.
+    const isModule = /^[ \t]*(?:import|export)(?![a-zA-Z0-9_$])/m.test(source);
+    const result: ScriptType = isModule ? 'module' : 'classic';
+    _scriptTypeCache.set(url, result);
+    return result;
+  } catch {
+    _scriptTypeCache.set(url, 'classic');
+    return 'classic';
+  }
+}
+
 /**
  * Build the iframe srcdoc.
  *
@@ -150,11 +186,18 @@ function resolveAssetUrl(extensionName: string, assetPath: string): string {
  * Stylesheet load order:
  *   1. base iframe styles (inline)
  *   2. manifest.css stylesheets in declared order
+ *
+ * `scriptType` controls the `type` attribute on the entry-point script tag.
+ * 'module' lets ES-module-style upstream extensions (Live2D etc.) parse their
+ * top-level `import` statements; 'classic' preserves the legacy globals-leaking
+ * semantics that pre-module extensions like Lovense Cloud rely on. Detection
+ * happens before this is called — see {@link detectScriptType}.
  */
 function buildSrcdoc(
   extensionName: string,
   fallbackScriptUrl: string,
-  manifest?: ExtensionManifestData,
+  manifest: ExtensionManifestData | undefined,
+  scriptType: ScriptType,
 ): string {
   const jsList = asArray(manifest?.js);
   const cssList = asArray(manifest?.css);
@@ -163,7 +206,8 @@ function buildSrcdoc(
     .map(escapeAttrUrl);
   const styleUrls = cssList.map((p) => escapeAttrUrl(resolveAssetUrl(extensionName, p)));
 
-  const scriptTags = scriptUrls.map((u) => `<script src="${u}"></script>`).join('\n');
+  const typeAttr = scriptType === 'module' ? ' type="module"' : '';
+  const scriptTags = scriptUrls.map((u) => `<script${typeAttr} src="${u}"></script>`).join('\n');
   const styleTags = styleUrls.map((u) => `<link rel="stylesheet" href="${u}">`).join('\n');
 
   return `<!DOCTYPE html>
@@ -190,7 +234,15 @@ ${styleTags}
 <script>${SHIM_CODE}</script>
 </head>
 <body>
+<!--
+  Upstream ST has two separate settings containers: #extensions_settings for
+  internal/built-in extensions (e.g. Lovense Cloud appends here) and
+  #extensions_settings2 for third-party extensions (Live2D, etc.). Provide
+  both so extensions of either flavor mount their UI without us having to
+  know which container they target.
+-->
 <div id="extensions_settings" class="extensions_settings"></div>
+<div id="extensions_settings2" class="extensions_settings"></div>
 <div id="send_form" style="display:none"></div>
 <div id="chat" style="display:none"></div>
 ${scriptTags}
@@ -374,15 +426,30 @@ export function ExtensionFrame({
     };
   }, [allowSlots, frameId]);
 
-  // ── Build srcdoc once ─────────────────────────────────────────────────────
-  // We use a ref so the srcdoc doesn't change on re-renders (which would cause
-  // the iframe to reload). Callers that need to react to a late-arriving
-  // manifest should remount this component via a key change rather than
-  // mutating the manifest prop after first render.
-  const srcdocRef = useRef<string | null>(null);
-  if (srcdocRef.current === null) {
-    srcdocRef.current = buildSrcdoc(extensionName, scriptUrl, manifest);
-  }
+  // ── Build srcdoc once detection completes ─────────────────────────────────
+  // Detection is async (we fetch the entry script and check for `import` /
+  // `export` at line start) so srcdoc lives in state, not a sync ref. The
+  // iframe doesn't mount until detection resolves; subsequent renders keep
+  // the same srcdoc to avoid reload-on-rerender. Callers that need to react
+  // to a late-arriving manifest should remount via a key change.
+  const [srcdoc, setSrcdoc] = useState<string | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    // The first script in the load list is what we probe. If manifest.js is
+    // declared we use its first entry; otherwise scriptUrl is the entry.
+    const firstJs = asArray(manifest?.js)[0];
+    const probeUrl = firstJs ? resolveAssetUrl(extensionName, firstJs) : scriptUrl;
+    detectScriptType(probeUrl).then((scriptType) => {
+      if (cancelled) return;
+      setSrcdoc(buildSrcdoc(extensionName, scriptUrl, manifest, scriptType));
+    });
+    return () => {
+      cancelled = true;
+    };
+    // We intentionally only use the initial values — re-running on prop
+    // changes would tear down the iframe and lose extension state.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <div
@@ -395,20 +462,22 @@ export function ExtensionFrame({
         minHeight: 0,
       }}
     >
-      <iframe
-        ref={iframeRef}
-        // Use srcDoc (React's camelCase spelling)
-        srcDoc={srcdocRef.current}
-        sandbox="allow-scripts allow-same-origin allow-forms"
-        title={`Extension UI: ${extensionName}`}
-        style={{
-          width: '100%',
-          height: '100%',
-          border: 'none',
-          display: 'block',
-          background: 'transparent',
-        }}
-      />
+      {srcdoc !== null && (
+        <iframe
+          ref={iframeRef}
+          // Use srcDoc (React's camelCase spelling)
+          srcDoc={srcdoc}
+          sandbox="allow-scripts allow-same-origin allow-forms"
+          title={`Extension UI: ${extensionName}`}
+          style={{
+            width: '100%',
+            height: '100%',
+            border: 'none',
+            display: 'block',
+            background: 'transparent',
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/src/extensions/sandbox/extensionShim.ts
+++ b/src/extensions/sandbox/extensionShim.ts
@@ -415,6 +415,13 @@ export const SHIM_CODE: string = /* javascript */ `
       serialize: function () { return ''; },
     };
 
+    // Expose els as numeric indices so the jq object is array-like — required
+    // for Array.prototype.slice / spread / for-of to iterate it. Without this,
+    // _toHtml(jqObj) returns empty for jq-wrapped HTML, which breaks
+    // pattern: \$(htmlString) → target.append(\$wrapper).
+    for (var _i = 0; _i < els.length; _i++) jq[_i] = els[_i];
+    jq.toArray = function () { return Array.prototype.slice.call(els); };
+
     return jq;
   }
 
@@ -646,7 +653,159 @@ export const SHIM_CODE: string = /* javascript */ `
   window.saveSettingsDebounced = function () {
     _post({ type: 'ST_RPC', id: 'rpc_' + (++_seq), method: 'saveSettings', args: [] });
   };
+  window.saveSettings = window.saveSettingsDebounced;
   window.loadSettings = function () {};
+
+  // ── upstream module-shim back-ends ────────────────────────────────────────
+  // The /script.js, /scripts/extensions.js, /scripts/utils.js and
+  // /scripts/slash-commands.js shim modules served from the host re-export
+  // these globals so ES-module-style upstream extensions resolve their
+  // canonical specifiers without us shipping the full upstream monolith.
+
+  window.getCharacters = function () { return _ctx.characters; };
+
+  // Best-effort CSRF token cache. Filled on first call; same-origin fetch.
+  var _csrfToken = null;
+  function _refreshCsrf() {
+    try {
+      fetch('/csrf-token', { credentials: 'include' })
+        .then(function (r) { return r.ok ? r.json() : null; })
+        .then(function (j) { if (j && j.token) _csrfToken = j.token; })
+        .catch(function () {});
+    } catch (_) {}
+  }
+  _refreshCsrf();
+  window.getRequestHeaders = function () {
+    return {
+      'Content-Type': 'application/json',
+      'X-CSRF-Token': _csrfToken || '',
+      Accept: 'application/json',
+    };
+  };
+
+  window.sendMessageAsUser = function (text) {
+    return _rpc('sendMessageAsUser', [String(text || '')]);
+  };
+
+  // ModuleWorkerWrapper: tiny debounce-style runner upstream uses to coalesce
+  // re-entrant async work. Faithful enough for extension purposes.
+  window.ModuleWorkerWrapper = function ModuleWorkerWrapper(callback) {
+    var busy = false;
+    var queued = false;
+    function run() {
+      if (busy) { queued = true; return Promise.resolve(); }
+      busy = true;
+      return Promise.resolve()
+        .then(function () { return callback(); })
+        .catch(function (e) { try { console.error('[ModuleWorkerWrapper]', e); } catch (_) {} })
+        .then(function () {
+          busy = false;
+          if (queued) { queued = false; return run(); }
+        });
+    }
+    this.update = run;
+  };
+
+  // renderExtensionTemplate: fetch an HTML template from the extension folder
+  // and return its text. Upstream supports {{var}} substitution; we honor that
+  // with a minimal pass over the optional template-data object.
+  window.renderExtensionTemplate = function (extensionName, templateName, templateData, sanitize, localize) {
+    var url = '/scripts/extensions/third-party/' + extensionName + '/' + templateName + '.html';
+    // Some upstream call sites pass the full module path (e.g.
+    // 'third-party/Extension-Live2d'); strip the prefix so the URL is correct.
+    url = url.replace('/third-party/third-party/', '/third-party/');
+    return fetch(url, { credentials: 'include' }).then(function (r) {
+      if (!r.ok) throw new Error('Template not found: ' + url);
+      return r.text();
+    }).then(function (html) {
+      if (templateData && typeof templateData === 'object') {
+        Object.keys(templateData).forEach(function (k) {
+          html = html.split('{{' + k + '}}').join(String(templateData[k]));
+        });
+      }
+      return html;
+    });
+  };
+  window.renderExtensionTemplateAsync = window.renderExtensionTemplate;
+
+  // Extras (the python sidecar) is not implemented on mobile.
+  window.getApiUrl = function () { return ''; };
+  window.doExtrasFetch = function () {
+    return Promise.reject(new Error('Extras backend is not available on mobile.'));
+  };
+  window.modules = [];
+
+  window.registerSlashCommand = function (name, callback, aliases, helpText) {
+    try {
+      _post({
+        type: 'ST_REGISTER_SLASH_COMMAND',
+        name: String(name),
+        aliases: Array.isArray(aliases) ? aliases.map(String) : [],
+        helpText: String(helpText || ''),
+      });
+    } catch (_) {}
+    // Stash callback locally so future ST_INVOKE_SLASH_COMMAND can dispatch.
+    if (!window.__shimSlashCommands) window.__shimSlashCommands = {};
+    window.__shimSlashCommands[String(name).toLowerCase()] = callback;
+  };
+
+  window.loadFileToDocument = function (url, type) {
+    return new Promise(function (resolve, reject) {
+      var el;
+      if (type === 'css') {
+        el = document.createElement('link');
+        el.rel = 'stylesheet';
+        el.href = url;
+      } else if (type === 'js') {
+        el = document.createElement('script');
+        el.src = url;
+      } else {
+        reject(new Error('loadFileToDocument: invalid type ' + type));
+        return;
+      }
+      el.onload = resolve;
+      el.onerror = reject;
+      (type === 'css' ? document.head : document.body).appendChild(el);
+    });
+  };
+
+  // Text utilities ported from upstream public/scripts/utils.js so port
+  // extensions don't need to vendor them. Backslash-escape sequences in this
+  // block are doubled so the outer TypeScript template literal preserves them
+  // — e.g. source \\\\p becomes the JS source \\p which becomes the regex \\p
+  // in the running iframe. Single-\\ would be eaten by the template literal
+  // and the regex would fail to parse, taking down the entire shim IIFE.
+  window.trimToEndSentence = function (input) {
+    if (!input) return '';
+    var isEmoji = function (x) { return /(\\p{Emoji_Presentation}|\\p{Extended_Pictographic})/gu.test(x); };
+    var punct = { '.':1,'!':1,'?':1,'*':1,'"':1,')':1,'}':1,'\`':1,']':1,'$':1,'。':1,'！':1,'？':1,'”':1,'）':1,'】':1,'’':1,'」':1,'_':1 };
+    var last = -1;
+    var chars = Array.from(input);
+    for (var i = chars.length - 1; i >= 0; i--) {
+      var c = chars[i];
+      var em = isEmoji(c);
+      if (punct[c] || em) {
+        if (!em && i > 0 && /[\\s\\n]/.test(chars[i - 1])) last = i - 1; else last = i;
+        break;
+      }
+    }
+    if (last === -1) return input.trimEnd();
+    return chars.slice(0, last + 1).join('').trimEnd();
+  };
+  window.trimToStartSentence = function (input) {
+    if (!input) return '';
+    var p1 = input.indexOf('.');
+    var p2 = input.indexOf('!');
+    var p3 = input.indexOf('?');
+    var p4 = input.indexOf('\\n');
+    var first = p1;
+    var skip1 = false;
+    if (p2 > 0 && p2 < first) first = p2;
+    if (p3 > 0 && p3 < first) first = p3;
+    if (p4 > 0 && p4 < first) { first = p4; skip1 = true; }
+    if (first > 0) return skip1 ? input.substring(first + 1) : input.substring(first + 2);
+    return input;
+  };
 
   // ── SillyTavern global ────────────────────────────────────────────────────
   window.SillyTavern = {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,6 +31,24 @@ export default defineConfig({
       '/scripts': {
         target: BACKEND,
         changeOrigin: true,
+        // Specific upstream-compat shim modules served from public/ must NOT
+        // be proxied — they shadow upstream files of the same name so
+        // ES-module-based extensions can `import { ... } from '../../../...'`
+        // without dragging in the upstream monolith. Returning the request
+        // URL bypasses the proxy and lets Vite's static middleware serve the
+        // public/ copy.
+        bypass(req) {
+          const url = req.url || ''
+          const path = url.split('?')[0]
+          if (
+            path === '/scripts/extensions.js' ||
+            path === '/scripts/slash-commands.js' ||
+            path === '/scripts/utils.js'
+          ) {
+            return url
+          }
+          return undefined
+        },
       },
     },
   },


### PR DESCRIPTION
## Summary
- Adds ES-module support to the server-extension iframe sandbox so modern upstream SillyTavern extensions (Live2D, expressions, gallery, etc.) actually run instead of silently failing on their top-level \`import\` statements
- Ships four upstream-compat shim modules at \`/script.js\`, \`/scripts/extensions.js\`, \`/scripts/slash-commands.js\`, \`/scripts/utils.js\` that re-export iframe-window globals so canonical specifiers like \`from '../../../../script.js'\` resolve to mobile-fork code instead of dragging in upstream's monolithic frontend
- Detects ES-module vs classic-script per extension by fetching the entry source and pattern-matching for top-level \`import\`/\`export\` — classic-script extensions (Lovense Cloud) are unaffected and continue to load via globals-leaking semantics

Follow-up to [#121](https://github.com/sammygallo/sillytavern-mobile/pull/121) which fixed the manifest-loading layer.

## What's verified
- Live2D's \`#extensions_settings2\` container now contains ~25KB of rendered settings HTML (6 checkboxes, 16 selects, no console errors)
- Lovense Cloud still loads its own body-attached UI (\`[Lovense] UI Loaded Successfully.\`)
- \`npm run build\` (Docker-equivalent: \`tsc -b && vite build\`) is green
- Dev-preview iframe inspection confirms \`type=\"module\"\` on Live2D's entry, \`type=\"\"\` (classic) on Lovense's

## Out of scope
- Floating canvas overlay for actual Live2D model rendering over the chat view. Settings panel renders, but the canvas is still confined to the hidden global iframe. Positioning a model overlay needs a separate sandbox tier — tracked as future work.

## Two pre-existing shim bugs fixed in passing
Surfaced by the more demanding Live2D init path:
1. jq objects from \`$(htmlString)\` weren't array-like (no numeric indices), so \`target.append(\$('<div>...'))\` silently produced empty output
2. Srcdoc only had \`#extensions_settings\`; upstream third-party extensions append to \`#extensions_settings2\`

## Test plan
- [x] \`npm run build\` clean
- [x] Live2D extension's settings UI renders in the sandbox iframe
- [x] Lovense Cloud still loads (unchanged classic-script path)
- [x] No console errors from either iframe
- [ ] Manual smoke test on the deployed environment with a logged-in user opening Live2D's UI panel

Marking draft until manual smoke test on the deployed env is done. Let me know when you want me to undraft + ship.