### PR TITLE
feat(live-portrait): single-image AI animator replacing static avatars

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "highlight.js": "^11.11.1",
         "lucide-react": "^0.555.0",
         "marked": "^17.0.6",
+        "pixi.js": "^8.18.1",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-router-dom": "^7.9.6",
@@ -1018,6 +1019,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@pixi/colord": {
+      "version": "2.9.6",
+      "resolved": "https://registry.npmjs.org/@pixi/colord/-/colord-2.9.6.tgz",
+      "integrity": "sha512-nezytU2pw587fQstUu1AsJZDVEynjskwOL+kibwcdxsMBFqPsFFNA7xl0ii/gXuDi6M0xj3mfRJj8pBSc2jCfA==",
+      "license": "MIT"
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.47",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.47.tgz",
@@ -1650,6 +1657,12 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/earcut": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/earcut/-/earcut-3.0.0.tgz",
+      "integrity": "sha512-k/9fOUGO39yd2sCjrbAJvGDEQvRwRnQIZlBz43roGwUZo5SHAmyVvSFyaVVZkicRVCaDXPKlbxrUcBuJoSWunQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1995,6 +2008,21 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.69",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.69.tgz",
+      "integrity": "sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -2283,6 +2311,12 @@
         "@types/trusted-types": "^2.0.7"
       }
     },
+    "node_modules/earcut": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
+      "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
+      "license": "ISC"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.262",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.262.tgz",
@@ -2554,6 +2588,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2667,6 +2707,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/gifuct-js": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/gifuct-js/-/gifuct-js-2.1.2.tgz",
+      "integrity": "sha512-rI2asw77u0mGgwhV3qA+OEgYqaDn5UNqgs+Bx0FGwSpuqfYn+Ir6RQY5ENNQ8SbIiG/m5gVa7CD5RriO4f4Lsg==",
+      "license": "MIT",
+      "dependencies": {
+        "js-binary-schema-parser": "^2.0.3"
       }
     },
     "node_modules/glob-parent": {
@@ -2812,6 +2861,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/ismobilejs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ismobilejs/-/ismobilejs-1.1.1.tgz",
+      "integrity": "sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw==",
+      "license": "MIT"
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -2821,6 +2876,12 @@
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
+    },
+    "node_modules/js-binary-schema-parser": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/js-binary-schema-parser/-/js-binary-schema-parser-2.0.3.tgz",
+      "integrity": "sha512-xezGJmOb4lk/M1ZZLTR/jaBHQ4gG/lqQnJqdIv4721DMggsa1bDVlHXNeHYogaIEHD9vCRv0fcL4hMA+Coarkg==",
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -3354,6 +3415,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-svg-path": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.1.2.tgz",
+      "integrity": "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==",
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3393,6 +3460,32 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pixi.js": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-8.18.1.tgz",
+      "integrity": "sha512-6LUPWYgulZhp/w4kam2XHXB0QedISZIqrJbRdHLLQ3csn5a38uzKxAp6B5j6s89QFYaIJbg95kvgTRcbgpO1ow==",
+      "license": "MIT",
+      "workspaces": [
+        "examples",
+        "playground"
+      ],
+      "dependencies": {
+        "@pixi/colord": "^2.9.6",
+        "@types/earcut": "^3.0.0",
+        "@webgpu/types": "^0.1.69",
+        "@xmldom/xmldom": "^0.8.12",
+        "earcut": "^3.0.2",
+        "eventemitter3": "^5.0.1",
+        "gifuct-js": "^2.1.2",
+        "ismobilejs": "^1.1.1",
+        "parse-svg-path": "^0.1.2",
+        "tiny-lru": "^11.4.7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/pixijs"
       }
     },
     "node_modules/postcss": {
@@ -3667,6 +3760,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tiny-lru": {
+      "version": "11.4.7",
+      "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-11.4.7.tgz",
+      "integrity": "sha512-w/Te7uMUVeH0CR8vZIjr+XiN41V+30lkDdK+NRIDCUYKKuL9VcmaUEmaPISuwGhLlrTGh5yu18lENtR9axSxYw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/tinyglobby": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "highlight.js": "^11.11.1",
     "lucide-react": "^0.555.0",
     "marked": "^17.0.6",
+    "pixi.js": "^8.18.1",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-router-dom": "^7.9.6",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { ProfilePage } from './components/auth/ProfilePage';
 import { RequireRole } from './components/auth/RequireRole';
 import { MainLayout } from './components/layout/MainLayout';
 import { ChatView } from './components/chat/ChatView';
+import { LivePortraitDebug } from './components/chat/LivePortraitDebug';
 // Settings pages are now rendered inside the slide-in SettingsPanel (not routes).
 import { InviteAcceptPage } from './components/auth/InviteAcceptPage';
 import { ToastProvider } from './components/ui/Toast';
@@ -23,6 +24,7 @@ function App() {
         <Route path="/register" element={<RegisterPage />} />
         <Route path="/profile" element={<RequireRole minRole="end_user"><ProfilePage /></RequireRole>} />
         <Route path="/invite/:token" element={<InviteAcceptPage />} />
+        <Route path="/debug/live-portrait" element={<LivePortraitDebug />} />
         <Route path="/" element={<MainLayout />}>
           <Route index element={<ChatView />} />
           <Route path="chat/:characterId" element={<ChatView />} />

--- a/src/components/character/CharacterEdit.tsx
+++ b/src/components/character/CharacterEdit.tsx
@@ -8,6 +8,8 @@ import { spritesApi, type CharacterInfo } from '../../api/client';
 import { Modal, Button, Input, TextArea, ImageUpload, ExpressionUpload, TagInput } from '../ui';
 import { AlternateGreetingsEditor } from './AlternateGreetingsEditor';
 import { CharacterLorebookSection } from './CharacterLorebookSection';
+import { LivePortraitSetup } from './LivePortraitSetup';
+import { useLivePortraitStore } from '../../stores/livePortraitStore';
 
 interface CharacterEditProps {
   isOpen: boolean;
@@ -46,6 +48,8 @@ export function CharacterEdit({
   const visibility = ownershipStore.getVisibility(character.avatar);
   const [isTogglingVisibility, setIsTogglingVisibility] = useState(false);
   const [showExportMenu, setShowExportMenu] = useState(false);
+  const [showLivePortraitSetup, setShowLivePortraitSetup] = useState(false);
+  const livePortraitAnchors = useLivePortraitStore((s) => s.anchorsByAvatar[character.avatar]);
 
   const [avatarFile, setAvatarFile] = useState<File | null>(null);
   const [expressionFiles, setExpressionFiles] = useState<Map<string, File>>(new Map());
@@ -423,6 +427,36 @@ export function CharacterEdit({
           onExpressionsChange={setExpressionFiles}
         />
 
+        {/* Live Portrait — anchor placement for the in-chat animator */}
+        <div className="border border-[var(--color-border)] rounded-lg p-3 space-y-2">
+          <div className="flex items-center gap-2">
+            <p className="text-sm font-medium text-[var(--color-text-primary)] flex-1">
+              Live Portrait
+            </p>
+            {livePortraitAnchors ? (
+              <span className="text-[10px] px-1.5 py-0.5 rounded font-medium bg-violet-500/15 text-violet-400">
+                set up
+              </span>
+            ) : (
+              <span className="text-[10px] px-1.5 py-0.5 rounded font-medium bg-[var(--color-bg-tertiary)] text-[var(--color-text-secondary)]">
+                not set
+              </span>
+            )}
+          </div>
+          <p className="text-xs text-[var(--color-text-secondary)]">
+            Mark this character's eyes and mouth so they can breathe, blink, and lip-sync in
+            chat. One-time setup, takes about 30 seconds.
+          </p>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => setShowLivePortraitSetup(true)}
+          >
+            {livePortraitAnchors ? 'Edit anchors' : 'Set up Live Portrait'}
+          </Button>
+        </div>
+
         {/* Phase 4.3: Character lorebooks */}
         <CharacterLorebookSection
           avatar={character.avatar}
@@ -591,6 +625,12 @@ export function CharacterEdit({
           </Button>
         </div>
       </form>
+      <LivePortraitSetup
+        avatar={character.avatar}
+        imageUrl={`/characters/${encodeURIComponent(character.avatar)}`}
+        isOpen={showLivePortraitSetup}
+        onClose={() => setShowLivePortraitSetup(false)}
+      />
     </Modal>
   );
 }

--- a/src/components/character/LivePortraitSetup.tsx
+++ b/src/components/character/LivePortraitSetup.tsx
@@ -1,0 +1,198 @@
+import { useEffect, useRef, useState } from 'react';
+import { Modal } from '../ui/Modal';
+import { Button } from '../ui/Button';
+import { showToastGlobal } from '../ui/Toast';
+import { useLivePortraitStore } from '../../stores/livePortraitStore';
+import {
+  LivePortrait,
+  type PortraitAnchors,
+  DEFAULT_ANCHORS,
+} from '../chat/LivePortrait';
+
+/**
+ * LivePortraitSetup — guided click-to-place modal for marking a character's
+ * left eye, right eye, and mouth on their avatar. Three clicks, sensible
+ * default radii, instant preview through the live mesh-warp pipeline so the
+ * user can sanity-check that blink/talk lands on the right spots.
+ *
+ * MediaPipe-driven auto-detection is a future iteration; manual placement
+ * works for any art style (anime/illustrated avatars are the dominant case
+ * in this app and don't auto-landmark well).
+ */
+
+interface LivePortraitSetupProps {
+  /** Character avatar filename, e.g. "Mina Hope.png". Used as the storage key. */
+  avatar: string;
+  /** Avatar URL to display in the setup canvas. */
+  imageUrl: string;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+type Step = 'leftEye' | 'rightEye' | 'mouth' | 'preview';
+
+const STEP_LABELS: Record<Exclude<Step, 'preview'>, string> = {
+  leftEye: 'Click the center of the LEFT eye',
+  rightEye: 'Click the center of the RIGHT eye',
+  mouth: 'Click the center of the mouth',
+};
+
+const STEP_ORDER: Step[] = ['leftEye', 'rightEye', 'mouth', 'preview'];
+
+/** Default radii sized for typical face proportions. cx/cy come from clicks. */
+const DEFAULT_RADII = {
+  leftEye:  { rx: 0.05, ry: 0.025 },
+  rightEye: { rx: 0.05, ry: 0.025 },
+  mouth:    { rx: 0.06, ry: 0.025 },
+};
+
+export function LivePortraitSetup({ avatar, imageUrl, isOpen, onClose }: LivePortraitSetupProps) {
+  const existing = useLivePortraitStore((s) => s.anchorsByAvatar[avatar]);
+  const setAnchorsInStore = useLivePortraitStore((s) => s.setAnchors);
+  const clearAnchorsInStore = useLivePortraitStore((s) => s.clearAnchors);
+
+  const [step, setStep] = useState<Step>(existing ? 'preview' : 'leftEye');
+  const [draft, setDraft] = useState<Partial<PortraitAnchors>>(() =>
+    existing ? { ...existing } : {},
+  );
+  const imgRef = useRef<HTMLImageElement>(null);
+
+  // Reset state whenever the modal is freshly opened (in case the user closed
+  // mid-setup last time and wants a clean run).
+  useEffect(() => {
+    if (!isOpen) return;
+    setStep(existing ? 'preview' : 'leftEye');
+    setDraft(existing ? { ...existing } : {});
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen]);
+
+  function handleImageClick(e: React.MouseEvent<HTMLImageElement>) {
+    if (step === 'preview') return;
+    const rect = e.currentTarget.getBoundingClientRect();
+    const cx = (e.clientX - rect.left) / rect.width;
+    const cy = (e.clientY - rect.top) / rect.height;
+    const radii = DEFAULT_RADII[step];
+    setDraft((d) => ({
+      ...d,
+      [step]: { cx, cy, rx: radii.rx, ry: radii.ry },
+    }));
+    // Advance to next step
+    const i = STEP_ORDER.indexOf(step);
+    setStep(STEP_ORDER[i + 1]);
+  }
+
+  function handleSave() {
+    if (!draft.leftEye || !draft.rightEye || !draft.mouth) {
+      showToastGlobal('Click all three points before saving.', 'error');
+      return;
+    }
+    setAnchorsInStore(avatar, draft as PortraitAnchors);
+    showToastGlobal('Live Portrait anchors saved.', 'success');
+    onClose();
+  }
+
+  function handleClear() {
+    clearAnchorsInStore(avatar);
+    setDraft({});
+    setStep('leftEye');
+    showToastGlobal('Live Portrait anchors cleared.', 'info');
+  }
+
+  function handleRestart() {
+    setDraft({});
+    setStep('leftEye');
+  }
+
+  // Markers overlaid on the image to show which clicks have landed.
+  const markers: { key: string; cx: number; cy: number; color: string }[] = [];
+  if (draft.leftEye) markers.push({ key: 'L', cx: draft.leftEye.cx, cy: draft.leftEye.cy, color: '#60a5fa' });
+  if (draft.rightEye) markers.push({ key: 'R', cx: draft.rightEye.cx, cy: draft.rightEye.cy, color: '#60a5fa' });
+  if (draft.mouth) markers.push({ key: 'M', cx: draft.mouth.cx, cy: draft.mouth.cy, color: '#f472b6' });
+
+  const previewAnchors: PortraitAnchors = {
+    leftEye:  draft.leftEye  ?? DEFAULT_ANCHORS.leftEye,
+    rightEye: draft.rightEye ?? DEFAULT_ANCHORS.rightEye,
+    mouth:    draft.mouth    ?? DEFAULT_ANCHORS.mouth,
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Live Portrait setup" size="lg">
+      <div className="space-y-3">
+        <p className="text-xs text-[var(--color-text-secondary)]">
+          {step === 'preview'
+            ? 'Preview — the avatar should breathe, blink, and open its mouth on the toggle below. Re-do or save when ready.'
+            : STEP_LABELS[step]}
+        </p>
+
+        <div className="flex flex-wrap gap-6">
+          {/* Click target / static reference */}
+          <div className="relative inline-block">
+            <img
+              ref={imgRef}
+              src={imageUrl}
+              alt="setup"
+              onClick={handleImageClick}
+              className={`block max-h-[480px] rounded ${step === 'preview' ? '' : 'cursor-crosshair'}`}
+              draggable={false}
+            />
+            {markers.map((m) => (
+              <div
+                key={m.key}
+                className="absolute pointer-events-none"
+                style={{
+                  left: `${m.cx * 100}%`,
+                  top: `${m.cy * 100}%`,
+                  width: 14,
+                  height: 14,
+                  marginLeft: -7,
+                  marginTop: -7,
+                  borderRadius: '50%',
+                  background: m.color,
+                  boxShadow: '0 0 0 2px rgba(0,0,0,0.5)',
+                }}
+              />
+            ))}
+          </div>
+
+          {/* Live preview only after all three points exist */}
+          {draft.leftEye && draft.rightEye && draft.mouth && (
+            <div>
+              <p className="text-[10px] font-mono uppercase tracking-wide text-[var(--color-text-secondary)] mb-1">
+                live preview
+              </p>
+              <LivePortrait
+                imageUrl={imageUrl}
+                size={320}
+                anchors={previewAnchors}
+                isSpeaking={step === 'preview'}
+              />
+            </div>
+          )}
+        </div>
+
+        <div className="flex flex-wrap gap-2 pt-2 border-t border-[var(--color-border)]">
+          <Button variant="ghost" size="sm" onClick={handleRestart}>
+            Restart
+          </Button>
+          {existing && (
+            <Button variant="ghost" size="sm" onClick={handleClear}>
+              Clear saved
+            </Button>
+          )}
+          <div className="flex-1" />
+          <Button variant="ghost" size="sm" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={handleSave}
+            disabled={!draft.leftEye || !draft.rightEye || !draft.mouth}
+          >
+            Save
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -15,6 +15,8 @@ import { applyRegexScripts, getActiveScripts } from '../../utils/regexScripts';
 import { useTranslateStore } from '../../stores/translateStore';
 import { useExtensionStore } from '../../stores/extensionStore';
 import { useSlotItems, invokeSlotItem } from '../../extensions/sandbox/sandboxSlotRegistry';
+import { LivePortrait } from './LivePortrait';
+import { useLivePortraitStore } from '../../stores/livePortraitStore';
 
 interface ChatMessageProps {
   /** Unique message id — used as TTS tracking key. */
@@ -36,6 +38,12 @@ interface ChatMessageProps {
   characterAvatar?: string;
   /** Phase 7.2: true while this message is actively being streamed. */
   isStreaming?: boolean;
+  /**
+   * True when this is the latest message in the chat — gates expensive
+   * per-message effects like the LivePortrait animator so we only run it
+   * for the visible/current speaker rather than every AI message in history.
+   */
+  isLastMessage?: boolean;
   /** Phase 7.3: display style settings. */
   layoutMode?: ChatLayoutMode;
   avatarShape?: AvatarShape;
@@ -80,6 +88,7 @@ export function ChatMessage({
   onSwipeLeft,
   onSwipeRight,
   isStreaming: isStreamingMsg,
+  isLastMessage,
   layoutMode = 'bubbles',
   avatarShape = 'circle',
   fontSize,
@@ -462,12 +471,56 @@ export function ChatMessage({
   ) : null;
 
   // ==================================================================
+  // Avatar selection — LivePortrait for the latest AI message of a
+  // character that has anchors set up; static <Avatar> everywhere else.
+  // Falls back gracefully when anchors are missing or the feature is
+  // globally disabled.
+  // ==================================================================
+  const livePortraitEnabled = useLivePortraitStore((s) => s.enabled);
+  const livePortraitAnchors = useLivePortraitStore((s) =>
+    characterAvatar ? s.anchorsByAvatar[characterAvatar] : undefined,
+  );
+  const useLivePortrait =
+    livePortraitEnabled &&
+    !!livePortraitAnchors &&
+    !!avatar &&
+    !isUser &&
+    !isSystem &&
+    !!isLastMessage;
+  const renderAvatar = (size: 'sm' | 'md') => {
+    if (useLivePortrait && livePortraitAnchors && avatar) {
+      const px = size === 'md' ? 80 : 48;
+      return (
+        <div className="flex-shrink-0">
+          <LivePortrait
+            imageUrl={avatar}
+            size={px}
+            isSpeaking={!!isStreamingMsg}
+            anchors={livePortraitAnchors}
+          />
+        </div>
+      );
+    }
+    return (
+      <Avatar
+        src={avatar}
+        fallbackSrc={avatarFallback}
+        onFallback={onAvatarError}
+        alt={name}
+        size={size}
+        shape={avatarShape}
+        className="flex-shrink-0"
+      />
+    );
+  };
+
+  // ==================================================================
   // Bubbles layout (default — original behavior)
   // ==================================================================
   if (layoutMode === 'bubbles') {
     return (
       <div className={`flex gap-3 px-4 py-3 group ${isUser ? 'flex-row-reverse' : 'flex-row'}`}>
-        <Avatar src={avatar} fallbackSrc={avatarFallback} onFallback={onAvatarError} alt={name} size="md" shape={avatarShape} className="flex-shrink-0" />
+        {renderAvatar('md')}
 
         <div
           className={`flex flex-col ${isUser ? 'items-end' : 'items-start'}`}
@@ -516,7 +569,7 @@ export function ChatMessage({
       >
         {/* Header row: avatar + name + time + actions */}
         <div className="flex items-center gap-2 mb-1.5">
-          <Avatar src={avatar} fallbackSrc={avatarFallback} onFallback={onAvatarError} alt={name} size="sm" shape={avatarShape} className="flex-shrink-0" />
+          {renderAvatar('sm')}
           <span className={`text-xs font-semibold ${
             isUser ? 'text-[var(--color-primary)]' : 'text-[var(--color-text-secondary)]'
           }`}>

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -1268,6 +1268,7 @@ export function ChatView() {
                     images={message.images}
                     characterAvatar={message.isUser ? selectedCharacter?.avatar : (message.characterAvatar || selectedCharacter?.avatar)}
                     isStreaming={isLastAiMessage && isStreaming}
+                    isLastMessage={isLastAiMessage}
                     layoutMode={chatLayoutMode}
                     avatarShape={avatarShapePref}
                     fontSize={chatFontSize}

--- a/src/components/chat/LivePortrait.tsx
+++ b/src/components/chat/LivePortrait.tsx
@@ -1,0 +1,284 @@
+import { useEffect, useRef, useState } from 'react';
+import { Application, MeshPlane, Texture } from 'pixi.js';
+
+/**
+ * LivePortrait — POC of a single-image AI-driven character animator.
+ *
+ * Renders the character avatar through a Pixi.js mesh plane and warps a
+ * triangulated grid every frame to fake breathing, blinking and talking
+ * without any per-character rigging. Anchors are expressed as ellipses in
+ * normalized image space (0..1), so the same defaults work-ish for any
+ * roughly-centered portrait. In a future phase these would be detected by
+ * MediaPipe (photoreal) or hand-placed in a setup dialog (anime art).
+ *
+ * NOT YET wired into ChatMessage — this component lives behind a debug route
+ * for POC evaluation.
+ */
+
+/** A region of interest on the avatar, in normalized 0..1 coordinates. */
+export interface AnchorRegion {
+  /** Center-x in [0, 1] across the image width. */
+  cx: number;
+  /** Center-y in [0, 1] across the image height. */
+  cy: number;
+  /** Horizontal half-width of the elliptical region. */
+  rx: number;
+  /** Vertical half-height of the elliptical region. */
+  ry: number;
+}
+
+/** All anchors a portrait needs to drive idle / talk animation. */
+export interface PortraitAnchors {
+  leftEye: AnchorRegion;
+  rightEye: AnchorRegion;
+  mouth: AnchorRegion;
+}
+
+/** Sensible defaults for a face-centered, camera-facing portrait. */
+export const DEFAULT_ANCHORS: PortraitAnchors = {
+  leftEye:  { cx: 0.40, cy: 0.42, rx: 0.06, ry: 0.04 },
+  rightEye: { cx: 0.60, cy: 0.42, rx: 0.06, ry: 0.04 },
+  mouth:    { cx: 0.50, cy: 0.62, rx: 0.08, ry: 0.04 },
+};
+
+export interface LivePortraitProps {
+  /** URL of the source avatar image. Loaded via Pixi Assets. */
+  imageUrl: string;
+  /**
+   * Longest-side display dimension in CSS pixels. The shorter side is
+   * derived from the source image's natural aspect ratio so portraits aren't
+   * squashed into a square. Defaults to 256.
+   */
+  size?: number;
+  /** Whether the character is "speaking" — drives mouth opening. */
+  isSpeaking?: boolean;
+  /** Anchor configuration. Defaults to face-centered presets. */
+  anchors?: PortraitAnchors;
+  /** Optional class on the wrapper div. */
+  className?: string;
+}
+
+const VERTICES_PER_AXIS = 24;
+
+export function LivePortrait({
+  imageUrl,
+  size = 256,
+  isSpeaking = false,
+  anchors = DEFAULT_ANCHORS,
+  className,
+}: LivePortraitProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const speakingRef = useRef(isSpeaking);
+  speakingRef.current = isSpeaking;
+  // Track the actual rendered dimensions so the wrapper div sizes to the
+  // image's natural aspect ratio rather than a forced square.
+  const [displaySize, setDisplaySize] = useState<{ w: number; h: number } | null>(null);
+
+  useEffect(() => {
+    let plane: MeshPlane | null = null;
+    let restPositions: Float32Array | null = null;
+    let cancelled = false;
+    let raf = 0;
+    let blinkPhase = randomBlinkInterval();
+    let blinkElapsed = 0;
+    const startTime = performance.now();
+
+    function randomBlinkInterval() {
+      // Real eyes blink every 4–6 s. Add jitter so it doesn't feel mechanical.
+      return 3500 + Math.random() * 2500;
+    }
+
+    /** Compute closed-amount in [0, 1] given how far into the blink we are. */
+    function blinkAmount(elapsedSinceTrigger: number): number {
+      // Total blink: 80ms close + 40ms hold + 100ms open
+      const close = 80;
+      const hold = 40;
+      const open = 100;
+      const t = elapsedSinceTrigger;
+      if (t < close) return t / close;
+      if (t < close + hold) return 1;
+      if (t < close + hold + open) return 1 - (t - close - hold) / open;
+      return 0;
+    }
+
+    // Track init through a single promise so cleanup can wait for init to
+    // finish before destroying — calling Application.destroy() before init()
+    // resolves throws "this._cancelResize is not a function" because
+    // _cancelResize is assigned inside init().
+    const initPromise: Promise<Application | null> = (async () => {
+      // Load the source image FIRST so we can size the Pixi app to the
+      // image's natural aspect ratio. Otherwise a portrait avatar gets
+      // stretched into a square.
+      //
+      // Pixi's Assets.load swallows non-extension URLs (the ST thumbnail
+      // endpoint uses a query-string for the file name and returns null
+      // without throwing). Loading via HTMLImageElement → Texture.from is
+      // reliable regardless of URL shape and gives the same GPU texture.
+      const img = new Image();
+      img.crossOrigin = 'anonymous';
+      img.src = imageUrl;
+      try {
+        await new Promise<void>((res, rej) => {
+          img.onload = () => res();
+          img.onerror = () => rej(new Error('image load failed: ' + imageUrl));
+        });
+      } catch (e) {
+        console.warn('[LivePortrait]', e);
+        return null;
+      }
+      if (cancelled) return null;
+
+      const aspect = img.naturalWidth / img.naturalHeight;
+      const displayWidth = aspect >= 1 ? size : size * aspect;
+      const displayHeight = aspect >= 1 ? size / aspect : size;
+      setDisplaySize({ w: displayWidth, h: displayHeight });
+
+      const localApp = new Application();
+      await localApp.init({
+        width: displayWidth,
+        height: displayHeight,
+        backgroundAlpha: 0,
+        antialias: true,
+        autoDensity: true,
+        resolution: window.devicePixelRatio || 1,
+      });
+      if (cancelled || !containerRef.current) {
+        localApp.destroy(true, { children: true, texture: false });
+        return null;
+      }
+      containerRef.current.appendChild(localApp.canvas);
+
+      const texture = Texture.from(img);
+
+      plane = new MeshPlane({
+        texture,
+        verticesX: VERTICES_PER_AXIS,
+        verticesY: VERTICES_PER_AXIS,
+      });
+      plane.width = displayWidth;
+      plane.height = displayHeight;
+      localApp.stage.addChild(plane);
+      // Force a first render — without this the canvas can stay blank under
+      // React StrictMode's double-mount until the auto-ticker catches up.
+      localApp.render();
+
+      // Snapshot rest positions so we can re-derive each frame from a clean
+      // baseline rather than accumulating drift.
+      restPositions = new Float32Array(plane.geometry.positions);
+
+      let last = performance.now();
+      const tick = (now: number) => {
+        if (cancelled || !plane || !restPositions) return;
+        const dt = now - last;
+        last = now;
+
+        // ── Drivers ──────────────────────────────────────────────────────
+        blinkElapsed += dt;
+        let blink = 0;
+        if (blinkElapsed >= blinkPhase) {
+          const sinceTrigger = blinkElapsed - blinkPhase;
+          blink = blinkAmount(sinceTrigger);
+          if (sinceTrigger > 220) {
+            blinkElapsed = 0;
+            blinkPhase = randomBlinkInterval();
+          }
+        }
+
+        // Mouth: when speaking, oscillate with light noise around 0.4–0.9 open.
+        // When silent, ride a tiny baseline to suggest subtle breath through nose.
+        const t = (now - startTime) / 1000;
+        const mouth = speakingRef.current
+          ? 0.4 + 0.5 * (0.5 + 0.5 * Math.sin(t * 14)) + 0.1 * Math.sin(t * 23)
+          : 0.02;
+
+        // Breath: gentle vertical sway of the whole portrait. ~3.5s period.
+        const breath = Math.sin((t * Math.PI * 2) / 3.5) * (displayHeight * 0.006);
+
+        // ── Apply to mesh ────────────────────────────────────────────────
+        // Anchor regions are normalized 0..1 coords within the IMAGE, so
+        // displacement scales need to be in the image's pixel space — not the
+        // square `size`, which would distort portraits.
+        const positions = plane.geometry.positions;
+        const eyeMaxClosePx = displayHeight * 0.045;
+        const mouthMaxOpenPx = displayHeight * 0.04;
+
+        for (let i = 0; i < positions.length; i += 2) {
+          const restX = restPositions[i];
+          const restY = restPositions[i + 1];
+          const nx = restX / displayWidth;
+          const ny = restY / displayHeight;
+
+          let dx = 0;
+          let dy = breath; // global breath sway
+
+          // Eyes: vertices inside the ellipse get pinched vertically toward
+          // the eye center, scaled by blink amount.
+          for (const eye of [anchors.leftEye, anchors.rightEye]) {
+            const ex = (nx - eye.cx) / eye.rx;
+            const ey = (ny - eye.cy) / eye.ry;
+            const d2 = ex * ex + ey * ey;
+            if (d2 < 1) {
+              const falloff = 1 - d2;
+              const isAbove = ny < eye.cy;
+              dy += (isAbove ? 1 : -1) * blink * eyeMaxClosePx * falloff;
+            }
+          }
+
+          // Mouth: vertices inside the ellipse stretch vertically away from
+          // the mouth center, opening the mouth.
+          {
+            const mx = (nx - anchors.mouth.cx) / anchors.mouth.rx;
+            const my = (ny - anchors.mouth.cy) / anchors.mouth.ry;
+            const d2 = mx * mx + my * my;
+            if (d2 < 1) {
+              const falloff = 1 - d2;
+              const isAbove = ny < anchors.mouth.cy;
+              dy += (isAbove ? -1 : 1) * mouth * mouthMaxOpenPx * falloff;
+            }
+          }
+
+          // dx is currently always 0 — kept here so we can add lateral warp
+          // (lip corners, eye tracking) later without restructuring.
+          if (dx !== 0) positions[i] = restX + dx; else positions[i] = restX;
+          positions[i + 1] = restY + dy;
+        }
+
+        // Pixi v8 picks up buffer changes automatically when you mutate the
+        // backing Float32Array, but we still need to flag it dirty.
+        plane.geometry.attributes.aPosition.buffer.update();
+
+        raf = requestAnimationFrame(tick);
+      };
+      raf = requestAnimationFrame(tick);
+      return localApp;
+    })();
+
+    return () => {
+      cancelled = true;
+      if (raf) cancelAnimationFrame(raf);
+      // Wait for init to finish before destroying — see comment on initPromise.
+      // Pixi v8 takes a {removeView} options object as the first arg (the
+      // legacy boolean removeView is interpreted differently). Pass it
+      // explicitly so the canvas gets pulled out of the DOM, otherwise React
+      // StrictMode's double-mount leaves a dead orphan canvas behind.
+      initPromise.then((readyApp) => {
+        if (!readyApp) return;
+        const canvas = readyApp.canvas;
+        readyApp.destroy({ removeView: true }, { children: true, texture: false });
+        // Belt-and-braces: ensure canvas is gone even if Pixi missed it.
+        if (canvas?.parentElement) canvas.parentElement.removeChild(canvas);
+      });
+    };
+  }, [imageUrl, size, anchors]);
+
+  return (
+    <div
+      ref={containerRef}
+      className={className}
+      style={{
+        width: displaySize ? displaySize.w : size,
+        height: displaySize ? displaySize.h : size,
+      }}
+    />
+  );
+}

--- a/src/components/chat/LivePortraitDebug.tsx
+++ b/src/components/chat/LivePortraitDebug.tsx
@@ -1,0 +1,99 @@
+import { useState } from 'react';
+import { LivePortrait, DEFAULT_ANCHORS, type PortraitAnchors } from './LivePortrait';
+
+/**
+ * POC debug page for the LivePortrait animator. Not linked from the main app
+ * navigation — visit `/debug/live-portrait` directly.
+ *
+ * Shows a single character avatar through the live mesh-warp pipeline next to
+ * a static <img> reference for comparison, plus on/off switches for the talk
+ * driver and live anchor sliders so the breath/blink baseline can be felt out
+ * before we wire MediaPipe or the click-to-place setup UI.
+ */
+export function LivePortraitDebug() {
+  const [character, setCharacter] = useState('Mina Hope.png');
+  const [isSpeaking, setIsSpeaking] = useState(false);
+  // Anchors hand-tuned to Mina Hope's avatar — face is right-of-center, head
+  // ~30% from the top. Off-the-shelf DEFAULT_ANCHORS still available below.
+  const [anchors, setAnchors] = useState<PortraitAnchors>({
+    leftEye:  { cx: 0.42, cy: 0.30, rx: 0.05, ry: 0.025 },
+    rightEye: { cx: 0.55, cy: 0.30, rx: 0.05, ry: 0.025 },
+    mouth:    { cx: 0.46, cy: 0.42, rx: 0.06, ry: 0.025 },
+  });
+  void DEFAULT_ANCHORS;
+
+  // Use the full character avatar (not the thumbnail) so the live mesh isn't
+  // up-rezzing a 96x144 source.
+  const imageUrl = `/characters/${encodeURIComponent(character)}`;
+
+  return (
+    <div className="min-h-screen p-6 bg-[var(--color-bg-primary)] text-[var(--color-text-primary)]">
+      <h1 className="text-xl font-semibold mb-1">LivePortrait — POC</h1>
+      <p className="text-xs text-[var(--color-text-secondary)] mb-4">
+        Single-image AI-driven character animator. Mesh-warp via Pixi v8.
+      </p>
+
+      <div className="flex gap-6 items-start flex-wrap">
+        <div>
+          <p className="text-xs font-mono mb-1">live (animated mesh)</p>
+          <div className="bg-[var(--color-bg-secondary)] rounded-lg p-2">
+            <LivePortrait imageUrl={imageUrl} size={384} isSpeaking={isSpeaking} anchors={anchors} />
+          </div>
+        </div>
+
+        <div>
+          <p className="text-xs font-mono mb-1">static (reference)</p>
+          <div className="bg-[var(--color-bg-secondary)] rounded-lg p-2">
+            <img src={imageUrl} width={384} height={384} alt="static reference" className="block" />
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-3 min-w-[260px]">
+          <label className="text-xs">
+            character file
+            <input
+              type="text"
+              value={character}
+              onChange={(e) => setCharacter(e.target.value)}
+              className="block w-full mt-1 px-2 py-1 text-sm rounded border border-[var(--color-border)] bg-[var(--color-bg-secondary)]"
+            />
+          </label>
+
+          <label className="text-xs flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={isSpeaking}
+              onChange={(e) => setIsSpeaking(e.target.checked)}
+            />
+            isSpeaking (drives mouth)
+          </label>
+
+          {(['leftEye', 'rightEye', 'mouth'] as const).map((key) => (
+            <fieldset key={key} className="border border-[var(--color-border)] rounded p-2">
+              <legend className="text-xs font-mono">{key}</legend>
+              {(['cx', 'cy', 'rx', 'ry'] as const).map((field) => (
+                <label key={field} className="text-[10px] block">
+                  {field}: {anchors[key][field].toFixed(3)}
+                  <input
+                    type="range"
+                    min={0}
+                    max={field === 'cx' || field === 'cy' ? 1 : 0.25}
+                    step={0.005}
+                    value={anchors[key][field]}
+                    onChange={(e) =>
+                      setAnchors((a) => ({
+                        ...a,
+                        [key]: { ...a[key], [field]: Number(e.target.value) },
+                      }))
+                    }
+                    className="block w-full"
+                  />
+                </label>
+              ))}
+            </fieldset>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/stores/livePortraitStore.ts
+++ b/src/stores/livePortraitStore.ts
@@ -1,0 +1,59 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import type { PortraitAnchors } from '../components/chat/LivePortrait';
+
+/**
+ * Per-character animation anchors for the LivePortrait feature.
+ *
+ * Keyed by the character's avatar filename (e.g., "Mina Hope.png"), which is
+ * the stable per-character identifier this codebase uses everywhere — there's
+ * no separate `id` field on `Character`. Persisted to localStorage so the
+ * one-time click-to-place setup survives reloads.
+ */
+
+interface LivePortraitState {
+  /** Anchors keyed by character avatar filename. Missing entry = not set up yet. */
+  anchorsByAvatar: Record<string, PortraitAnchors>;
+  /** Global on/off — disables the feature everywhere when false. */
+  enabled: boolean;
+
+  setAnchors: (avatar: string, anchors: PortraitAnchors) => void;
+  clearAnchors: (avatar: string) => void;
+  getAnchors: (avatar: string) => PortraitAnchors | null;
+  setEnabled: (enabled: boolean) => void;
+}
+
+export const useLivePortraitStore = create<LivePortraitState>()(
+  persist(
+    (set, get) => ({
+      anchorsByAvatar: {},
+      enabled: true,
+
+      setAnchors(avatar, anchors) {
+        set((s) => ({
+          anchorsByAvatar: { ...s.anchorsByAvatar, [avatar]: anchors },
+        }));
+      },
+
+      clearAnchors(avatar) {
+        set((s) => {
+          const next = { ...s.anchorsByAvatar };
+          delete next[avatar];
+          return { anchorsByAvatar: next };
+        });
+      },
+
+      getAnchors(avatar) {
+        return get().anchorsByAvatar[avatar] ?? null;
+      },
+
+      setEnabled(enabled) {
+        set({ enabled });
+      },
+    }),
+    {
+      name: 'live-portrait',
+      version: 1,
+    },
+  ),
+);


### PR DESCRIPTION
## Summary
- Replaces the static `<img>` avatar in chat with a Pixi.js mesh-warp animator for the latest AI message — breath, blink, and mouth-open at 60fps without any per-character rigging.
- Three-click setup ("left eye, right eye, mouth") in the character edit form is the entire per-character cost, vs. days of work in Cubism Editor for a Live2D model.
- Falls back to static `<Avatar>` everywhere except the latest AI message, so chat-history performance is unchanged. Bundle cost: ~150KB gzipped (pixi.js).

This is the first concrete differentiator vs. upstream SillyTavern: upstream requires the full Live2D extension + a hand-rigged Cubism model + lib/pixi.min.js + lib/live2dcubismcore.min.js + a model bundle. GGBC's animator runs on any character avatar after a 30-second click-to-place setup.

## What ships

| Piece | Path |
|---|---|
| Renderer (Pixi v8 + MeshPlane vertex warp) | [LivePortrait.tsx](src/components/chat/LivePortrait.tsx) |
| Click-to-place setup modal | [LivePortraitSetup.tsx](src/components/character/LivePortraitSetup.tsx) |
| Per-character anchor store (localStorage-persisted) | [livePortraitStore.ts](src/stores/livePortraitStore.ts) |
| CharacterEdit "Live Portrait" section | [CharacterEdit.tsx](src/components/character/CharacterEdit.tsx) |
| ChatMessage avatar swap (latest AI message only) | [ChatMessage.tsx](src/components/chat/ChatMessage.tsx) |
| Internal QA page at `/debug/live-portrait` | [LivePortraitDebug.tsx](src/components/chat/LivePortraitDebug.tsx) |

## Behavior

- New "Live Portrait" section in character edit; status badge shows "set up" / "not set"
- Setup modal walks through 3 clicks (left eye, right eye, mouth) with default elliptical extents and a live preview
- During chat, the latest AI message's avatar becomes a live-animated portrait that breathes always, blinks every 4–6s with jitter, and opens its mouth while the message is streaming
- All other places (sidebar, chat history) remain static `<Avatar>`
- Global enable/disable flag in the store; per-character "Clear saved" wipes that character's anchors

## Out of scope (tracked for follow-ups)

- **MediaPipe auto-detect** — manual click-to-place works for anime art, which is the dominant style. Auto-detect is a phase-2 upgrade for photoreal avatars.
- **Audio-driven lip-sync from TTS amplitude** — streaming on/off is the v1 driver; audio comes later when the TTS pipeline is mature.
- **Floating canvas overlay over chat** for full-body Live2D-style models — needs a positioned-overlay sandbox tier; separate task.

## Test plan
- [x] `npm run build` (Docker-equivalent) clean
- [x] Live Portrait section renders in CharacterEdit; "not set" badge shows for fresh characters
- [x] Setup modal: 3 clicks place anchors at correct normalized coords (verified via store inspection)
- [x] Save → anchors persist to localStorage and re-appear on reload
- [x] Latest AI message renders as a Pixi canvas (53×80 portrait-aspect, mounted in the avatar slot)
- [x] Clearing anchors reverts to the static `<Avatar>` (fallback path)
- [x] StrictMode double-mount handled cleanly (cleanup awaits init promise)
- [ ] Manual smoke on the deployed environment with a real chat

POC screenshots and the verification trail of the click-to-place + chat integration live in the working session.