### PR TITLE
fix(live-portrait): make eye + mouth warps actually visible

### DIFF
--- a/src/components/character/LivePortraitSetup.tsx
+++ b/src/components/character/LivePortraitSetup.tsx
@@ -39,11 +39,16 @@ const STEP_LABELS: Record<Exclude<Step, 'preview'>, string> = {
 
 const STEP_ORDER: Step[] = ['leftEye', 'rightEye', 'mouth', 'preview'];
 
-/** Default radii sized for typical face proportions. cx/cy come from clicks. */
+/**
+ * Default radii sized for typical face proportions. cx/cy come from clicks.
+ * Set generously so the warp always has multiple mesh vertices to work with;
+ * tighter ellipses look anatomically truer but produce no visible motion on
+ * sparse grids.
+ */
 const DEFAULT_RADII = {
-  leftEye:  { rx: 0.05, ry: 0.025 },
-  rightEye: { rx: 0.05, ry: 0.025 },
-  mouth:    { rx: 0.06, ry: 0.025 },
+  leftEye:  { rx: 0.06, ry: 0.04 },
+  rightEye: { rx: 0.06, ry: 0.04 },
+  mouth:    { rx: 0.07, ry: 0.04 },
 };
 
 export function LivePortraitSetup({ avatar, imageUrl, isOpen, onClose }: LivePortraitSetupProps) {

--- a/src/components/chat/LivePortrait.tsx
+++ b/src/components/chat/LivePortrait.tsx
@@ -58,7 +58,12 @@ export interface LivePortraitProps {
   className?: string;
 }
 
-const VERTICES_PER_AXIS = 24;
+// 48×48 mesh (2304 verts) so small anchor regions still contain multiple
+// vertices to warp. 24×24 was too sparse — eye/mouth ellipses with
+// ry≈0.025 could land entirely between vertex rows and produce no visible
+// warp at all, while breath (which displaces every vertex globally) was
+// the only thing users could see.
+const VERTICES_PER_AXIS = 48;
 
 export function LivePortrait({
   imageUrl,
@@ -79,7 +84,9 @@ export function LivePortrait({
     let restPositions: Float32Array | null = null;
     let cancelled = false;
     let raf = 0;
-    let blinkPhase = randomBlinkInterval();
+    // First blink fires ~700 ms after mount so users see *something* happen
+    // immediately. Subsequent blinks use the human-ish 3.5–6 s schedule.
+    let blinkPhase = 700;
     let blinkElapsed = 0;
     const startTime = performance.now();
 
@@ -185,11 +192,13 @@ export function LivePortrait({
         }
 
         // Mouth: when speaking, oscillate with light noise around 0.4–0.9 open.
-        // When silent, ride a tiny baseline to suggest subtle breath through nose.
+        // When silent, gentle ambient mouth motion (~10% open with sigh-like
+        // periodicity) so the user sees the mouth driver is alive even
+        // outside of streaming.
         const t = (now - startTime) / 1000;
         const mouth = speakingRef.current
           ? 0.4 + 0.5 * (0.5 + 0.5 * Math.sin(t * 14)) + 0.1 * Math.sin(t * 23)
-          : 0.02;
+          : 0.06 + 0.04 * Math.sin((t * Math.PI * 2) / 4.2);
 
         // Breath: gentle vertical sway of the whole portrait. ~3.5s period.
         const breath = Math.sin((t * Math.PI * 2) / 3.5) * (displayHeight * 0.006);
@@ -198,9 +207,15 @@ export function LivePortrait({
         // Anchor regions are normalized 0..1 coords within the IMAGE, so
         // displacement scales need to be in the image's pixel space — not the
         // square `size`, which would distort portraits.
+        //
+        // FALLOFF_REACH widens the effective influence to 1.8× the user's
+        // chosen radius with a smooth quartic decay. Without this, sparse
+        // grids miss small ellipses entirely; with this, nearby vertices
+        // get partial warp and the motion is always visible.
         const positions = plane.geometry.positions;
-        const eyeMaxClosePx = displayHeight * 0.045;
-        const mouthMaxOpenPx = displayHeight * 0.04;
+        const eyeMaxClosePx = displayHeight * 0.07;
+        const mouthMaxOpenPx = displayHeight * 0.06;
+        const FALLOFF_REACH = 1.8;
 
         for (let i = 0; i < positions.length; i += 2) {
           const restX = restPositions[i];
@@ -208,38 +223,36 @@ export function LivePortrait({
           const nx = restX / displayWidth;
           const ny = restY / displayHeight;
 
-          let dx = 0;
           let dy = breath; // global breath sway
 
-          // Eyes: vertices inside the ellipse get pinched vertically toward
-          // the eye center, scaled by blink amount.
+          // Eyes: vertices near the ellipse get pinched vertically toward
+          // the eye center, scaled by blink amount with a smooth falloff
+          // that extends past the strict ellipse boundary.
           for (const eye of [anchors.leftEye, anchors.rightEye]) {
-            const ex = (nx - eye.cx) / eye.rx;
-            const ey = (ny - eye.cy) / eye.ry;
+            const ex = (nx - eye.cx) / (eye.rx * FALLOFF_REACH);
+            const ey = (ny - eye.cy) / (eye.ry * FALLOFF_REACH);
             const d2 = ex * ex + ey * ey;
             if (d2 < 1) {
-              const falloff = 1 - d2;
+              const falloff = (1 - d2) * (1 - d2); // quartic — sharper near peak
               const isAbove = ny < eye.cy;
               dy += (isAbove ? 1 : -1) * blink * eyeMaxClosePx * falloff;
             }
           }
 
-          // Mouth: vertices inside the ellipse stretch vertically away from
+          // Mouth: vertices near the ellipse stretch vertically away from
           // the mouth center, opening the mouth.
           {
-            const mx = (nx - anchors.mouth.cx) / anchors.mouth.rx;
-            const my = (ny - anchors.mouth.cy) / anchors.mouth.ry;
+            const mx = (nx - anchors.mouth.cx) / (anchors.mouth.rx * FALLOFF_REACH);
+            const my = (ny - anchors.mouth.cy) / (anchors.mouth.ry * FALLOFF_REACH);
             const d2 = mx * mx + my * my;
             if (d2 < 1) {
-              const falloff = 1 - d2;
+              const falloff = (1 - d2) * (1 - d2);
               const isAbove = ny < anchors.mouth.cy;
               dy += (isAbove ? -1 : 1) * mouth * mouthMaxOpenPx * falloff;
             }
           }
 
-          // dx is currently always 0 — kept here so we can add lateral warp
-          // (lip corners, eye tracking) later without restructuring.
-          if (dx !== 0) positions[i] = restX + dx; else positions[i] = restX;
+          positions[i] = restX;
           positions[i + 1] = restY + dy;
         }
 


### PR DESCRIPTION
## Summary
Hotfix for the Live Portrait MVP. User reported on production: *"breath works but eyes and mouth have no motion at all"* — and they were right. Root cause was a sparse-mesh-vs-tight-ellipse mismatch that made the conditional warps land in dead zones between vertex rows.

## What was wrong
- 24×24 mesh (vertex spacing ≈ 4.3% per cell) + eye `ry=0.025` (2.5%) → ellipse could land entirely between rows, no vertex inside, zero warp
- Breath was visible because it adds dy to *every* vertex unconditionally — that masked the bug
- First blink delay 3.5–6 s + 220 ms duration → user could easily watch and never see one
- Mouth baseline of 2% open + only animates while streaming → looks dead at rest
- Amplitudes (4.5% blink, 4% mouth open) were tuned for "subtle and lifelike" but read as "static" at chat-avatar sizes

## What's fixed
- **48×48 mesh** — ~2300 verts, ~2.1% spacing. Tight ellipses always contain multiple verts now.
- **Quartic falloff over 1.8× radius** — soft decay past the ellipse boundary. Existing saved anchors (ry=0.025) get an effective 0.045 reach, ~2 vertex rows of coverage.
- **Bigger amplitudes** — eye blink 4.5% → 7%, mouth open 4% → 6% of image height
- **First blink at 700 ms** — user sees motion within a second; subsequent blinks return to 3.5–6 s schedule
- **Idle mouth** — gentle ~10% open sigh-like motion when not streaming, so the mouth driver shows it's alive between messages
- **Setup defaults bumped** — eye/mouth `ry` 0.025 → 0.04 for new setups (existing anchors stay valid; falloff covers them)

No migration needed — old saved anchors continue working with the wider falloff.

## Test plan
- [x] `npm run build` clean
- [x] Mathematical verification: with new 48×48 grid + 1.8× falloff, eye ellipses with ry=0.025 capture ~16 vertices (was 0–1)
- [ ] Manual smoke on the deployed env: open a chat with the existing-setup character, watch the avatar — should see breath + blinks within ~1 s + ambient mouth movement