### PR TITLE
feat(live-portrait): auto-detect anchors via Claude vision + per-marker editing

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -2,7 +2,7 @@
 
 let csrfToken: string | null = null;
 
-async function getCsrfToken(): Promise<string> {
+export async function getCsrfToken(): Promise<string> {
   if (csrfToken) return csrfToken;
 
   const response = await fetch('/csrf-token');

--- a/src/api/faceDetection.ts
+++ b/src/api/faceDetection.ts
@@ -1,0 +1,180 @@
+import { getCsrfToken } from './client';
+import { useSettingsStore } from '../stores/settingsStore';
+import type { PortraitAnchors } from '../components/chat/LivePortrait';
+
+/**
+ * Auto-detect Live Portrait anchor coordinates from a character avatar by
+ * asking the user's currently-configured vision-capable LLM to look at the
+ * image and return JSON.
+ *
+ * Uses the same SillyTavern backend chat-completions proxy the chat already
+ * relies on, so auth/CSRF/provider routing all reuse the existing plumbing.
+ * One-shot (`stream: false`) so we get the full response in a single fetch.
+ *
+ * Throws on network error or unparseable response. Caller should surface a
+ * toast — the user can always fall back to manual click-to-place.
+ */
+
+type AnchorCenters = {
+  leftEye: { cx: number; cy: number };
+  rightEye: { cx: number; cy: number };
+  mouth: { cx: number; cy: number };
+};
+
+/** Default radii to apply to each detected center. Match the manual setup defaults. */
+const DEFAULT_RADII = {
+  leftEye:  { rx: 0.06, ry: 0.04 },
+  rightEye: { rx: 0.06, ry: 0.04 },
+  mouth:    { rx: 0.07, ry: 0.04 },
+};
+
+const DETECTION_PROMPT =
+  `Look at this character portrait. Identify the center of the LEFT eye, the center of the RIGHT eye, ` +
+  `and the center of the MOUTH. Return ONLY a JSON object with normalized 0..1 coordinates ` +
+  `(0,0 = top-left of image, 1,1 = bottom-right), exactly this shape, no markdown, no commentary:\n\n` +
+  `{"leftEye":{"cx":0.42,"cy":0.30},"rightEye":{"cx":0.58,"cy":0.30},"mouth":{"cx":0.50,"cy":0.50}}\n\n` +
+  `LEFT and RIGHT are from the CHARACTER's perspective (so the character's left eye appears on the ` +
+  `right side of the image when they face the camera). If the character is facing sideways and an eye ` +
+  `is hidden, place that eye's coordinates at where it would be if visible. Be precise — these ` +
+  `coordinates drive an animation overlay.`;
+
+/**
+ * Fetch an image URL and return its raw bytes as base64 + the inferred MIME type.
+ * Re-encodes via canvas to JPEG so the payload to the LLM is small (PNGs of ST
+ * avatars can be 700KB+ which slows the API call without improving detection).
+ */
+async function imageUrlToBase64Jpeg(imageUrl: string): Promise<{ base64: string; mimeType: string }> {
+  const img = new Image();
+  img.crossOrigin = 'anonymous';
+  img.src = imageUrl;
+  await new Promise<void>((resolve, reject) => {
+    img.onload = () => resolve();
+    img.onerror = () => reject(new Error('Could not load image: ' + imageUrl));
+  });
+  // Cap at 768px on the long side — plenty for landmark detection, much faster
+  // upload than full-resolution avatars.
+  const MAX = 768;
+  const scale = Math.min(1, MAX / Math.max(img.naturalWidth, img.naturalHeight));
+  const w = Math.round(img.naturalWidth * scale);
+  const h = Math.round(img.naturalHeight * scale);
+  const canvas = document.createElement('canvas');
+  canvas.width = w;
+  canvas.height = h;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('Could not get 2D canvas context');
+  ctx.drawImage(img, 0, 0, w, h);
+  const dataUrl = canvas.toDataURL('image/jpeg', 0.85);
+  const base64 = dataUrl.split(',')[1] ?? '';
+  return { base64, mimeType: 'image/jpeg' };
+}
+
+/** Strip provider noise (markdown fences, leading text) and extract the first JSON object. */
+function extractJsonObject(raw: string): unknown {
+  // Try direct parse first
+  try {
+    return JSON.parse(raw);
+  } catch {
+    // fall through
+  }
+  // Find the first {...} block
+  const start = raw.indexOf('{');
+  const end = raw.lastIndexOf('}');
+  if (start >= 0 && end > start) {
+    const slice = raw.slice(start, end + 1);
+    return JSON.parse(slice);
+  }
+  throw new Error('No JSON object found in response: ' + raw.slice(0, 200));
+}
+
+function isAnchorCenters(value: unknown): value is AnchorCenters {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  const ok = (p: unknown) =>
+    !!p &&
+    typeof p === 'object' &&
+    typeof (p as Record<string, unknown>).cx === 'number' &&
+    typeof (p as Record<string, unknown>).cy === 'number';
+  return ok(v.leftEye) && ok(v.rightEye) && ok(v.mouth);
+}
+
+/**
+ * Run vision-LLM auto-detection on a character avatar and return full
+ * Live Portrait anchors (centers + default radii).
+ */
+export async function detectFaceAnchors(imageUrl: string): Promise<PortraitAnchors> {
+  const { activeProvider, activeModel } = useSettingsStore.getState();
+  const provider = activeProvider || 'claude';
+  const model = activeModel || 'claude-sonnet-4-6';
+
+  const { base64, mimeType } = await imageUrlToBase64Jpeg(imageUrl);
+  const token = await getCsrfToken();
+
+  const body = {
+    stream: false,
+    max_tokens: 256,
+    temperature: 0,
+    model,
+    chat_completion_source: provider,
+    messages: [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: DETECTION_PROMPT },
+          { type: 'image_url', image_url: { url: `data:${mimeType};base64,${base64}` } },
+        ],
+      },
+    ],
+  };
+
+  const response = await fetch('/api/backends/chat-completions/generate', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-CSRF-Token': token,
+    },
+    credentials: 'include',
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const errText = await response.text().catch(() => '');
+    throw new Error(`Vision request failed (${response.status}): ${errText.slice(0, 200)}`);
+  }
+
+  const data = await response.json();
+  // Pull the text content out of whichever response shape the backend returned.
+  // Two formats land here depending on the provider:
+  //   • OpenAI-style:    { choices: [{ message: { content: "..." } }] }
+  //   • Anthropic-native: { content: [{ type: "thinking", ... }, { type: "text", text: "..." }] }
+  // Claude with extended thinking yields the second; we read text blocks from
+  // either shape and concatenate (just in case there are multiple).
+  const contentText = (() => {
+    const openai = data?.choices?.[0]?.message?.content;
+    if (typeof openai === 'string' && openai.length > 0) return openai;
+    const anthropic = data?.content;
+    if (Array.isArray(anthropic)) {
+      return anthropic
+        .filter((b: unknown) => (b as { type?: string })?.type === 'text')
+        .map((b: { text?: string }) => b.text ?? '')
+        .join('\n');
+    }
+    return '';
+  })();
+  if (!contentText) {
+    throw new Error('Vision response had no readable text content');
+  }
+
+  const parsed = extractJsonObject(contentText);
+  if (!isAnchorCenters(parsed)) {
+    throw new Error('Vision response did not contain expected anchor coordinates');
+  }
+
+  // Clamp to [0, 1] in case the model returns a value just outside.
+  const clamp = (n: number) => Math.max(0, Math.min(1, n));
+
+  return {
+    leftEye:  { cx: clamp(parsed.leftEye.cx),  cy: clamp(parsed.leftEye.cy),  ...DEFAULT_RADII.leftEye },
+    rightEye: { cx: clamp(parsed.rightEye.cx), cy: clamp(parsed.rightEye.cy), ...DEFAULT_RADII.rightEye },
+    mouth:    { cx: clamp(parsed.mouth.cx),    cy: clamp(parsed.mouth.cy),    ...DEFAULT_RADII.mouth },
+  };
+}

--- a/src/components/character/LivePortraitSetup.tsx
+++ b/src/components/character/LivePortraitSetup.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { Sparkles, Loader2 } from 'lucide-react';
 import { Modal } from '../ui/Modal';
 import { Button } from '../ui/Button';
 import { showToastGlobal } from '../ui/Toast';
@@ -8,16 +9,19 @@ import {
   type PortraitAnchors,
   DEFAULT_ANCHORS,
 } from '../chat/LivePortrait';
+import { detectFaceAnchors } from '../../api/faceDetection';
 
 /**
- * LivePortraitSetup — guided click-to-place modal for marking a character's
- * left eye, right eye, and mouth on their avatar. Three clicks, sensible
- * default radii, instant preview through the live mesh-warp pipeline so the
- * user can sanity-check that blink/talk lands on the right spots.
+ * LivePortraitSetup — anchor-placement modal for the Live Portrait animator.
  *
- * MediaPipe-driven auto-detection is a future iteration; manual placement
- * works for any art style (anime/illustrated avatars are the dominant case
- * in this app and don't auto-landmark well).
+ * Three approaches, in order of effort:
+ *   1. ✨ Auto-detect — vision LLM finds eyes and mouth, fills all three.
+ *   2. Click any anchor tab, then click on the avatar to place / move that
+ *      one anchor. Other markers stay put.
+ *   3. Click directly on a marker dot to switch the active tab to that anchor.
+ *
+ * Live preview through the same renderer is always visible so the user can
+ * sanity-check that blink/talk lands on the right spots before saving.
  */
 
 interface LivePortraitSetupProps {
@@ -29,171 +33,249 @@ interface LivePortraitSetupProps {
   onClose: () => void;
 }
 
-type Step = 'leftEye' | 'rightEye' | 'mouth' | 'preview';
+type AnchorKey = 'leftEye' | 'rightEye' | 'mouth';
 
-const STEP_LABELS: Record<Exclude<Step, 'preview'>, string> = {
-  leftEye: 'Click the center of the LEFT eye',
-  rightEye: 'Click the center of the RIGHT eye',
-  mouth: 'Click the center of the mouth',
+const ANCHOR_KEYS: AnchorKey[] = ['leftEye', 'rightEye', 'mouth'];
+
+const ANCHOR_LABELS: Record<AnchorKey, string> = {
+  leftEye: 'Left eye',
+  rightEye: 'Right eye',
+  mouth: 'Mouth',
 };
 
-const STEP_ORDER: Step[] = ['leftEye', 'rightEye', 'mouth', 'preview'];
+const ANCHOR_COLORS: Record<AnchorKey, string> = {
+  leftEye: '#60a5fa',
+  rightEye: '#60a5fa',
+  mouth: '#f472b6',
+};
 
-/**
- * Default radii sized for typical face proportions. cx/cy come from clicks.
- * Set generously so the warp always has multiple mesh vertices to work with;
- * tighter ellipses look anatomically truer but produce no visible motion on
- * sparse grids.
- */
-const DEFAULT_RADII = {
+/** Default radii sized for typical face proportions. cx/cy come from clicks. */
+const DEFAULT_RADII: Record<AnchorKey, { rx: number; ry: number }> = {
   leftEye:  { rx: 0.06, ry: 0.04 },
   rightEye: { rx: 0.06, ry: 0.04 },
   mouth:    { rx: 0.07, ry: 0.04 },
 };
+
+/** Initial draft when no anchors have been saved yet — sensible centered guesses. */
+function initialDraft(): PortraitAnchors {
+  return {
+    leftEye:  { cx: 0.42, cy: 0.42, ...DEFAULT_RADII.leftEye },
+    rightEye: { cx: 0.58, cy: 0.42, ...DEFAULT_RADII.rightEye },
+    mouth:    { cx: 0.50, cy: 0.62, ...DEFAULT_RADII.mouth },
+  };
+}
 
 export function LivePortraitSetup({ avatar, imageUrl, isOpen, onClose }: LivePortraitSetupProps) {
   const existing = useLivePortraitStore((s) => s.anchorsByAvatar[avatar]);
   const setAnchorsInStore = useLivePortraitStore((s) => s.setAnchors);
   const clearAnchorsInStore = useLivePortraitStore((s) => s.clearAnchors);
 
-  const [step, setStep] = useState<Step>(existing ? 'preview' : 'leftEye');
-  const [draft, setDraft] = useState<Partial<PortraitAnchors>>(() =>
-    existing ? { ...existing } : {},
-  );
+  const [draft, setDraft] = useState<PortraitAnchors>(() => existing ?? initialDraft());
+  const [activeKey, setActiveKey] = useState<AnchorKey>('leftEye');
+  const [isDetecting, setIsDetecting] = useState(false);
   const imgRef = useRef<HTMLImageElement>(null);
 
-  // Reset state whenever the modal is freshly opened (in case the user closed
-  // mid-setup last time and wants a clean run).
+  // Reset state whenever the modal is freshly opened.
   useEffect(() => {
     if (!isOpen) return;
-    setStep(existing ? 'preview' : 'leftEye');
-    setDraft(existing ? { ...existing } : {});
+    setDraft(existing ?? initialDraft());
+    setActiveKey('leftEye');
+    setIsDetecting(false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen]);
 
+  function placeAnchor(cx: number, cy: number) {
+    setDraft((d) => ({
+      ...d,
+      [activeKey]: { ...d[activeKey], cx, cy },
+    }));
+  }
+
   function handleImageClick(e: React.MouseEvent<HTMLImageElement>) {
-    if (step === 'preview') return;
+    if (isDetecting) return;
     const rect = e.currentTarget.getBoundingClientRect();
     const cx = (e.clientX - rect.left) / rect.width;
     const cy = (e.clientY - rect.top) / rect.height;
-    const radii = DEFAULT_RADII[step];
-    setDraft((d) => ({
-      ...d,
-      [step]: { cx, cy, rx: radii.rx, ry: radii.ry },
-    }));
-    // Advance to next step
-    const i = STEP_ORDER.indexOf(step);
-    setStep(STEP_ORDER[i + 1]);
+    placeAnchor(cx, cy);
+  }
+
+  function handleMarkerClick(e: React.MouseEvent, key: AnchorKey) {
+    e.stopPropagation();
+    setActiveKey(key);
+  }
+
+  async function handleAutoDetect() {
+    setIsDetecting(true);
+    try {
+      const detected = await detectFaceAnchors(imageUrl);
+      setDraft(detected);
+      showToastGlobal('Anchors detected — review and save.', 'success');
+    } catch (err) {
+      showToastGlobal(
+        err instanceof Error ? err.message : 'Auto-detection failed',
+        'error',
+      );
+    } finally {
+      setIsDetecting(false);
+    }
   }
 
   function handleSave() {
-    if (!draft.leftEye || !draft.rightEye || !draft.mouth) {
-      showToastGlobal('Click all three points before saving.', 'error');
-      return;
-    }
-    setAnchorsInStore(avatar, draft as PortraitAnchors);
+    setAnchorsInStore(avatar, draft);
     showToastGlobal('Live Portrait anchors saved.', 'success');
     onClose();
   }
 
   function handleClear() {
     clearAnchorsInStore(avatar);
-    setDraft({});
-    setStep('leftEye');
+    setDraft(initialDraft());
+    setActiveKey('leftEye');
     showToastGlobal('Live Portrait anchors cleared.', 'info');
   }
-
-  function handleRestart() {
-    setDraft({});
-    setStep('leftEye');
-  }
-
-  // Markers overlaid on the image to show which clicks have landed.
-  const markers: { key: string; cx: number; cy: number; color: string }[] = [];
-  if (draft.leftEye) markers.push({ key: 'L', cx: draft.leftEye.cx, cy: draft.leftEye.cy, color: '#60a5fa' });
-  if (draft.rightEye) markers.push({ key: 'R', cx: draft.rightEye.cx, cy: draft.rightEye.cy, color: '#60a5fa' });
-  if (draft.mouth) markers.push({ key: 'M', cx: draft.mouth.cx, cy: draft.mouth.cy, color: '#f472b6' });
-
-  const previewAnchors: PortraitAnchors = {
-    leftEye:  draft.leftEye  ?? DEFAULT_ANCHORS.leftEye,
-    rightEye: draft.rightEye ?? DEFAULT_ANCHORS.rightEye,
-    mouth:    draft.mouth    ?? DEFAULT_ANCHORS.mouth,
-  };
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} title="Live Portrait setup" size="lg">
       <div className="space-y-3">
+        {/* Action row: auto-detect + per-anchor tabs */}
+        <div className="flex flex-wrap items-center gap-2 pb-2 border-b border-[var(--color-border)]">
+          <Button
+            type="button"
+            variant="primary"
+            size="sm"
+            onClick={handleAutoDetect}
+            disabled={isDetecting}
+          >
+            {isDetecting ? (
+              <>
+                <Loader2 size={14} className="animate-spin mr-1.5" />
+                Detecting…
+              </>
+            ) : (
+              <>
+                <Sparkles size={14} className="mr-1.5" />
+                Auto-detect
+              </>
+            )}
+          </Button>
+
+          <div className="flex-1" />
+
+          <div className="flex gap-1 bg-[var(--color-bg-tertiary)] rounded-lg p-1">
+            {ANCHOR_KEYS.map((k) => (
+              <button
+                key={k}
+                type="button"
+                onClick={() => setActiveKey(k)}
+                disabled={isDetecting}
+                className={`px-3 py-1 text-xs rounded-md transition-colors ${
+                  activeKey === k
+                    ? 'bg-[var(--color-primary)] text-white'
+                    : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]'
+                }`}
+              >
+                <span
+                  className="inline-block w-2 h-2 rounded-full mr-1.5 align-middle"
+                  style={{ background: ANCHOR_COLORS[k] }}
+                />
+                {ANCHOR_LABELS[k]}
+              </button>
+            ))}
+          </div>
+        </div>
+
         <p className="text-xs text-[var(--color-text-secondary)]">
-          {step === 'preview'
-            ? 'Preview — the avatar should breathe, blink, and open its mouth on the toggle below. Re-do or save when ready.'
-            : STEP_LABELS[step]}
+          Tap <strong>Auto-detect</strong> to have an AI find the anchors for you, or click on the
+          image to place the currently-selected anchor (
+          <span className="font-medium text-[var(--color-text-primary)]">
+            {ANCHOR_LABELS[activeKey].toLowerCase()}
+          </span>
+          ). Tap a colored dot to switch which anchor you're editing.
         </p>
 
         <div className="flex flex-wrap gap-6">
-          {/* Click target / static reference */}
+          {/* Click target with overlaid markers */}
           <div className="relative inline-block">
             <img
               ref={imgRef}
               src={imageUrl}
               alt="setup"
               onClick={handleImageClick}
-              className={`block max-h-[480px] rounded ${step === 'preview' ? '' : 'cursor-crosshair'}`}
+              className={`block max-h-[480px] rounded select-none ${
+                isDetecting ? 'opacity-60 cursor-progress' : 'cursor-crosshair'
+              }`}
               draggable={false}
             />
-            {markers.map((m) => (
-              <div
-                key={m.key}
-                className="absolute pointer-events-none"
-                style={{
-                  left: `${m.cx * 100}%`,
-                  top: `${m.cy * 100}%`,
-                  width: 14,
-                  height: 14,
-                  marginLeft: -7,
-                  marginTop: -7,
-                  borderRadius: '50%',
-                  background: m.color,
-                  boxShadow: '0 0 0 2px rgba(0,0,0,0.5)',
-                }}
-              />
-            ))}
+            {ANCHOR_KEYS.map((k) => {
+              const a = draft[k];
+              const isActive = activeKey === k;
+              return (
+                <button
+                  key={k}
+                  type="button"
+                  aria-label={`Edit ${ANCHOR_LABELS[k]}`}
+                  onClick={(e) => handleMarkerClick(e, k)}
+                  className="absolute"
+                  style={{
+                    left: `${a.cx * 100}%`,
+                    top: `${a.cy * 100}%`,
+                    width: 18,
+                    height: 18,
+                    marginLeft: -9,
+                    marginTop: -9,
+                    borderRadius: '50%',
+                    background: ANCHOR_COLORS[k],
+                    border: isActive ? '3px solid #fff' : '2px solid rgba(0,0,0,0.6)',
+                    boxShadow: isActive
+                      ? '0 0 0 3px rgba(255,255,255,0.4), 0 0 8px ' + ANCHOR_COLORS[k]
+                      : '0 0 0 2px rgba(0,0,0,0.5)',
+                    cursor: 'pointer',
+                    padding: 0,
+                  }}
+                />
+              );
+            })}
           </div>
 
-          {/* Live preview only after all three points exist */}
-          {draft.leftEye && draft.rightEye && draft.mouth && (
-            <div>
-              <p className="text-[10px] font-mono uppercase tracking-wide text-[var(--color-text-secondary)] mb-1">
-                live preview
-              </p>
-              <LivePortrait
-                imageUrl={imageUrl}
-                size={320}
-                anchors={previewAnchors}
-                isSpeaking={step === 'preview'}
-              />
-            </div>
-          )}
+          {/* Live preview always visible — always animates */}
+          <div>
+            <p className="text-[10px] font-mono uppercase tracking-wide text-[var(--color-text-secondary)] mb-1">
+              live preview
+            </p>
+            <LivePortrait
+              imageUrl={imageUrl}
+              size={320}
+              anchors={draft}
+              isSpeaking={true}
+            />
+            <p className="text-[10px] text-[var(--color-text-secondary)] mt-1 max-w-[320px]">
+              Mouth is forced open here so you can verify mouth placement. In chat it only
+              opens during AI replies.
+            </p>
+          </div>
         </div>
 
         <div className="flex flex-wrap gap-2 pt-2 border-t border-[var(--color-border)]">
-          <Button variant="ghost" size="sm" onClick={handleRestart}>
-            Restart
-          </Button>
           {existing && (
-            <Button variant="ghost" size="sm" onClick={handleClear}>
+            <Button type="button" variant="ghost" size="sm" onClick={handleClear}>
               Clear saved
             </Button>
           )}
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              setDraft(initialDraft());
+              setActiveKey('leftEye');
+            }}
+          >
+            Reset
+          </Button>
           <div className="flex-1" />
-          <Button variant="ghost" size="sm" onClick={onClose}>
+          <Button type="button" variant="ghost" size="sm" onClick={onClose}>
             Cancel
           </Button>
-          <Button
-            variant="primary"
-            size="sm"
-            onClick={handleSave}
-            disabled={!draft.leftEye || !draft.rightEye || !draft.mouth}
-          >
+          <Button type="button" variant="primary" size="sm" onClick={handleSave}>
             Save
           </Button>
         </div>
@@ -201,3 +283,6 @@ export function LivePortraitSetup({ avatar, imageUrl, isOpen, onClose }: LivePor
     </Modal>
   );
 }
+
+// Used for the live preview's initial-state fallback if draft isn't yet shaped right.
+void DEFAULT_ANCHORS;


### PR DESCRIPTION
## Summary
The original Live Portrait setup was a linear state machine — click eye → eye → mouth → save, or hit Restart and start over. If your right eye landed wrong, you couldn't tell which one was off and you couldn't edit it without redoing all three. This PR fixes that two ways:

1. **Per-marker editing.** Three selectable tabs at the top (Left eye / Right eye / Mouth). Whichever is active gets placed on the next image click; tap any colored dot on the image to switch the active tab to that one. Live preview always renders all three current anchors so you can sanity-check while editing.
2. **✨ Auto-detect button.** Sends the avatar through the existing SillyTavern chat-completions backend (same plumbing the chat already uses — auth/CSRF/provider routing all reused) with a structured prompt asking for normalized eye + mouth coordinates as JSON. One click, fills all three markers. Verified end-to-end: Claude Sonnet 4.6 placed anchors directly on Mina Hope's eyes and mouth on the first try.

## Technical notes
- **Response shape handling.** Claude with extended thinking returns Anthropic-native `content[]` with `thinking` and `text` blocks rather than OpenAI-style `choices[0].message.content`. The parser reads text blocks from either shape so we don't depend on which provider the user has configured.
- **Image preprocessing.** Avatars are downscaled to 768px on the long side and JPEG-encoded at 85% quality before upload — full-res PNGs are 700KB+ and slow the call without improving detection.
- **No new deps.** Adds ~5KB to the main chunk.

## Test plan
- [x] `npm run build` clean
- [x] Manual marker placement: click "Right eye" tab → click on image → only right eye moves; left eye and mouth stay put
- [x] Click on existing marker dot → switches active tab to that one
- [x] Auto-detect HTTP call hits `/api/backends/chat-completions/generate` with a multimodal payload
- [x] Anchor coords from Claude land directly on the actual face features
- [x] "Mouth is forced open" preview now visible at all times so the user can verify mouth placement before save
- [ ] Manual smoke on the deployed env with a real Claude API key