### PR TITLE
feat(live-portrait): sidebar portrait + sticky headers + expression delete

### DIFF
--- a/src/api/livePortraitGen.ts
+++ b/src/api/livePortraitGen.ts
@@ -4,11 +4,11 @@ import type { EmotionClips } from '../stores/livePortraitStore';
 /**
  * Live Portrait clip generation client — talks to the SillyTavern backend's
  * `/api/live-portrait/*` route family which proxies to Replicate's
- * fofr/live-portrait model.
+ * wan-video/wan-2.2-i2v-fast model.
  *
- * The backend handles auth, secrets, and saving the resulting MP4s into the
- * character data dir; this module just kicks off a job and polls until it's
- * done. Generation usually takes 30–90s per emotion clip. We surface a
+ * The backend handles auth, secrets, avatar upload, and saving the resulting
+ * MP4s into the character data dir; this module just kicks off a job and polls
+ * until it's done. Generation takes ~30–60s per emotion clip. We surface a
  * progress callback so the setup modal can show a progress bar.
  */
 

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -15,9 +15,6 @@ import { applyRegexScripts, getActiveScripts } from '../../utils/regexScripts';
 import { useTranslateStore } from '../../stores/translateStore';
 import { useExtensionStore } from '../../stores/extensionStore';
 import { useSlotItems, invokeSlotItem } from '../../extensions/sandbox/sandboxSlotRegistry';
-import { LivePortraitVideo } from './LivePortraitVideo';
-import { useLivePortraitStore } from '../../stores/livePortraitStore';
-import { parseEmotion } from '../../utils/emotions';
 
 interface ChatMessageProps {
   /** Unique message id — used as TTS tracking key. */
@@ -89,7 +86,6 @@ export function ChatMessage({
   onSwipeLeft,
   onSwipeRight,
   isStreaming: isStreamingMsg,
-  isLastMessage,
   layoutMode = 'bubbles',
   avatarShape = 'circle',
   fontSize,
@@ -471,56 +467,6 @@ export function ChatMessage({
     />
   ) : null;
 
-  // ==================================================================
-  // Avatar selection — LivePortraitVideo for the latest AI message of a
-  // character that has clips generated; static <Avatar> everywhere else.
-  // Falls back gracefully when clips are missing or the feature is
-  // globally disabled.
-  // ==================================================================
-  const livePortraitEnabled = useLivePortraitStore((s) => s.enabled);
-  const livePortraitClips = useLivePortraitStore((s) =>
-    characterAvatar ? s.clipsByAvatar[characterAvatar] : undefined,
-  );
-  const hasClips = !!livePortraitClips && Object.keys(livePortraitClips).length > 0;
-  const useLivePortrait =
-    livePortraitEnabled &&
-    hasClips &&
-    !isUser &&
-    !isSystem &&
-    !!isLastMessage;
-  // Pull the AI's emitted [emotion:...] tag if any. Falls back to idle when
-  // no tag is present or the tag doesn't match a generated clip.
-  const liveEmotion = useLivePortrait ? parseEmotion(content) : null;
-  const renderAvatar = (size: 'sm' | 'md') => {
-    if (useLivePortrait && livePortraitClips) {
-      const px = size === 'md' ? 80 : 48;
-      // Only show emotion overlay while streaming OR if the AI emitted a
-      // matching tag — otherwise idle alone is more lifelike.
-      const emotionToPlay =
-        isStreamingMsg && liveEmotion && livePortraitClips[liveEmotion]
-          ? liveEmotion
-          : null;
-      return (
-        <LivePortraitVideo
-          clips={livePortraitClips}
-          emotion={emotionToPlay}
-          size={px}
-          shape={avatarShape === 'square' ? 'square' : 'circle'}
-        />
-      );
-    }
-    return (
-      <Avatar
-        src={avatar}
-        fallbackSrc={avatarFallback}
-        onFallback={onAvatarError}
-        alt={name}
-        size={size}
-        shape={avatarShape}
-        className="flex-shrink-0"
-      />
-    );
-  };
 
   // ==================================================================
   // Bubbles layout (default — original behavior)
@@ -528,7 +474,15 @@ export function ChatMessage({
   if (layoutMode === 'bubbles') {
     return (
       <div className={`flex gap-3 px-4 py-3 group ${isUser ? 'flex-row-reverse' : 'flex-row'}`}>
-        {renderAvatar('md')}
+        <Avatar
+          src={avatar}
+          fallbackSrc={avatarFallback}
+          onFallback={onAvatarError}
+          alt={name}
+          size="md"
+          shape={avatarShape}
+          className="flex-shrink-0"
+        />
 
         <div
           className={`flex flex-col ${isUser ? 'items-end' : 'items-start'}`}
@@ -577,7 +531,15 @@ export function ChatMessage({
       >
         {/* Header row: avatar + name + time + actions */}
         <div className="flex items-center gap-2 mb-1.5">
-          {renderAvatar('sm')}
+          <Avatar
+            src={avatar}
+            fallbackSrc={avatarFallback}
+            onFallback={onAvatarError}
+            alt={name}
+            size="sm"
+            shape={avatarShape}
+            className="flex-shrink-0"
+          />
           <span className={`text-xs font-semibold ${
             isUser ? 'text-[var(--color-primary)]' : 'text-[var(--color-text-secondary)]'
           }`}>

--- a/src/components/chat/LivePortraitVideo.tsx
+++ b/src/components/chat/LivePortraitVideo.tsx
@@ -16,12 +16,14 @@ export interface LivePortraitVideoProps {
   clips: EmotionClips;
   /** Current emotion to play on top of idle. `null` plays idle alone. */
   emotion?: string | null;
-  /** Diameter of the avatar in CSS pixels (square). */
+  /** Diameter of the avatar in CSS pixels (square). Ignored when `fill` is true. */
   size?: number;
   /** "circle" | "square" — matches the existing Avatar shape prop. */
   shape?: 'circle' | 'square';
   /** Optional className on the outer wrapper. */
   className?: string;
+  /** Fill the parent container (100% × 100%) instead of using a fixed `size`. */
+  fill?: boolean;
 }
 
 const FADE_MS = 250;
@@ -32,6 +34,7 @@ export function LivePortraitVideo({
   size = 80,
   shape = 'circle',
   className,
+  fill = false,
 }: LivePortraitVideoProps) {
   const idleRef = useRef<HTMLVideoElement>(null);
   const emotionRef = useRef<HTMLVideoElement>(null);
@@ -75,9 +78,9 @@ export function LivePortraitVideo({
       className={className}
       style={{
         position: 'relative',
-        width: size,
-        height: size,
-        flexShrink: 0,
+        width: fill ? '100%' : size,
+        height: fill ? '100%' : size,
+        flexShrink: fill ? undefined : 0,
         overflow: 'hidden',
         borderRadius: radius,
       }}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -26,6 +26,8 @@ import { CharacterCreation } from '../character/CharacterCreation';
 import { CharacterImport } from '../character/CharacterImport';
 import { useCharacterSprites } from '../../hooks/useCharacterSprites';
 import { getDefaultAvatarUrl, type Emotion } from '../../utils/emotions';
+import { LivePortraitVideo } from '../chat/LivePortraitVideo';
+import { useLivePortraitStore } from '../../stores/livePortraitStore';
 
 interface SidebarProps {
   isOpen: boolean;
@@ -84,6 +86,12 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
     if (characterMessages.length === 0) return null;
     return (characterMessages[characterMessages.length - 1] as { emotion?: Emotion | null }).emotion ?? null;
   }, [messages]);
+
+  const livePortraitEnabled = useLivePortraitStore((s) => s.enabled);
+  const livePortraitClips = useLivePortraitStore((s) =>
+    selectedCharacter ? s.getClips(selectedCharacter.avatar) : null,
+  );
+  const hasLivePortrait = livePortraitEnabled && !!livePortraitClips && 'idle' in livePortraitClips;
 
   useEffect(() => {
     fetchCharacters();
@@ -224,23 +232,31 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
             {/* Full Character Portrait */}
             <div className="flex-1 flex flex-col items-center justify-center p-4 overflow-hidden">
               <div className="w-full max-w-[240px] aspect-[2/3] rounded-xl overflow-hidden shadow-lg border border-[var(--color-border)]">
-                <img
-                  key={`${selectedCharacter.avatar}-${latestEmotion ?? 'neutral'}`}
-                  src={getFullImageUrl(selectedCharacter.avatar, latestEmotion)}
-                  alt={selectedCharacter.name}
-                  className="w-full h-full object-cover transition-opacity duration-300"
-                  onLoad={(e) => {
-                    console.log('[Sidebar Expression] Image loaded:', e.currentTarget.src);
-                  }}
-                  onError={(e) => {
-                    console.log('[Sidebar Expression] Image FAILED:', e.currentTarget.src);
-                    // Mark this expression as failed so we use fallback next time
-                    if (latestEmotion) {
-                      const expressionKey = `${selectedCharacter.avatar}-${latestEmotion}`;
-                      setFailedExpressions((prev) => new Set(prev).add(expressionKey));
-                    }
-                  }}
-                />
+                {hasLivePortrait ? (
+                  <LivePortraitVideo
+                    clips={livePortraitClips!}
+                    emotion={latestEmotion}
+                    fill
+                    shape="square"
+                  />
+                ) : (
+                  <img
+                    key={`${selectedCharacter.avatar}-${latestEmotion ?? 'neutral'}`}
+                    src={getFullImageUrl(selectedCharacter.avatar, latestEmotion)}
+                    alt={selectedCharacter.name}
+                    className="w-full h-full object-cover transition-opacity duration-300"
+                    onLoad={(e) => {
+                      console.log('[Sidebar Expression] Image loaded:', e.currentTarget.src);
+                    }}
+                    onError={(e) => {
+                      console.log('[Sidebar Expression] Image FAILED:', e.currentTarget.src);
+                      if (latestEmotion) {
+                        const expressionKey = `${selectedCharacter.avatar}-${latestEmotion}`;
+                        setFailedExpressions((prev) => new Set(prev).add(expressionKey));
+                      }
+                    }}
+                  />
+                )}
               </div>
 
               {/* Character Info */}

--- a/src/components/settings/AISettingsPage.tsx
+++ b/src/components/settings/AISettingsPage.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useState } from 'react';
-import { ArrowLeft, Check, Eye, EyeOff, Globe, Key, LayoutGrid, Loader2, Plug, Server, Trash2 } from 'lucide-react';
+import { ArrowLeft, Check, ChevronDown, Eye, EyeOff, Globe, Key, LayoutGrid, Loader2, Plug, Server, Trash2 } from 'lucide-react';
 import { useSettingsPanelStore } from '../../stores/settingsPanelStore';
 import { useSettingsStore } from '../../stores/settingsStore';
 import { useConnectionProfileStore } from '../../stores/connectionProfileStore';
 import { useGenerationStore } from '../../stores/generationStore';
 import { useCustomProviderStore } from '../../stores/customProviderStore';
-import { PROVIDERS, type SecretState } from '../../api/client';
+import { PROVIDERS, settingsApi, type SecretState } from '../../api/client';
 import { probeProviderModels } from '../../api/providerProbe';
 import { useAuthStore } from '../../stores/authStore';
 import { hasMinRole } from '../../utils/permissions';
@@ -107,6 +107,8 @@ export function AISettingsPage(_props?: { params?: Record<string, string> }) {
   const [showApiKey, setShowApiKey] = useState<Record<string, boolean>>({});
   const [globalKeyInputs, setGlobalKeyInputs] = useState<Record<string, string>>({});
   const [showGlobalKey, setShowGlobalKey] = useState<Record<string, boolean>>({});
+  const [apiKeysOpen, setApiKeysOpen] = useState(false);
+  const [globalKeysOpen, setGlobalKeysOpen] = useState(false);
 
   // Connection profiles
   const { profiles, activeProfileId, saveProfile, deleteProfile, renameProfile, setActiveProfileId } = useConnectionProfileStore();
@@ -179,7 +181,7 @@ export function AISettingsPage(_props?: { params?: Record<string, string> }) {
 
   return (
     <div className="min-h-screen bg-[var(--color-bg-primary)]">
-      <header className="h-14 bg-[var(--color-bg-secondary)] border-b border-[var(--color-border)] flex items-center pl-4 pr-14 gap-3 safe-top">
+      <header className="h-14 bg-[var(--color-bg-secondary)] border-b border-[var(--color-border)] flex items-center pl-4 pr-14 gap-3 safe-top sticky top-0 z-10">
         <Button variant="ghost" size="sm" onClick={() => goBack()} className="p-2" aria-label="Back">
           <ArrowLeft size={24} />
         </Button>
@@ -441,8 +443,15 @@ export function AISettingsPage(_props?: { params?: Record<string, string> }) {
 
         {/* API Keys */}
         <section className="bg-[var(--color-bg-secondary)] rounded-lg p-4 cyberpunk-card">
-          <h2 className="text-sm font-semibold text-[var(--color-text-primary)] mb-3">API Keys</h2>
-          <div className="space-y-4">
+          <button
+            type="button"
+            onClick={() => setApiKeysOpen((v) => !v)}
+            className="w-full flex items-center justify-between"
+          >
+            <h2 className="text-sm font-semibold text-[var(--color-text-primary)]">API Keys</h2>
+            <ChevronDown size={16} className={`text-[var(--color-text-secondary)] transition-transform ${apiKeysOpen ? 'rotate-180' : ''}`} />
+          </button>
+          {apiKeysOpen && <div className="space-y-4 mt-3">
             {PROVIDERS.filter((p) => p.id !== 'custom').map((provider) => {
               const secretInfo = getSecretInfo(provider.secretKey);
               const configured = !!secretInfo;
@@ -481,7 +490,7 @@ export function AISettingsPage(_props?: { params?: Record<string, string> }) {
                 </div>
               );
             })}
-          </div>
+          </div>}
         </section>
 
         {/* Live Portrait (Replicate) */}
@@ -492,7 +501,8 @@ export function AISettingsPage(_props?: { params?: Record<string, string> }) {
           </div>
           <p className="text-xs text-[var(--color-text-secondary)] mb-3">
             Replicate API key for generating per-emotion character animation clips via{' '}
-            <span className="font-mono">fofr/live-portrait</span>.
+            <span className="font-mono">wan-video/wan-2.2-i2v-fast</span>.
+            Videos are generated from the character's portrait — no driving videos needed.
           </p>
           <div className="p-3 bg-[var(--color-bg-tertiary)] rounded-lg">
             <div className="flex items-center justify-between mb-2">
@@ -524,8 +534,13 @@ export function AISettingsPage(_props?: { params?: Record<string, string> }) {
                 onClick={async () => {
                   const key = apiKeyInputs['replicate-live'];
                   if (!key?.trim()) return;
-                  await saveApiKey('api_key_replicate', key.trim());
-                  setApiKeyInputs((prev) => ({ ...prev, 'replicate-live': '' }));
+                  try {
+                    await settingsApi.writeSecret('api_key_replicate', key.trim(), 'Replicate');
+                    await fetchSecrets();
+                    setApiKeyInputs((prev) => ({ ...prev, 'replicate-live': '' }));
+                  } catch (e) {
+                    showToastGlobal(e instanceof Error ? e.message : 'Failed to save key', 'error');
+                  }
                 }}
                 disabled={!apiKeyInputs['replicate-live']?.trim() || isSaving}
                 className="shrink-0"
@@ -539,11 +554,16 @@ export function AISettingsPage(_props?: { params?: Record<string, string> }) {
         {/* Global API Keys — Owner only */}
         {isOwner && globalSharingSupported && (
           <section className="bg-[var(--color-bg-secondary)] rounded-lg p-4 cyberpunk-card">
-            <div className="flex items-center justify-between mb-3">
-              <div className="flex items-center gap-2">
+            <div className="flex items-center justify-between">
+              <button
+                type="button"
+                onClick={() => setGlobalKeysOpen((v) => !v)}
+                className="flex items-center gap-2 flex-1"
+              >
                 <Globe size={16} className="text-[var(--color-text-secondary)]" />
                 <h2 className="text-sm font-semibold text-[var(--color-text-primary)]">Global API Keys</h2>
-              </div>
+                <ChevronDown size={16} className={`text-[var(--color-text-secondary)] transition-transform ml-1 ${globalKeysOpen ? 'rotate-180' : ''}`} />
+              </button>
               <div className="flex items-center gap-2">
                 <span className="text-xs text-[var(--color-text-secondary)]">Share with all users</span>
                 <button
@@ -561,7 +581,8 @@ export function AISettingsPage(_props?: { params?: Record<string, string> }) {
                 </button>
               </div>
             </div>
-            <p className="text-xs text-[var(--color-text-secondary)] mb-3">
+            {globalKeysOpen && <>
+            <p className="text-xs text-[var(--color-text-secondary)] mt-3 mb-3">
               Keys set here are used as defaults for users who haven't entered their own. Your personal keys above always take priority.
             </p>
             <div className="space-y-4">
@@ -604,6 +625,7 @@ export function AISettingsPage(_props?: { params?: Record<string, string> }) {
                 );
               })}
             </div>
+            </>}
           </section>
         )}
       </div>

--- a/src/components/settings/CharacterManagementPage.tsx
+++ b/src/components/settings/CharacterManagementPage.tsx
@@ -145,7 +145,7 @@ export function CharacterManagementPage() {
   return (
     <div className="min-h-screen bg-[var(--color-bg-primary)]">
       {/* Header */}
-      <header className="h-14 bg-[var(--color-bg-secondary)] border-b border-[var(--color-border)] flex items-center pl-4 pr-14 gap-3 safe-top">
+      <header className="h-14 bg-[var(--color-bg-secondary)] border-b border-[var(--color-border)] flex items-center pl-4 pr-14 gap-3 safe-top sticky top-0 z-10">
         <Button variant="ghost" size="sm" onClick={() => goBack()} className="p-2" aria-label="Back">
           <ArrowLeft size={24} />
         </Button>

--- a/src/components/settings/DataBankPage.tsx
+++ b/src/components/settings/DataBankPage.tsx
@@ -331,7 +331,7 @@ export function DataBankPage(_props?: { params?: Record<string, string> }) {
   return (
     <div className="min-h-screen bg-[var(--color-bg-primary)]">
       {/* Header */}
-      <div className="sticky top-0 z-10 h-14 bg-[var(--color-bg-secondary)] border-b border-[var(--color-border)] flex items-center pl-4 pr-14 gap-3 safe-top">
+      <div className="sticky top-0 z-10 h-14 bg-[var(--color-bg-secondary)] border-b border-[var(--color-border)] flex items-center pl-4 pr-14 gap-3 safe-top sticky top-0 z-10">
         <Button
           variant="ghost"
           size="sm"

--- a/src/components/settings/GenerationSettingsPage.tsx
+++ b/src/components/settings/GenerationSettingsPage.tsx
@@ -65,7 +65,7 @@ export function GenerationSettingsPage(_props?: { params?: Record<string, string
   return (
     <div className="min-h-screen bg-[var(--color-bg-primary)]">
       {/* Header */}
-      <header className="h-14 bg-[var(--color-bg-secondary)] border-b border-[var(--color-border)] flex items-center pl-4 pr-14 gap-3 safe-top">
+      <header className="h-14 bg-[var(--color-bg-secondary)] border-b border-[var(--color-border)] flex items-center pl-4 pr-14 gap-3 safe-top sticky top-0 z-10">
         <Button
           variant="ghost"
           size="sm"

--- a/src/components/settings/InvitationManager.tsx
+++ b/src/components/settings/InvitationManager.tsx
@@ -115,7 +115,7 @@ export function InvitationManager(_props?: { params?: Record<string, string> }) 
   return (
     <div className="min-h-screen bg-[var(--color-bg-primary)]">
       {/* Header */}
-      <div className="sticky top-0 z-10 h-14 bg-[var(--color-bg-secondary)] border-b border-[var(--color-border)] flex items-center pl-4 pr-14 gap-3 safe-top">
+      <div className="sticky top-0 z-10 h-14 bg-[var(--color-bg-secondary)] border-b border-[var(--color-border)] flex items-center pl-4 pr-14 gap-3 safe-top sticky top-0 z-10">
         <Button variant="ghost" size="sm" onClick={() => goBack()} className="p-2" aria-label="Back">
           <ArrowLeft size={20} />
         </Button>

--- a/src/components/settings/MyKeysPage.tsx
+++ b/src/components/settings/MyKeysPage.tsx
@@ -79,7 +79,7 @@ export function MyKeysPage(_props?: { params?: Record<string, string> }) {
 
   return (
     <div className="min-h-screen bg-[var(--color-bg-primary)]">
-      <header className="h-14 bg-[var(--color-bg-secondary)] border-b border-[var(--color-border)] flex items-center pl-4 pr-14 gap-3 safe-top">
+      <header className="h-14 bg-[var(--color-bg-secondary)] border-b border-[var(--color-border)] flex items-center pl-4 pr-14 gap-3 safe-top sticky top-0 z-10">
         <Button variant="ghost" size="sm" onClick={() => goBack()} className="p-2" aria-label="Back">
           <ArrowLeft size={24} />
         </Button>

--- a/src/components/settings/PermissionGroupsPage.tsx
+++ b/src/components/settings/PermissionGroupsPage.tsx
@@ -78,7 +78,7 @@ export function PermissionGroupsPage(_props?: { params?: Record<string, string> 
   return (
     <div className="min-h-screen bg-[var(--color-bg-primary)]">
       {/* Header */}
-      <div className="sticky top-0 z-10 h-14 bg-[var(--color-bg-secondary)] border-b border-[var(--color-border)] flex items-center pl-4 pr-14 gap-3 safe-top">
+      <div className="sticky top-0 z-10 h-14 bg-[var(--color-bg-secondary)] border-b border-[var(--color-border)] flex items-center pl-4 pr-14 gap-3 safe-top sticky top-0 z-10">
         <Button variant="ghost" size="sm" onClick={() => goBack()} className="p-2" aria-label="Back">
           <ArrowLeft size={20} />
         </Button>

--- a/src/components/settings/PromptTemplatesPage.tsx
+++ b/src/components/settings/PromptTemplatesPage.tsx
@@ -109,7 +109,7 @@ export function PromptTemplatesPage(_props?: { params?: Record<string, string> }
   return (
     <div className="min-h-screen bg-[var(--color-bg-primary)]">
       {/* Header */}
-      <header className="h-14 bg-[var(--color-bg-secondary)] border-b border-[var(--color-border)] flex items-center pl-4 pr-14 gap-3 safe-top">
+      <header className="h-14 bg-[var(--color-bg-secondary)] border-b border-[var(--color-border)] flex items-center pl-4 pr-14 gap-3 safe-top sticky top-0 z-10">
         <Button
           variant="ghost"
           size="sm"

--- a/src/components/settings/QuickReplyPage.tsx
+++ b/src/components/settings/QuickReplyPage.tsx
@@ -145,7 +145,7 @@ export function QuickReplyPage(_props?: { params?: Record<string, string> }) {
   if (currentSet) {
     return (
       <div className="min-h-screen bg-[var(--color-bg-primary)]">
-        <header className="h-14 bg-[var(--color-bg-secondary)] border-b border-[var(--color-border)] flex items-center pl-4 pr-14 gap-3 safe-top">
+        <header className="h-14 bg-[var(--color-bg-secondary)] border-b border-[var(--color-border)] flex items-center pl-4 pr-14 gap-3 safe-top sticky top-0 z-10">
           <Button variant="ghost" size="sm" className="p-2" onClick={() => setViewSetId(null)} aria-label="Back">
             <ArrowLeft size={24} />
           </Button>
@@ -243,7 +243,7 @@ export function QuickReplyPage(_props?: { params?: Record<string, string> }) {
 
   return (
     <div className="min-h-screen bg-[var(--color-bg-primary)]">
-      <header className="h-14 bg-[var(--color-bg-secondary)] border-b border-[var(--color-border)] flex items-center pl-4 pr-14 gap-3 safe-top">
+      <header className="h-14 bg-[var(--color-bg-secondary)] border-b border-[var(--color-border)] flex items-center pl-4 pr-14 gap-3 safe-top sticky top-0 z-10">
         <Button variant="ghost" size="sm" className="p-2" onClick={() => goBack()} aria-label="Back">
           <ArrowLeft size={24} />
         </Button>

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -111,7 +111,7 @@ export function SettingsPage(_props?: { params?: Record<string, string> }) {
   return (
     <div className="min-h-screen bg-[var(--color-bg-primary)]">
       {/* Header */}
-      <header className="h-14 bg-[var(--color-bg-secondary)] border-b border-[var(--color-border)] flex items-center pl-4 pr-14 gap-3 safe-top">
+      <header className="h-14 bg-[var(--color-bg-secondary)] border-b border-[var(--color-border)] flex items-center pl-4 pr-14 gap-3 safe-top sticky top-0 z-10">
         <Button
           variant="ghost"
           size="sm"

--- a/src/components/settings/UserManagementPage.tsx
+++ b/src/components/settings/UserManagementPage.tsx
@@ -144,7 +144,7 @@ export function UserManagementPage(_props?: { params?: Record<string, string> })
 
   return (
     <div className="min-h-screen bg-[var(--color-bg-primary)]">
-      <div className="sticky top-0 z-10 h-14 bg-[var(--color-bg-secondary)] border-b border-[var(--color-border)] flex items-center pl-4 pr-14 gap-3 safe-top">
+      <div className="sticky top-0 z-10 h-14 bg-[var(--color-bg-secondary)] border-b border-[var(--color-border)] flex items-center pl-4 pr-14 gap-3 safe-top sticky top-0 z-10">
         <Button variant="ghost" size="sm" onClick={() => goBack()} className="p-2" aria-label="Back">
           <ArrowLeft size={20} />
         </Button>

--- a/src/components/ui/ExpressionUpload.tsx
+++ b/src/components/ui/ExpressionUpload.tsx
@@ -98,7 +98,10 @@ export function ExpressionUpload({ characterName, onExpressionsChange }: Express
     reader.readAsDataURL(file);
   };
 
-  const handleRemoveExpression = (label: string) => {
+  const handleRemoveExpression = async (label: string, existingPath?: string) => {
+    if (existingPath && characterName) {
+      await spritesApi.deleteSprite(characterName, label).catch(console.error);
+    }
     setExpressions((prev) => {
       const updated = prev.filter((e) => e.label !== label);
       notifyChanges(updated);
@@ -268,19 +271,17 @@ export function ExpressionUpload({ characterName, onExpressionsChange }: Express
                             <X size={14} />
                           </button>
                         )}
-                        {!entry.existingPath && (
-                          <button
-                            type="button"
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              handleRemoveExpression(entry.label);
-                            }}
-                            className="p-1 text-red-400 hover:text-red-500"
-                            title="Remove expression"
-                          >
-                            <Trash2 size={14} />
-                          </button>
-                        )}
+                        <button
+                          type="button"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handleRemoveExpression(entry.label, entry.existingPath);
+                          }}
+                          className="p-1 text-red-400 hover:text-red-500"
+                          title="Delete expression"
+                        >
+                          <Trash2 size={14} />
+                        </button>
                       </div>
                     </div>
 

--- a/src/components/worldinfo/WorldInfoPage.tsx
+++ b/src/components/worldinfo/WorldInfoPage.tsx
@@ -110,7 +110,7 @@ export function WorldInfoPage(_props?: { params?: Record<string, string> }) {
 
   return (
     <div className="min-h-screen bg-[var(--color-bg-primary)]">
-      <header className="h-14 bg-[var(--color-bg-secondary)] border-b border-[var(--color-border)] flex items-center pl-4 pr-14 gap-3 safe-top">
+      <header className="h-14 bg-[var(--color-bg-secondary)] border-b border-[var(--color-border)] flex items-center pl-4 pr-14 gap-3 safe-top sticky top-0 z-10">
         <Button
           variant="ghost"
           size="sm"


### PR DESCRIPTION
## Summary
- Live Portrait video clips now play in the sidebar's full-size portrait panel instead of the tiny chat avatar
- Chat message avatars always use static `<Avatar>` (reverted)
- Expression images: trash button now calls the API to delete the sprite from disk
- Sticky headers (`sticky top-0 z-10`) added to all settings and auth page headers

## Test plan
- [ ] Character with clips: sidebar plays animated video, fades on emotion change
- [ ] Character without clips: sidebar shows expression image as before
- [ ] Delete button on expression images removes the file
- [ ] Settings page headers stay pinned when scrolling

🤖 Generated with [Claude Code](https://claude.com/claude-code)