### PR TITLE
fix(nginx): bump header/cookie buffer sizes

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -95,4 +95,9 @@ server {
 
     # Allow uploads up to 20 MB (avatars, sprites, attachments)
     client_max_body_size 20M;
+
+    # Cookies + auth headers can grow past nginx's 8 KB default after a few
+    # sessions, producing 400 "Request Header Or Cookie Too Large".
+    large_client_header_buffers 8 32k;
+    client_header_buffer_size 16k;
 }


### PR DESCRIPTION
## Summary
Default `large_client_header_buffers 4 8k` overflowed after accumulated session cookies on production, causing 400 "Request Header Or Cookie Too Large" from the in-container nginx (1.29.8).

Already hotfixed on the live container; this PR makes the change persistent so the next docker image build inherits it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)