### PR TITLE
feat(portrait): tap-and-drag to reframe mobile portrait

### DIFF
--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -31,6 +31,7 @@ import { useAutoMemoryStore } from '../../stores/autoMemoryStore';
 import { useCharacterSprites } from '../../hooks/useCharacterSprites';
 import { LivePortraitVideo } from './LivePortraitVideo';
 import { useLivePortraitStore } from '../../stores/livePortraitStore';
+import { usePortraitPositionStore } from '../../stores/portraitPositionStore';
 import {
   getExpressionThumbnailUrl,
   getDefaultAvatarUrl,
@@ -226,6 +227,73 @@ export function ChatView() {
     selectedCharacter ? s.getClips(selectedCharacter.avatar) : null,
   );
   const hasLivePortrait = livePortraitEnabled && !!livePortraitClips && 'idle' in livePortraitClips;
+
+  // Per-character draggable framing for the mobile portrait panel.
+  // Stored as {x%, y%} object-position values, persisted via Zustand.
+  // Selectors return primitives to avoid Zustand getSnapshot identity churn.
+  const portraitAvatar = selectedCharacter?.avatar ?? null;
+  const storedPortraitX = usePortraitPositionStore((s) =>
+    portraitAvatar ? s.positionsByAvatar[portraitAvatar]?.x ?? 50 : 50,
+  );
+  const storedPortraitY = usePortraitPositionStore((s) =>
+    portraitAvatar ? s.positionsByAvatar[portraitAvatar]?.y ?? 0 : 0,
+  );
+  const setStoredPortraitPos = usePortraitPositionStore((s) => s.setPosition);
+  const [livePortraitPos, setLivePortraitPos] = useState({ x: storedPortraitX, y: storedPortraitY });
+  useEffect(() => {
+    setLivePortraitPos({ x: storedPortraitX, y: storedPortraitY });
+  }, [storedPortraitX, storedPortraitY, portraitAvatar]);
+
+  const portraitDragRef = useRef<HTMLDivElement>(null);
+  const portraitDragState = useRef<{
+    startX: number;
+    startY: number;
+    posX: number;
+    posY: number;
+    pointerId: number;
+  } | null>(null);
+
+  const handlePortraitPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (!portraitAvatar) return;
+    // Don't hijack taps on overlay buttons (search, etc.)
+    if ((e.target as HTMLElement).closest('button')) return;
+    portraitDragState.current = {
+      startX: e.clientX,
+      startY: e.clientY,
+      posX: livePortraitPos.x,
+      posY: livePortraitPos.y,
+      pointerId: e.pointerId,
+    };
+    e.currentTarget.setPointerCapture(e.pointerId);
+  };
+
+  const handlePortraitPointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    const drag = portraitDragState.current;
+    const el = portraitDragRef.current;
+    if (!drag || !el || drag.pointerId !== e.pointerId) return;
+    const rect = el.getBoundingClientRect();
+    if (rect.width === 0 || rect.height === 0) return;
+    // object-position decreases visually-rightward content as % grows, so a
+    // rightward finger drag should DECREASE x (reveal the left side of image).
+    const dx = -((e.clientX - drag.startX) / rect.width) * 100;
+    const dy = -((e.clientY - drag.startY) / rect.height) * 100;
+    setLivePortraitPos({
+      x: Math.max(0, Math.min(100, drag.posX + dx)),
+      y: Math.max(0, Math.min(100, drag.posY + dy)),
+    });
+  };
+
+  const handlePortraitPointerUp = (e: React.PointerEvent<HTMLDivElement>) => {
+    const drag = portraitDragState.current;
+    if (!drag || drag.pointerId !== e.pointerId) return;
+    if (portraitAvatar) {
+      setStoredPortraitPos(portraitAvatar, livePortraitPos);
+    }
+    portraitDragState.current = null;
+    if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+      e.currentTarget.releasePointerCapture(e.pointerId);
+    }
+  };
 
   // Find the last AI message id for swipe control display
   const lastAiMessageId = useMemo(() => {
@@ -915,8 +983,13 @@ export function ChatView() {
           {!isVnMode && !isMobileLandscape && (
             <>
               <div
-                className="lg:hidden relative bg-gradient-to-b from-[var(--color-bg-tertiary)] to-[var(--color-bg-primary)] overflow-hidden"
-                style={{ height: `${portraitHeight * 100}vh` }}
+                ref={portraitDragRef}
+                onPointerDown={handlePortraitPointerDown}
+                onPointerMove={handlePortraitPointerMove}
+                onPointerUp={handlePortraitPointerUp}
+                onPointerCancel={handlePortraitPointerUp}
+                className="lg:hidden relative bg-gradient-to-b from-[var(--color-bg-tertiary)] to-[var(--color-bg-primary)] overflow-hidden cursor-grab active:cursor-grabbing"
+                style={{ height: `${portraitHeight * 100}vh`, touchAction: 'none' }}
               >
                 {hasLivePortrait ? (
                   <LivePortraitVideo
@@ -924,13 +997,16 @@ export function ChatView() {
                     emotion={latestEmotion}
                     fill
                     shape="square"
+                    objectPosition={`${livePortraitPos.x}% ${livePortraitPos.y}%`}
                   />
                 ) : (
                   <img
                     key={`${selectedCharacter.avatar}-${latestEmotion ?? 'neutral'}`}
                     src={getFullImageUrl(selectedCharacter.avatar, latestEmotion)}
                     alt={selectedCharacter.name}
-                    className="w-full h-full object-cover object-top transition-opacity duration-300"
+                    draggable={false}
+                    className="w-full h-full object-cover transition-opacity duration-300 select-none pointer-events-none"
+                    style={{ objectPosition: `${livePortraitPos.x}% ${livePortraitPos.y}%` }}
                     onError={() => {
                       if (latestEmotion) {
                         const expressionKey = `${selectedCharacter.avatar}-${latestEmotion}`;

--- a/src/components/chat/LivePortraitVideo.tsx
+++ b/src/components/chat/LivePortraitVideo.tsx
@@ -24,6 +24,8 @@ export interface LivePortraitVideoProps {
   className?: string;
   /** Fill the parent container (100% × 100%) instead of using a fixed `size`. */
   fill?: boolean;
+  /** CSS object-position string (e.g. "50% 25%"). Defaults to center. */
+  objectPosition?: string;
 }
 
 const FADE_MS = 250;
@@ -35,6 +37,7 @@ export function LivePortraitVideo({
   shape = 'circle',
   className,
   fill = false,
+  objectPosition,
 }: LivePortraitVideoProps) {
   const idleRef = useRef<HTMLVideoElement>(null);
   const emotionRef = useRef<HTMLVideoElement>(null);
@@ -99,6 +102,7 @@ export function LivePortraitVideo({
             width: '100%',
             height: '100%',
             objectFit: 'cover',
+            objectPosition,
             opacity: overlayUrl ? 0 : 1,
             transition: `opacity ${FADE_MS}ms ease`,
           }}
@@ -118,6 +122,7 @@ export function LivePortraitVideo({
             width: '100%',
             height: '100%',
             objectFit: 'cover',
+            objectPosition,
             opacity: 1,
             transition: `opacity ${FADE_MS}ms ease`,
           }}

--- a/src/stores/portraitPositionStore.ts
+++ b/src/stores/portraitPositionStore.ts
@@ -1,0 +1,49 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+/**
+ * Per-character object-position values for the mobile portrait panel.
+ * Values are CSS percentages (0-100) on each axis. Default of 50/0 matches
+ * the original `object-cover object-top` behavior.
+ */
+
+export interface PortraitPosition {
+  x: number;
+  y: number;
+}
+
+const DEFAULT_POSITION: PortraitPosition = { x: 50, y: 0 };
+
+interface PortraitPositionState {
+  positionsByAvatar: Record<string, PortraitPosition>;
+  getPosition: (avatar: string) => PortraitPosition;
+  setPosition: (avatar: string, pos: PortraitPosition) => void;
+  resetPosition: (avatar: string) => void;
+}
+
+export const usePortraitPositionStore = create<PortraitPositionState>()(
+  persist(
+    (set, get) => ({
+      positionsByAvatar: {},
+
+      getPosition(avatar) {
+        return get().positionsByAvatar[avatar] ?? DEFAULT_POSITION;
+      },
+
+      setPosition(avatar, pos) {
+        set((s) => ({
+          positionsByAvatar: { ...s.positionsByAvatar, [avatar]: pos },
+        }));
+      },
+
+      resetPosition(avatar) {
+        set((s) => {
+          const next = { ...s.positionsByAvatar };
+          delete next[avatar];
+          return { positionsByAvatar: next };
+        });
+      },
+    }),
+    { name: 'portrait-position', version: 1 },
+  ),
+);


### PR DESCRIPTION
## Summary
Users can now drag the mobile chat portrait to adjust where the visual center sits. Useful when a character's face is in the lower or off-center part of the source image and gets cropped by the default top-anchored framing.

- Per-character position persisted in a new Zustand store (`portraitPositionStore`)
- Applies to both the static expression image and `LivePortraitVideo`
- Pointer-capture-based drag, bounded to the portrait area; doesn't hijack the resize handle below or the search button overlay
- `touch-action: none` prevents page scroll while dragging on touch devices

## Test plan
- [ ] Drag works on touch and mouse
- [ ] Position survives reload
- [ ] Position is per-character (different framing for different characters)
- [ ] Search button in the overlay still tappable
- [ ] Resize handle below the portrait still works