### PR TITLE
feat(live-portrait): auto-load clips from server on character select

### DIFF
--- a/src/api/livePortraitGen.ts
+++ b/src/api/livePortraitGen.ts
@@ -23,6 +23,21 @@ const POLL_INTERVAL_MS = 3000;
 const POLL_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes total — leaves headroom over backend's per-clip timeout
 
 /**
+ * Fetch existing clip URLs for a character (any clips already generated
+ * server-side). Lets clients auto-populate their local store on character
+ * load so users see Live Portrait everywhere — not just on the device
+ * that ran generation.
+ */
+export async function fetchExistingClips(characterName: string): Promise<EmotionClips> {
+  const r = await fetch(`/api/live-portrait/list/${encodeURIComponent(characterName)}`, {
+    credentials: 'include',
+  });
+  if (!r.ok) throw new Error(`HTTP ${r.status}`);
+  const data = await r.json();
+  return data.clips ?? {};
+}
+
+/**
  * Fetch the list of emotions the backend's Replicate client supports. Cached
  * for the session.
  */

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -32,6 +32,7 @@ import { useCharacterSprites } from '../../hooks/useCharacterSprites';
 import { LivePortraitVideo } from './LivePortraitVideo';
 import { useLivePortraitStore } from '../../stores/livePortraitStore';
 import { usePortraitPositionStore } from '../../stores/portraitPositionStore';
+import { fetchExistingClips } from '../../api/livePortraitGen';
 import {
   getExpressionThumbnailUrl,
   getDefaultAvatarUrl,
@@ -227,6 +228,29 @@ export function ChatView() {
     selectedCharacter ? s.getClips(selectedCharacter.avatar) : null,
   );
   const hasLivePortrait = livePortraitEnabled && !!livePortraitClips && 'idle' in livePortraitClips;
+
+  // Auto-discover server-side clips when a character is selected so users
+  // see Live Portrait on any device — not just the one that ran generation.
+  // Skips the fetch when the local store already has clips for this avatar.
+  useEffect(() => {
+    if (!selectedCharacter || !livePortraitEnabled) return;
+    if (livePortraitClips && Object.keys(livePortraitClips).length > 0) return;
+    const characterName = selectedCharacter.avatar.replace(/\.png$/i, '');
+    let cancelled = false;
+    fetchExistingClips(characterName)
+      .then((clips) => {
+        if (cancelled) return;
+        if (Object.keys(clips).length > 0) {
+          useLivePortraitStore.getState().setClips(selectedCharacter.avatar, clips);
+        }
+      })
+      .catch(() => {
+        // No clips, no route, or auth issue — fall back to static avatar silently.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedCharacter?.avatar, livePortraitEnabled, livePortraitClips]);
 
   // Per-character draggable framing for the mobile portrait panel.
   // Stored as {x%, y%} object-position values, persisted via Zustand.


### PR DESCRIPTION
## Summary
Live Portrait clip URLs only lived in localStorage, so the iPhone (or any device that didn't run generation) showed the static avatar even when MP4s were on the server. Now `ChatView` calls `/api/live-portrait/list/:character` when a character is selected and populates the store from any clips found server-side.

Pairs with [SillyTavern#22](https://github.com/sammygallo/SillyTavern/pull/22) which adds the backend route. Falls back silently if the route isn't deployed yet.

## Test plan
- [ ] Login on second device → live portrait plays for any character with server-side clips
- [ ] Other users see clips you generated for global characters
- [ ] Characters without clips: still show static avatar