### PR TITLE
feat(help): in-app support assistant grounded on docs/faq.md

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,186 @@
+# Good Girls Bot Club — FAQ
+
+This is the corpus the in-app support assistant grounds on. Each entry is a
+question (`##` heading) followed by the answer. Keep entries focused, concrete,
+and pointing at where to find the setting in the UI.
+
+---
+
+## Where do the prompts come from? Do I write the main prompt and jailbreak myself?
+
+Yes — they're yours to fill in. The app ships with the **Main Prompt**,
+**Jailbreak / Auxiliary Prompt**, and **Post-History Instructions** fields all
+blank by default.
+
+**Where:** Settings → Generation Settings.
+
+You can save a full prompt setup as a named template under **Settings → Prompt
+Templates** and switch between them per character or scene.
+
+**Note:** character cards can carry their own `system_prompt` and post-history
+instructions. By default the app honors those over the user's prompts. Toggle
+**Respect character override** / **Respect character PHI** in Generation
+Settings to change this.
+
+---
+
+## How does memory work? What's the difference between Auto-Memory, RAG, and Summarize?
+
+The app has three memory mechanisms — they can run together:
+
+1. **Auto-Memory** — every N messages (default 30), the active model extracts
+   canonical facts from the chat and appends them to a per-character lorebook
+   called "{Character} — Auto Memory". Same retrieval as regular World Info
+   (keyword-triggered). Toggle under Settings → Extensions → Auto-Memory.
+
+2. **Chat-History RAG** — embeds your past chat messages and pulls the most
+   semantically relevant past turns into context at generation time. Better
+   recall than keyword-based World Info. Opt-in. One embedding call per new
+   message. Settings → Data Bank.
+
+3. **Summarize** — periodic rolling summary of older chat, injected as a
+   system message. More about compression than recall. Settings → Extensions
+   → Summarize.
+
+For long-term character memory, Auto-Memory is the simplest. For "the model
+forgot something we talked about 200 messages ago", Chat-History RAG is the
+right tool.
+
+---
+
+## How do I change AI models? Why don't I see all the models my provider offers?
+
+**Where:** Settings → AI Settings → pick a provider → use the **Model** dropdown.
+
+The dropdown auto-loads the live catalog for these providers (when an API key
+is configured): OpenAI, Mistral, Groq, DeepSeek, Cohere, xAI, Moonshot, Google
+AI Studio, NanoGPT, Pollinations, AIMLAPI, Electron Hub. **OpenRouter** loads
+its full catalog (370+) without needing a key.
+
+These providers still show a curated default list because their backends don't
+expose a model catalog yet: Claude, Vertex AI, Perplexity, AI21, 01.AI, Zhipu,
+Block Entropy. You can still type a model id elsewhere if you know one.
+
+A small "X models from …" line under the dropdown confirms when you're seeing
+the live list.
+
+---
+
+## How do I add an API key?
+
+Settings → AI Settings → pick the provider → enter the key in the
+**API Keys** section that appears below the provider grid.
+
+Keys are stored server-side, encrypted at rest. Each user has their own keys
+unless an admin enables global sharing for that provider, in which case
+everyone uses the shared key.
+
+**For non-admin users:** Settings → My API Keys is the same flow with the
+admin-only sections hidden.
+
+---
+
+## How do I import a character card?
+
+Sidebar → **Import** button at the bottom. Accepts PNG character cards
+(SillyTavern v2/v3 format), JSON exports, and Tavern AI cards.
+
+Once imported, the character shows up in the sidebar list. Tap it to start a
+chat. To edit the card after import, tap the pencil icon in the header while
+the character is selected.
+
+---
+
+## What's the difference between OpenAI, Claude, OpenRouter, and the other providers?
+
+- **OpenAI / Claude / Google Gemini / Mistral / xAI / DeepSeek / etc.** —
+  direct connections to that provider's API. You bring your own key.
+- **OpenRouter** — one key gets you access to 370+ models from every major
+  provider (OpenAI, Anthropic, Google, Meta, etc.). Slight cost markup, but
+  much less account juggling.
+- **Aggregators (NanoGPT, AIMLAPI, Electron Hub, Pollinations)** — similar to
+  OpenRouter, different model selections and pricing.
+- **Custom / Local** — point at any OpenAI-compatible endpoint (Ollama, LM
+  Studio, vLLM, KoboldCpp, llama.cpp). Useful for self-hosted models.
+
+If you're starting out and want one key for everything, OpenRouter is the
+easiest path. If you want the cheapest route for a specific model, go direct.
+
+---
+
+## How do extensions work?
+
+Settings → Extensions. Built-in extensions: Text-to-Speech, Image Generation,
+Translation, Summarize, Auto-Memory.
+
+Each extension has its own toggle and settings. Some extensions add slots in
+the chat UI (e.g., the message-action menu, the chat-input toolbar) when
+enabled.
+
+Server-side extensions (third-party SillyTavern extensions installed on the
+backend) are listed at the bottom of the Extensions page.
+
+---
+
+## What are connection profiles?
+
+A snapshot of "provider + model + sampler settings + custom URL" you can save
+under a name and switch between in one click.
+
+**Where:** Settings → AI Settings → **Connection Profiles** section.
+
+Useful for: a "creative writing" profile (high temperature, Claude Opus) vs.
+a "tight roleplay" profile (low temp, Mistral Large) vs. a "local cheap"
+profile (Ollama running llama3).
+
+---
+
+## How do lorebooks / World Info work?
+
+Lorebooks are keyword-triggered context. When the user's last message (or the
+recent chat) contains a key from a lorebook entry, that entry's content is
+injected into the prompt before generation.
+
+**Where:** Settings → World Info.
+
+Lorebooks can be:
+- **Character-attached** — only active when that character is selected.
+- **Chat-attached** — only active in that specific chat.
+- **Globally enabled** — active everywhere.
+
+The injection budget is shared with the rest of the prompt context, so very
+large lorebooks can push older chat messages out.
+
+---
+
+## Why isn't my character responding?
+
+Most common causes, in order:
+
+1. **No API key configured.** Settings → AI Settings → check that the active
+   provider shows a green checkmark. If not, enter a key.
+
+2. **Model name wrong.** Some providers return errors like "model not found"
+   — check the active model is one your account has access to.
+
+3. **Character card has a broken `system_prompt`.** Try toggling **Respect
+   character override** off in Generation Settings.
+
+4. **Context too large.** The prompt may have exceeded the model's window.
+   Check the token budget in Generation Settings.
+
+5. **Provider outage.** Try a different provider via Connection Profiles to
+   isolate.
+
+If none of those: the browser console (DevTools → Console) usually has the
+exact error from the server.
+
+---
+
+## How do I share characters with other users on the same server?
+
+When viewing or editing a character, look for the **Visibility** toggle:
+- **Personal** — only you see it.
+- **Global** — every user on the server sees it.
+
+Admins can edit any character's visibility from Settings → Character Management.

--- a/src/components/help/HelpChat.tsx
+++ b/src/components/help/HelpChat.tsx
@@ -1,0 +1,229 @@
+// In-app support assistant. Streams answers from the user's active provider,
+// grounded on docs/faq.md and a small slice of current app state. No backend
+// changes — uses the existing chat-completions client.
+
+import { useEffect, useRef, useState } from 'react';
+import { Loader2, RefreshCw, Send } from 'lucide-react';
+import { Modal, Button, TextArea } from '../ui';
+import { api } from '../../api/client';
+import { useSettingsStore } from '../../stores/settingsStore';
+import { useCharacterStore } from '../../stores/characterStore';
+import faqMarkdown from '../../../docs/faq.md?raw';
+
+interface HelpChatProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+interface HelpMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+// Inline minimal SSE parser — `parseSSEStream` exists in chatStore and
+// summarizeStore but isn't exported. Duplicating once more is cheaper than
+// the refactor and keeps this prototype self-contained.
+async function* readSSE(stream: ReadableStream<Uint8Array>): AsyncGenerator<string> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop() || '';
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed === 'data: [DONE]') continue;
+        if (!trimmed.startsWith('data: ')) continue;
+        const data = trimmed.slice(6);
+        if (!data || data === '[DONE]') continue;
+        try {
+          const json = JSON.parse(data);
+          const content =
+            json.choices?.[0]?.delta?.content ||
+            json.choices?.[0]?.text ||
+            json.delta?.text ||
+            (json.type === 'content_block_delta' ? json.delta?.text : null) ||
+            json.content ||
+            json.message?.content?.[0]?.text ||
+            '';
+          if (content) yield content;
+        } catch {
+          if (data.length > 0 && data !== 'undefined') yield data;
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function buildSystemPrompt(activeProvider: string, activeModel: string, characterName: string | undefined): string {
+  const stateLines = [
+    `Active provider: ${activeProvider || '(none)'}`,
+    `Active model: ${activeModel || '(none)'}`,
+    `Selected character: ${characterName || '(none)'}`,
+  ].join('\n');
+
+  return `You are the in-app support assistant for Good Girls Bot Club, a SillyTavern-based mobile chat app for AI roleplay. Answer the user's question using ONLY the FAQ below. If the answer isn't in the FAQ, say so plainly and suggest where they might look (Discord, GitHub issues) — do not invent features or settings paths. Be concise, point at the exact UI location ("Settings → AI Settings → Model"), and skip preambles.
+
+Current app state:
+${stateLines}
+
+=== FAQ ===
+${faqMarkdown}
+=== END FAQ ===`;
+}
+
+export function HelpChat({ isOpen, onClose }: HelpChatProps) {
+  const activeProvider = useSettingsStore((s) => s.activeProvider);
+  const activeModel = useSettingsStore((s) => s.activeModel);
+  const selectedCharacter = useCharacterStore((s) => s.selectedCharacter);
+
+  const [messages, setMessages] = useState<HelpMessage[]>([]);
+  const [input, setInput] = useState('');
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+  const scrollerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (scrollerRef.current) {
+      scrollerRef.current.scrollTop = scrollerRef.current.scrollHeight;
+    }
+  }, [messages]);
+
+  useEffect(() => () => abortRef.current?.abort(), []);
+
+  const reset = () => {
+    abortRef.current?.abort();
+    setMessages([]);
+    setError(null);
+    setIsStreaming(false);
+  };
+
+  const send = async () => {
+    const text = input.trim();
+    if (!text || isStreaming) return;
+    if (!activeProvider || !activeModel) {
+      setError('Configure a provider and model in Settings → AI Settings first.');
+      return;
+    }
+
+    setError(null);
+    const next: HelpMessage[] = [...messages, { role: 'user', content: text }, { role: 'assistant', content: '' }];
+    setMessages(next);
+    setInput('');
+    setIsStreaming(true);
+
+    const abort = new AbortController();
+    abortRef.current = abort;
+
+    try {
+      const sysPrompt = buildSystemPrompt(activeProvider, activeModel, selectedCharacter?.name);
+      const wireMessages: { role: 'user' | 'assistant' | 'system'; content: string }[] = [
+        { role: 'system', content: sysPrompt },
+        ...next.slice(0, -1).map((m) => ({ role: m.role, content: m.content })),
+      ];
+
+      const stream = await api.generateMessage(
+        wireMessages,
+        'support',
+        activeProvider,
+        activeModel,
+        abort.signal,
+        { maxTokens: 800, temperature: 0.3 },
+      );
+      if (!stream) throw new Error('No response from API.');
+
+      let acc = '';
+      for await (const token of readSSE(stream)) {
+        if (abort.signal.aborted) break;
+        acc += token;
+        setMessages((prev) => {
+          const copy = [...prev];
+          copy[copy.length - 1] = { role: 'assistant', content: acc };
+          return copy;
+        });
+      }
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      setError(msg);
+      // Drop both the empty assistant placeholder and the just-appended user
+      // turn so a retry doesn't ship the failed question to the model again.
+      // Put their text back in the input box for easy edit + retry.
+      setMessages((prev) => prev.slice(0, -2));
+      setInput(text);
+    } finally {
+      setIsStreaming(false);
+      abortRef.current = null;
+    }
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      send();
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Help" size="lg">
+      <div className="flex flex-col h-[70vh]">
+        <div ref={scrollerRef} className="flex-1 overflow-y-auto pr-1 space-y-3">
+          {messages.length === 0 && (
+            <div className="text-sm text-[var(--color-text-secondary)] space-y-2">
+              <p>Ask anything about how the app works — providers, prompts, memory, characters, lorebooks, settings.</p>
+              <p className="text-xs opacity-70">
+                Answers come from a curated FAQ. The bot will say "I don't know" rather than guess. Uses your active model
+                ({activeModel || '—'} via {activeProvider || '—'}).
+              </p>
+            </div>
+          )}
+          {messages.map((m, i) => (
+            <div
+              key={i}
+              className={`text-sm whitespace-pre-wrap rounded-lg px-3 py-2 ${
+                m.role === 'user'
+                  ? 'bg-[var(--color-primary)]/15 text-[var(--color-text-primary)] ml-8'
+                  : 'bg-[var(--color-bg-tertiary)] text-[var(--color-text-primary)] mr-8'
+              }`}
+            >
+              {m.content || (isStreaming && i === messages.length - 1 ? <Loader2 size={14} className="animate-spin" /> : '')}
+            </div>
+          ))}
+          {error && <p className="text-xs text-amber-400">{error}</p>}
+        </div>
+
+        <div className="mt-3 pt-3 border-t border-[var(--color-border)] space-y-2">
+          <TextArea
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={onKeyDown}
+            placeholder="Ask a question…"
+            rows={2}
+            disabled={isStreaming}
+          />
+          <div className="flex items-center justify-between gap-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={reset}
+              disabled={messages.length === 0 && !error}
+              className="text-xs"
+            >
+              <RefreshCw size={12} className="mr-1" /> Clear
+            </Button>
+            <Button onClick={send} disabled={!input.trim() || isStreaming} size="sm">
+              {isStreaming ? <Loader2 size={14} className="animate-spin" /> : <Send size={14} />}
+              <span className="ml-1">Send</span>
+            </Button>
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Download, Key, Menu, Settings, LogOut, Pencil, History, UserCircle } from 'lucide-react';
+import { Download, HelpCircle, Key, Menu, Settings, LogOut, Pencil, History, UserCircle } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useAuthStore } from '../../stores/authStore';
 import { useSettingsPanelStore } from '../../stores/settingsPanelStore';
@@ -8,6 +8,7 @@ import { can } from '../../utils/permissions';
 import { Avatar, Button } from '../ui';
 import { CharacterEdit } from '../character/CharacterEdit';
 import { ChatHistoryPanel } from '../chat/ChatHistoryPanel';
+import { HelpChat } from '../help/HelpChat';
 import { PersonaSelector, PersonaManager } from '../persona';
 import { usePwaInstall } from '../../hooks/usePwaInstall';
 import type { CharacterInfo } from '../../api/client';
@@ -26,6 +27,7 @@ export function Header({ onMenuClick }: HeaderProps) {
   const { canInstall, install: installPwa } = usePwaInstall();
   const [showEditModal, setShowEditModal] = useState(false);
   const [showHistoryPanel, setShowHistoryPanel] = useState(false);
+  const [showHelp, setShowHelp] = useState(false);
   const [convertToPersonaData, setConvertToPersonaData] = useState<
     { name: string; description: string } | null
   >(null);
@@ -110,6 +112,15 @@ export function Header({ onMenuClick }: HeaderProps) {
           </Button>
         )}
         <PersonaSelector />
+        <Button
+          variant="ghost"
+          size="sm"
+          className="p-2"
+          aria-label="Help"
+          onClick={() => setShowHelp(true)}
+        >
+          <HelpCircle size={20} />
+        </Button>
         {canViewSettings && (
           <Button
             variant="ghost"
@@ -168,6 +179,9 @@ export function Header({ onMenuClick }: HeaderProps) {
         isOpen={showHistoryPanel}
         onClose={() => setShowHistoryPanel(false)}
       />
+
+      {/* In-app help assistant */}
+      <HelpChat isOpen={showHelp} onClose={() => setShowHelp(false)} />
 
       {/* Persona Manager (opened from convert-to-persona) */}
       {convertToPersonaData && (


### PR DESCRIPTION
## Summary

- Adds a Help button (lucide-react `HelpCircle`) to the app header. Click → opens a streaming chat modal grounded on a new `docs/faq.md` corpus.
- Uses the user's active provider/model + key — zero new infrastructure, zero new API key dependencies.
- Active provider, model, and selected character are injected into the system prompt so answers can reference current state ("you don't have a character selected right now").
- On send failure, the user's question is restored to the input box so a retry doesn't re-ship the previously failed turn (orphaned-question quirk).
- 11 FAQ entries seeded from real questions: prompts, memory (auto-memory + RAG + summarize), models, API keys, character import, providers, extensions, connection profiles, lorebooks, troubleshooting, sharing.

## Test plan

- [x] Help button appears in header next to Settings.
- [x] Modal opens with welcome state showing active model.
- [x] Streaming response works end-to-end via Claude (verified locally).
- [x] FAQ-grounded answers — output structure matches the markdown corpus.
- [x] Contextual state injection ("no character selected" surfaced correctly).
- [x] Failure path: error message shown, user message dropped, input restored.
- [x] `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)