### PR TITLE
fix(mobile): sticky header and send button overflow

### DIFF
--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -521,7 +521,7 @@ export function ChatInput({
         )}
 
         {/* Input Area */}
-        <div className="flex-1 flex items-end bg-[var(--color-bg-tertiary)] rounded-2xl px-4 py-2 relative">
+        <div className="flex-1 min-w-0 flex items-end bg-[var(--color-bg-tertiary)] rounded-2xl px-4 py-2 relative">
           {/* Phase 8.7: Slash command autocomplete */}
           <CommandAutocomplete
             prefix={autocompletePrefix}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -48,7 +48,7 @@ export function Header({ onMenuClick }: HeaderProps) {
   const getAvatarUrl = (avatar: string) => `/thumbnail?type=avatar&file=${encodeURIComponent(avatar)}`;
 
   return (
-    <header className="h-14 bg-[var(--color-bg-secondary)] border-b border-[var(--color-border)] flex items-center px-4 gap-3 safe-top">
+    <header className="sticky top-0 z-50 flex-shrink-0 h-14 bg-[var(--color-bg-secondary)] border-b border-[var(--color-border)] flex items-center px-4 gap-3 safe-top">
       {/* Menu Button (Mobile) */}
       <Button
         variant="ghost"


### PR DESCRIPTION
## Summary
- Header is now `sticky top-0 z-50 flex-shrink-0` — stays pinned when the character portrait panel is large or being repositioned
- Chat input textarea wrapper gets `min-w-0` — prevents the send button from overflowing off-screen when multiple action buttons are present

## Test plan
- [ ] Resize the character portrait panel to max height, confirm header stays visible
- [ ] Drag the character image focal point, confirm header stays reachable
- [ ] Type a message, confirm send button is visible on narrow mobile widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)