### PR TITLE
fix(header): lower z-index so sidebar renders above it

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -48,7 +48,7 @@ export function Header({ onMenuClick }: HeaderProps) {
   const getAvatarUrl = (avatar: string) => `/thumbnail?type=avatar&file=${encodeURIComponent(avatar)}`;
 
   return (
-    <header className="sticky top-0 z-50 flex-shrink-0 h-14 bg-[var(--color-bg-secondary)] border-b border-[var(--color-border)] flex items-center px-4 gap-3 safe-top">
+    <header className="sticky top-0 z-20 flex-shrink-0 h-14 bg-[var(--color-bg-secondary)] border-b border-[var(--color-border)] flex items-center px-4 gap-3 safe-top">
       {/* Menu Button (Mobile) */}
       <Button
         variant="ghost"


### PR DESCRIPTION
## Summary
- `z-50` on the header matched the sidebar's z-index, but since the header is later in the DOM it was painting on top of the open sidebar — hiding the sidebar's own nav controls (back, close, character name)
- Correct z-index hierarchy: ChatView content `z-10` < Header `z-20` < Sidebar backdrop `z-40` < Sidebar `z-50`

🤖 Generated with [Claude Code](https://claude.com/claude-code)