### PR TITLE
fix(mobile): message actions, enter key, and input positioning

### DIFF
--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -313,8 +313,10 @@ export function ChatInput({
     }
   };
 
+  const isTouchDevice = typeof window !== 'undefined' && window.matchMedia('(hover: none)').matches;
+
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
+    if (e.key === 'Enter' && !e.shiftKey && !isTouchDevice) {
       e.preventDefault();
       handleSubmit(e);
     }
@@ -383,7 +385,7 @@ export function ChatInput({
   return (
     <form
       onSubmit={handleSubmit}
-      className="border-t border-[var(--color-border)] bg-[var(--color-bg-secondary)] p-3 pb-4 input-safe-bottom"
+      className="flex-shrink-0 border-t border-[var(--color-border)] bg-[var(--color-bg-secondary)] p-3 pb-4 input-safe-bottom"
     >
       {/* Hidden file picker, driven by the paperclip button. */}
       <input
@@ -543,7 +545,7 @@ export function ChatInput({
               setShowAutocomplete(trimmed.startsWith('/') && !trimmed.includes(' '));
             }}
             onKeyDown={handleKeyDown}
-            enterKeyHint="send"
+            enterKeyHint={isTouchDevice ? 'enter' : 'send'}
             placeholder={isListening ? 'Listening…' : placeholder}
             disabled={disabled || isListening}
             rows={1}

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -258,7 +258,7 @@ export function ChatMessage({
       <button
         onClick={() => { setShowMenu(!showMenu); haptic(); }}
         disabled={disabled}
-        className="p-1.5 rounded-lg text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-tertiary)] opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity disabled:opacity-50"
+        className="p-1.5 rounded-lg text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-tertiary)] opacity-100 lg:opacity-0 lg:group-hover:opacity-100 focus:opacity-100 transition-opacity disabled:opacity-50"
         aria-label="Message actions"
       >
         <MoreHorizontal size={16} />
@@ -310,7 +310,7 @@ export function ChatMessage({
           className={`p-1.5 rounded-lg transition-all ${
             isSpeaking
               ? 'text-[var(--color-primary)] bg-[var(--color-primary)]/10 opacity-100'
-              : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-tertiary)] opacity-0 group-hover:opacity-100 focus:opacity-100'
+              : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-tertiary)] opacity-100 lg:opacity-0 lg:group-hover:opacity-100 focus:opacity-100'
           }`}
           aria-label={isSpeaking ? 'Stop speaking' : 'Read aloud'}
           title={isSpeaking ? 'Stop' : 'Read aloud'}

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -64,7 +64,7 @@ export function MainLayout() {
   }
 
   return (
-    <div ref={swipeRef} className="h-screen flex bg-[var(--color-bg-primary)] overflow-hidden">
+    <div ref={swipeRef} className="flex bg-[var(--color-bg-primary)] overflow-hidden" style={{ height: '100dvh' }}>
       {/* Sidebar */}
       <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
 


### PR DESCRIPTION
## Summary
- **Message actions visible on mobile**: `opacity-0 group-hover:opacity-100` never fires on touch — changed to always-visible on mobile, hover-only on `lg:` and up
- **Android Enter key**: soft keyboard Enter was triggering send; now touch devices skip the Enter-to-send handler so users can type line breaks. `enterKeyHint` also updated to `enter` on touch
- **Chat input fixed to bottom**: added `flex-shrink-0` to the form so it can't be squeezed off-screen by the portrait panel
- **iOS keyboard resize**: root container now uses `100dvh` (dynamic viewport height) so the layout shrinks when the iOS keyboard opens, keeping the input visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)