### PR TITLE
fix(mobile): Enter-key newline + chat menu buttons on iOS/Android

### DIFF
--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -313,7 +313,18 @@ export function ChatInput({
     }
   };
 
-  const isTouchDevice = typeof window !== 'undefined' && window.matchMedia('(hover: none)').matches;
+  // Treat as touch if any of: coarse pointer, no hover, touch points, or mobile UA.
+  // Errs toward "newline on Enter" for ambiguous hybrid devices (Surface, Chromebook
+  // with touchscreen) — minor inconvenience for those, but the right default for
+  // every actual phone/tablet, including Samsung Internet, Android in DeX mode,
+  // and Android Chrome with a paired stylus that reports hover capability.
+  const isTouchDevice =
+    typeof window !== 'undefined' &&
+    (window.matchMedia('(pointer: coarse)').matches ||
+      window.matchMedia('(hover: none)').matches ||
+      (typeof navigator !== 'undefined' && navigator.maxTouchPoints > 0) ||
+      (typeof navigator !== 'undefined' &&
+        /Android|iPhone|iPad|iPod|Mobile/i.test(navigator.userAgent)));
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' && !e.shiftKey && !isTouchDevice) {

--- a/src/components/ui/BottomSheet.tsx
+++ b/src/components/ui/BottomSheet.tsx
@@ -47,22 +47,26 @@ export function BottomSheet({ isOpen, onClose, title, children }: BottomSheetPro
   if (!isOpen) return null;
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-end"
-      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
-    >
-      {/* Backdrop */}
-      <div className="absolute inset-0 bg-black/50 transition-opacity" />
+    <div className="fixed inset-0 z-50 flex items-end">
+      {/* Backdrop — closes sheet on tap */}
+      <div
+        className="absolute inset-0 bg-black/50 transition-opacity"
+        onClick={onClose}
+      />
 
       {/* Sheet */}
       <div
         ref={sheetRef}
         className="relative w-full max-h-[60dvh] bg-[var(--color-bg-secondary)] rounded-t-2xl overflow-y-auto animate-slide-up"
-        onTouchStart={handleTouchStart}
-        onTouchEnd={handleTouchEnd}
       >
-        {/* Drag handle */}
-        <div className="sticky top-0 flex justify-center pt-3 pb-2 bg-[var(--color-bg-secondary)]">
+        {/* Drag handle — owns the drag-to-dismiss gesture so taps on action
+            buttons inside the sheet don't get consumed as part of a gesture
+            (was suppressing synthesized clicks on iOS and Android). */}
+        <div
+          className="sticky top-0 flex justify-center pt-3 pb-2 bg-[var(--color-bg-secondary)] cursor-grab touch-none"
+          onTouchStart={handleTouchStart}
+          onTouchEnd={handleTouchEnd}
+        >
           <div className="w-10 h-1 rounded-full bg-[var(--color-border)]" />
         </div>
 


### PR DESCRIPTION
## Summary
Two cross-platform mobile bugs reported by users.

**1. Enter key sends instead of newline on some Android devices.** [`ChatInput.tsx`](src/components/chat/ChatInput.tsx) detected touch only via `(hover: none)`, which misses Samsung Internet on tablets, DeX mode, and Android Chromium with a paired stylus that reports hover. Broadened the check to OR `(pointer: coarse)`, `navigator.maxTouchPoints > 0`, and a UA fallback. Hybrid devices (Surface, Chromebook with touchscreen) now err toward newline-on-Enter — the right default for ambiguous cases.

**2. Chat-menu action buttons don't fire on iOS or Android.** [`BottomSheet.tsx`](src/components/ui/BottomSheet.tsx) attached drag-to-dismiss `onTouchStart`/`onTouchEnd` to the entire sheet. Mobile Safari and Android Chrome consume touches on a scroll container with attached touch listeners as part of a gesture, suppressing the synthesized click on inner buttons. Moved the handlers to just the drag-handle pill (with `touch-none` to own the gesture). Also fixed the related backdrop-dismiss bug — the parent's `e.target === e.currentTarget` guard never matched because the backdrop covered the entire parent.

## Test plan
- [x] `npm run build` (CI-equivalent) — green
- [x] Verified in mobile preview (375x812): tapping "Manage chat files" closes the sheet and opens Chat History
- [x] Verified backdrop tap dismisses the sheet
- [ ] Smoke-test on a real iPhone after deploy
- [ ] Smoke-test on a real Android phone after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)