### PR TITLE
feat: add crop editor to character portrait upload

### DIFF
--- a/src/components/ui/ImageCropModal.tsx
+++ b/src/components/ui/ImageCropModal.tsx
@@ -1,0 +1,157 @@
+import { useRef, useState, useEffect, useCallback } from 'react';
+import { X, Check, ZoomIn, ZoomOut } from 'lucide-react';
+
+const CROP_SIZE = 300;
+
+interface Props {
+  imageSrc: string;
+  onConfirm: (file: File) => void;
+  onClose: () => void;
+}
+
+export function ImageCropModal({ imageSrc, onConfirm, onClose }: Props) {
+  const [scale, setScale] = useState(1);
+  const [offset, setOffset] = useState({ x: 0, y: 0 });
+  const [imgNatural, setImgNatural] = useState({ w: 1, h: 1 });
+  const dragRef = useRef<{ startX: number; startY: number; startOX: number; startOY: number } | null>(null);
+  const imgEl = useRef<HTMLImageElement | null>(null);
+
+  useEffect(() => {
+    const img = new Image();
+    img.onload = () => {
+      setImgNatural({ w: img.naturalWidth, h: img.naturalHeight });
+      const initScale = Math.max(CROP_SIZE / img.naturalWidth, CROP_SIZE / img.naturalHeight);
+      setScale(initScale);
+      setOffset({ x: 0, y: 0 });
+      imgEl.current = img;
+    };
+    img.src = imageSrc;
+  }, [imageSrc]);
+
+  const clampOffset = useCallback((ox: number, oy: number, s: number) => {
+    const displayW = imgNatural.w * s;
+    const displayH = imgNatural.h * s;
+    return {
+      x: Math.min(0, Math.max(-(displayW - CROP_SIZE), ox)),
+      y: Math.min(0, Math.max(-(displayH - CROP_SIZE), oy)),
+    };
+  }, [imgNatural]);
+
+  const onPointerDown = (e: React.PointerEvent) => {
+    e.currentTarget.setPointerCapture(e.pointerId);
+    dragRef.current = { startX: e.clientX, startY: e.clientY, startOX: offset.x, startOY: offset.y };
+  };
+
+  const onPointerMove = (e: React.PointerEvent) => {
+    if (!dragRef.current) return;
+    const dx = e.clientX - dragRef.current.startX;
+    const dy = e.clientY - dragRef.current.startY;
+    setOffset(clampOffset(dragRef.current.startOX + dx, dragRef.current.startOY + dy, scale));
+  };
+
+  const onPointerUp = () => { dragRef.current = null; };
+
+  const onWheel = (e: React.WheelEvent) => {
+    e.preventDefault();
+    const newScale = Math.max(0.3, Math.min(5, scale - e.deltaY * 0.001));
+    setScale(newScale);
+    setOffset(prev => clampOffset(prev.x, prev.y, newScale));
+  };
+
+  const handleConfirm = () => {
+    const canvas = document.createElement('canvas');
+    canvas.width = CROP_SIZE;
+    canvas.height = CROP_SIZE;
+    const ctx = canvas.getContext('2d');
+    if (ctx && imgEl.current) {
+      const srcX = -offset.x / scale;
+      const srcY = -offset.y / scale;
+      const srcSize = CROP_SIZE / scale;
+      ctx.drawImage(imgEl.current, srcX, srcY, srcSize, srcSize, 0, 0, CROP_SIZE, CROP_SIZE);
+    }
+    canvas.toBlob((blob) => {
+      if (blob) onConfirm(new File([blob], 'avatar.png', { type: 'image/png' }));
+    }, 'image/png');
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4">
+      <div className="bg-[var(--color-bg-secondary)] rounded-2xl p-4 flex flex-col gap-4 w-full max-w-[360px]">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-semibold text-[var(--color-text-primary)]">Crop portrait</h3>
+          <button type="button" onClick={onClose} className="text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]">
+            <X size={18} />
+          </button>
+        </div>
+
+        {/* Crop viewport */}
+        <div
+          className="relative overflow-hidden rounded-lg bg-black cursor-grab active:cursor-grabbing touch-none mx-auto"
+          style={{ width: CROP_SIZE, height: CROP_SIZE }}
+          onPointerDown={onPointerDown}
+          onPointerMove={onPointerMove}
+          onPointerUp={onPointerUp}
+          onPointerCancel={onPointerUp}
+          onWheel={onWheel}
+        >
+          <img
+            src={imageSrc}
+            alt="crop preview"
+            draggable={false}
+            style={{
+              position: 'absolute',
+              left: offset.x,
+              top: offset.y,
+              width: imgNatural.w * scale,
+              height: imgNatural.h * scale,
+              userSelect: 'none',
+              pointerEvents: 'none',
+            }}
+          />
+          <div className="absolute inset-0 border-2 border-white/30 pointer-events-none rounded-lg" />
+        </div>
+
+        {/* Zoom slider */}
+        <div className="flex items-center gap-2">
+          <ZoomOut size={14} className="text-[var(--color-text-secondary)] flex-shrink-0" />
+          <input
+            type="range"
+            min="0.3"
+            max="3"
+            step="0.01"
+            value={scale}
+            onChange={(e) => {
+              const s = Number(e.target.value);
+              setScale(s);
+              setOffset(prev => clampOffset(prev.x, prev.y, s));
+            }}
+            className="flex-1 accent-[var(--color-primary)]"
+          />
+          <ZoomIn size={14} className="text-[var(--color-text-secondary)] flex-shrink-0" />
+        </div>
+
+        <p className="text-xs text-[var(--color-text-secondary)] text-center -mt-2">
+          Drag to reposition · Scroll or slider to zoom
+        </p>
+
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="flex-1 py-2 rounded-xl border border-[var(--color-border)] text-sm text-[var(--color-text-primary)]"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleConfirm}
+            className="flex-1 py-2 rounded-xl bg-[var(--color-primary)] text-white text-sm font-medium flex items-center justify-center gap-1.5"
+          >
+            <Check size={14} />
+            Apply crop
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/ImageUpload.tsx
+++ b/src/components/ui/ImageUpload.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from 'react';
-import { Upload, X } from 'lucide-react';
+import { Upload, X, Crop } from 'lucide-react';
 import { Button } from './Button';
+import { ImageCropModal } from './ImageCropModal';
 
 interface ImageUploadProps {
   currentImage?: string;
@@ -10,33 +11,41 @@ interface ImageUploadProps {
 
 export function ImageUpload({ currentImage, onImageSelect, label = 'Avatar' }: ImageUploadProps) {
   const [preview, setPreview] = useState<string | null>(null);
+  const [cropSrc, setCropSrc] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const openCrop = (dataUrl: string) => setCropSrc(dataUrl);
 
   const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
-    if (file) {
-      // Validate file type
-      if (!file.type.startsWith('image/')) {
-        return;
-      }
+    if (!file) return;
+    if (!file.type.startsWith('image/')) return;
 
-      // Create preview
-      const reader = new FileReader();
-      reader.onload = (e) => {
-        setPreview(e.target?.result as string);
-      };
-      reader.readAsDataURL(file);
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      const dataUrl = ev.target?.result as string;
+      openCrop(dataUrl);
+    };
+    reader.readAsDataURL(file);
 
-      onImageSelect(file);
-    }
+    // Reset so re-selecting same file fires change again
+    e.target.value = '';
+  };
+
+  const handleCropConfirm = (file: File) => {
+    setCropSrc(null);
+    const url = URL.createObjectURL(file);
+    // Revoke previous blob URL to avoid leaks
+    if (preview?.startsWith('blob:')) URL.revokeObjectURL(preview);
+    setPreview(url);
+    onImageSelect(file);
   };
 
   const handleClear = () => {
+    if (preview?.startsWith('blob:')) URL.revokeObjectURL(preview);
     setPreview(null);
     onImageSelect(null);
-    if (fileInputRef.current) {
-      fileInputRef.current.value = '';
-    }
+    if (fileInputRef.current) fileInputRef.current.value = '';
   };
 
   const displayImage = preview || currentImage;
@@ -48,27 +57,36 @@ export function ImageUpload({ currentImage, onImageSelect, label = 'Avatar' }: I
       </label>
 
       <div className="flex items-start gap-4">
-        {/* Preview Area */}
-        <div className="relative">
-          <div
+        {/* Preview — click to open file picker */}
+        <div className="relative flex-shrink-0">
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            title="Click to upload or change image"
             className={`
               w-24 h-24 rounded-lg border-2 border-dashed
               ${displayImage ? 'border-[var(--color-primary)]' : 'border-[var(--color-border)]'}
               bg-[var(--color-bg-tertiary)]
               flex items-center justify-center
-              overflow-hidden
+              overflow-hidden group relative
             `}
           >
             {displayImage ? (
-              <img
-                src={displayImage}
-                alt="Avatar preview"
-                className="w-full h-full object-cover"
-              />
+              <>
+                <img
+                  src={displayImage}
+                  alt="Avatar preview"
+                  className="w-full h-full object-cover"
+                />
+                {/* Hover overlay */}
+                <div className="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
+                  <Crop size={20} className="text-white" />
+                </div>
+              </>
             ) : (
               <Upload size={24} className="text-[var(--color-text-secondary)]" />
             )}
-          </div>
+          </button>
 
           {/* Clear button */}
           {preview && (
@@ -82,7 +100,7 @@ export function ImageUpload({ currentImage, onImageSelect, label = 'Avatar' }: I
           )}
         </div>
 
-        {/* Upload Controls */}
+        {/* Upload / re-crop controls */}
         <div className="flex-1 flex flex-col gap-2">
           <input
             ref={fileInputRef}
@@ -102,11 +120,31 @@ export function ImageUpload({ currentImage, onImageSelect, label = 'Avatar' }: I
             {displayImage ? 'Change Image' : 'Upload Image'}
           </Button>
 
+          {displayImage && (
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              onClick={() => openCrop(displayImage)}
+            >
+              <Crop size={16} className="mr-2" />
+              Crop
+            </Button>
+          )}
+
           <p className="text-xs text-[var(--color-text-secondary)]">
             PNG, JPG, or GIF. Will be resized to 400x600.
           </p>
         </div>
       </div>
+
+      {cropSrc && (
+        <ImageCropModal
+          imageSrc={cropSrc}
+          onConfirm={handleCropConfirm}
+          onClose={() => setCropSrc(null)}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Implements #136.

- New `ImageCropModal` component: canvas-based drag-to-pan + zoom-to-scale crop UI, no new dependencies
- After uploading an image, the crop modal opens automatically — user drags to reposition and uses slider/scroll to zoom, then confirms
- Clicking the avatar thumbnail also opens the file picker → crop flow
- A "Crop" button appears alongside "Change Image" when a portrait is already loaded (lets users re-crop existing images)
- Applies to CharacterEdit, CharacterCreation, PersonaForm, and CharacterImport (all use `ImageUpload`)

## Test plan
- [ ] Local `npm run build` passes (already verified)
- [ ] Create a new character → upload an image → crop modal opens, drag + zoom works, Apply Crop saves the cropped result
- [ ] Edit an existing character → click avatar thumbnail → crop flow works
- [ ] "Crop" button re-crops an already-set image
- [ ] Cancel closes modal without changing the image
- [ ] Edge cases: tall/wide images (should fill crop frame initially), very small images (min zoom clamp)

🤖 Draft opened by the build-next-issue skill. Human review required before merge.