### PR TITLE
feat: add fallback provider for API requests

### DIFF
--- a/src/components/settings/AISettingsPage.tsx
+++ b/src/components/settings/AISettingsPage.tsx
@@ -178,6 +178,7 @@ export function AISettingsPage(_props?: { params?: Record<string, string> }) {
     fetchSecrets, fetchSettings, fetchGlobalSecrets,
     saveApiKey, deleteApiKey, saveGlobalApiKey, deleteGlobalApiKey,
     setActiveProvider, setActiveModel, setCustomUrl, setGlobalSharing, clearMessages,
+    fallbackProvider, fallbackModel, setFallbackProvider, setFallbackModel, clearFallbackProvider,
   } = useSettingsStore();
   const userRole = useAuthStore((s) => s.currentUser?.role);
   const isOwner = hasMinRole(userRole, 'owner');
@@ -416,6 +417,76 @@ export function AISettingsPage(_props?: { params?: Record<string, string> }) {
               Add more providers from the catalog to expand this list.
             </p>
           )}
+        </section>
+
+        {/* Fallback Provider */}
+        <section className="bg-[var(--color-bg-secondary)] rounded-lg p-4 cyberpunk-card">
+          <div className="flex items-center justify-between mb-3">
+            <div>
+              <h2 className="text-sm font-semibold text-[var(--color-text-primary)]">Fallback Provider</h2>
+              <p className="text-xs text-[var(--color-text-secondary)] mt-0.5">
+                Automatically retried if the primary provider fails.
+              </p>
+            </div>
+            {fallbackProvider && (
+              <button
+                type="button"
+                onClick={clearFallbackProvider}
+                className="text-xs text-red-400 hover:text-red-300 transition-colors"
+              >
+                Clear
+              </button>
+            )}
+          </div>
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+            {PROVIDERS.filter((p) => p.id !== 'custom').map((provider) => (
+              <button
+                key={provider.id}
+                type="button"
+                onClick={() => {
+                  if (fallbackProvider === provider.id) {
+                    clearFallbackProvider();
+                  } else {
+                    setFallbackProvider(provider.id);
+                    if (!fallbackModel) setFallbackModel(provider.models[0] || '');
+                  }
+                }}
+                className={`flex items-center gap-2 px-3 py-2 rounded-lg border text-sm transition-colors
+                  ${fallbackProvider === provider.id
+                    ? 'bg-[var(--color-primary)]/15 border-[var(--color-primary)]/40 text-[var(--color-primary)]'
+                    : 'border-[var(--color-border)] text-[var(--color-text-secondary)] hover:border-[var(--color-text-secondary)]/40 hover:text-[var(--color-text-primary)]'
+                  }`}
+              >
+                <span className="truncate">{provider.name}</span>
+              </button>
+            ))}
+          </div>
+          {fallbackProvider && (() => {
+            const fbProvider = PROVIDERS.find((p) => p.id === fallbackProvider);
+            if (!fbProvider) return null;
+            const modelList = fbProvider.models;
+            return (
+              <div className="mt-3">
+                <label className="block text-xs text-[var(--color-text-secondary)] mb-1.5">Fallback model</label>
+                <div className="flex flex-wrap gap-1.5">
+                  {modelList.map((m) => (
+                    <button
+                      key={m}
+                      type="button"
+                      onClick={() => setFallbackModel(m)}
+                      className={`px-2.5 py-1 rounded-full text-xs border transition-colors
+                        ${fallbackModel === m
+                          ? 'bg-[var(--color-primary)]/15 border-[var(--color-primary)]/40 text-[var(--color-primary)]'
+                          : 'border-[var(--color-border)] text-[var(--color-text-secondary)] hover:border-[var(--color-text-secondary)]/40'
+                        }`}
+                    >
+                      {m}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            );
+          })()}
         </section>
 
         {/* Custom Endpoint */}

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -39,6 +39,7 @@ import { useChatHistoryRagStore } from './chatHistoryRagStore';
 import { extensionRegistry } from '../extensions/registry';
 import type { ContextContribution } from '../extensions/types';
 import { useAuthStore } from './authStore';
+import { showToastGlobal } from '../components/ui/Toast';
 import { parseChatTranscript, toSaveChatPayload } from '../utils/chatTranscript';
 
 // Resolve the display name for the current user: active persona → auth user name → fallback.
@@ -1391,6 +1392,34 @@ function getProviderAndModel(): { provider: string; model: string } {
   return { provider, model };
 }
 
+function getFallbackProviderAndModel(): { provider: string; model: string } | null {
+  const { fallbackProvider, fallbackModel } = useSettingsStore.getState();
+  if (!fallbackProvider) return null;
+  return { provider: fallbackProvider, model: fallbackModel || fallbackProvider };
+}
+
+async function generateWithFallback(
+  messages: { role: 'user' | 'assistant' | 'system'; content: string }[],
+  characterName: string,
+  provider: string,
+  model: string,
+  signal: AbortSignal,
+  generationOptions: GenerationOptions,
+  images: GenerationImage[] | undefined,
+  textCompletionMode: boolean,
+): Promise<{ stream: ReadableStream<Uint8Array> | null; usedFallback: boolean }> {
+  try {
+    const stream = await api.generateMessage(messages, characterName, provider, model, signal, generationOptions, images, textCompletionMode);
+    return { stream, usedFallback: false };
+  } catch (err) {
+    if ((err as Error).name === 'AbortError') throw err;
+    const fallback = getFallbackProviderAndModel();
+    if (!fallback) throw err;
+    const stream = await api.generateMessage(messages, characterName, fallback.provider, fallback.model, signal, generationOptions, images, textCompletionMode);
+    return { stream, usedFallback: true };
+  }
+}
+
 // Helper: build generation options from the current sampler + instruct config.
 function getGenerationOptions(): GenerationOptions {
   const { sampler, instruct } = useGenerationStore.getState();
@@ -2528,7 +2557,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
         maybeApplyInstructMode(context),
         character.name,
       );
-      const stream = await api.generateMessage(
+      const { stream, usedFallback } = await generateWithFallback(
         finalContext,
         character.name,
         provider,
@@ -2538,6 +2567,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
         resolveImagesForSend(attachedImages),
         isTextCompletionMode()
       );
+      if (usedFallback) showToastGlobal('Primary provider failed — using fallback', 'warning');
 
       if (stream) {
         const aiMessageId = generateId();

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -33,6 +33,25 @@ function modelFieldFor(provider: string): string {
   return PROVIDER_MODEL_FIELD[provider] ?? `${provider}_model`;
 }
 
+const FALLBACK_STORAGE_KEY = 'sillytavern_fallback_provider';
+
+function loadFallback(): { provider: string; model: string } | null {
+  try {
+    const raw = localStorage.getItem(FALLBACK_STORAGE_KEY);
+    return raw ? JSON.parse(raw) : null;
+  } catch {
+    return null;
+  }
+}
+
+function saveFallback(provider: string, model: string) {
+  localStorage.setItem(FALLBACK_STORAGE_KEY, JSON.stringify({ provider, model }));
+}
+
+function clearFallback() {
+  localStorage.removeItem(FALLBACK_STORAGE_KEY);
+}
+
 interface SettingsState {
   secrets: SecretsResponse;
   activeProvider: string;
@@ -46,6 +65,9 @@ interface SettingsState {
   globalSecrets: SecretsResponse;
   globalSharingEnabled: boolean;
   globalSharingSupported: boolean;
+  /** Fallback provider/model used when the primary fails. Stored locally. */
+  fallbackProvider: string;
+  fallbackModel: string;
 
   // Actions
   fetchSecrets: () => Promise<void>;
@@ -60,6 +82,9 @@ interface SettingsState {
   saveGlobalApiKey: (provider: string, apiKey: string) => Promise<void>;
   deleteGlobalApiKey: (secretKey: string) => Promise<void>;
   setGlobalSharing: (enabled: boolean) => Promise<void>;
+  setFallbackProvider: (provider: string) => void;
+  setFallbackModel: (model: string) => void;
+  clearFallbackProvider: () => void;
 }
 
 export const useSettingsStore = create<SettingsState>((set, get) => ({
@@ -73,6 +98,8 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
   successMessage: null,
   globalSecrets: {},
   globalSharingEnabled: false,
+  fallbackProvider: loadFallback()?.provider ?? '',
+  fallbackModel: loadFallback()?.model ?? '',
   globalSharingSupported: false,
 
   fetchSecrets: async () => {
@@ -360,5 +387,23 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
     } catch (error) {
       set({ isSaving: false, error: error instanceof Error ? error.message : 'Failed to toggle global sharing' });
     }
+  },
+
+  setFallbackProvider: (provider: string) => {
+    const { fallbackModel } = get();
+    const model = fallbackModel || '';
+    saveFallback(provider, model);
+    set({ fallbackProvider: provider });
+  },
+
+  setFallbackModel: (model: string) => {
+    const { fallbackProvider } = get();
+    saveFallback(fallbackProvider, model);
+    set({ fallbackModel: model });
+  },
+
+  clearFallbackProvider: () => {
+    clearFallback();
+    set({ fallbackProvider: '', fallbackModel: '' });
   },
 }));


### PR DESCRIPTION
## Summary
Implements #146.

- Adds a **Fallback Provider** section to AI Settings — pick a provider chip and model pill, same UI pattern as the Active Provider section
- When any `sendMessage` call fails (non-abort error), it automatically retries once with the fallback provider + model
- A warning toast notifies the user when the fallback activates ("Primary provider failed — using fallback")
- Fallback config persisted in `localStorage` (`sillytavern_fallback_provider`) — no backend sync needed, user-local setting
- No fallback configured → behavior is unchanged (error surfaces as before)

## Test plan
- [ ] Local `npm run build` passes (already verified)
- [ ] AI Settings → Fallback Provider section appears with provider chips
- [ ] Selecting a provider shows its model pills; Clear button removes config
- [ ] Config persists across page reloads
- [ ] With a bad primary key + valid fallback: send a message → toast fires, response arrives from fallback
- [ ] Abort mid-stream → no fallback attempt (abort errors are not retried)
- [ ] No fallback configured → error still surfaces normally

🤖 Draft opened by the build-next-issue skill. Human review required before merge.