### PR TITLE
fix(mobile): ensure sheet renders above backdrop on iOS

### DIFF
--- a/src/components/ui/BottomSheet.tsx
+++ b/src/components/ui/BottomSheet.tsx
@@ -54,10 +54,11 @@ export function BottomSheet({ isOpen, onClose, title, children }: BottomSheetPro
         onClick={onClose}
       />
 
-      {/* Sheet */}
+      {/* Sheet — explicit z-index so iOS hit-tests the sheet above the backdrop */}
       <div
         ref={sheetRef}
-        className="relative w-full max-h-[60dvh] bg-[var(--color-bg-secondary)] rounded-t-2xl overflow-y-auto animate-slide-up"
+        onClick={(e) => e.stopPropagation()}
+        className="relative z-10 w-full max-h-[60dvh] bg-[var(--color-bg-secondary)] rounded-t-2xl overflow-y-auto animate-slide-up"
       >
         {/* Drag handle — owns the drag-to-dismiss gesture so taps on action
             buttons inside the sheet don't get consumed as part of a gesture
@@ -76,7 +77,9 @@ export function BottomSheet({ isOpen, onClose, title, children }: BottomSheetPro
           </div>
         )}
 
-        <div className="px-4 pb-6 safe-bottom">
+        {/* touch-action: manipulation tells iOS to treat touches as taps
+            immediately, not delay them waiting to see if it's a scroll */}
+        <div className="px-4 pb-6 safe-bottom" style={{ touchAction: 'manipulation' }}>
           {children}
         </div>
       </div>


### PR DESCRIPTION
## Summary

PR #145 moved the drag-dismiss touch listeners to the drag handle only, which was correct. But the buttons are still not firing on iPhone because of a separate issue: the `absolute inset-0` backdrop and the `relative` sheet are siblings with no explicit `z-index`, so iOS hit-testing is ambiguous about which element is on top when they overlap.

Three-part fix:
- **`z-index: 10`** on the sheet div — iOS now unambiguously routes taps to the sheet, not the backdrop
- **`touch-action: manipulation`** on the content area — tells iOS to treat touches as immediate taps without the scroll-detection delay that `overflow-y-auto` containers introduce
- **`onClick stopPropagation`** on the sheet div — belt-and-suspenders in case any tap event somehow propagates toward the backdrop

## Test plan
- [ ] `npm run build` passes (already verified)
- [ ] On real iPhone: tap "Start new chat" → chat resets; tap "Manage chat files" → history opens; tap "Delete messages" → messages clear
- [ ] Backdrop tap still dismisses the sheet
- [ ] Swipe-down still dismisses the sheet
- [ ] No regressions on desktop (dropdown path unaffected)

🤖 Generated with Claude Code