### PR TITLE
fix(mobile): backdrop pointer-events:none to unblock iOS button taps

### DIFF
--- a/src/components/ui/BottomSheet.tsx
+++ b/src/components/ui/BottomSheet.tsx
@@ -47,17 +47,20 @@ export function BottomSheet({ isOpen, onClose, title, children }: BottomSheetPro
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-end">
-      {/* Backdrop — closes sheet on tap */}
-      <div
-        className="absolute inset-0 bg-black/50 transition-opacity"
-        onClick={onClose}
-      />
+    // Outer container handles backdrop-tap dismiss via target check.
+    // The dark overlay is pointer-events:none so it can NEVER intercept taps
+    // meant for sheet buttons — on iOS, overlapping clickable divs cause the
+    // backdrop to swallow button taps regardless of z-index.
+    <div
+      className="fixed inset-0 z-50 flex items-end"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      {/* Visual backdrop — pointer-events:none, purely cosmetic */}
+      <div className="absolute inset-0 bg-black/50 pointer-events-none" />
 
-      {/* Sheet — explicit z-index so iOS hit-tests the sheet above the backdrop */}
+      {/* Sheet */}
       <div
         ref={sheetRef}
-        onClick={(e) => e.stopPropagation()}
         className="relative z-10 w-full max-h-[60dvh] bg-[var(--color-bg-secondary)] rounded-t-2xl overflow-y-auto animate-slide-up"
       >
         {/* Drag handle — owns the drag-to-dismiss gesture so taps on action


### PR DESCRIPTION
## What was wrong

Previous attempts (PR #145, #150) focused on touch handlers and z-index, but the real cause is simpler: the backdrop div had `onClick={onClose}` and `pointer-events` enabled. On iOS Safari, when two clickable elements overlap at the same tap point, iOS routes the tap to the backdrop — z-index doesn't resolve the ambiguity the way it does on desktop.

## Fix

- Set `pointer-events-none` on the backdrop div so it **cannot receive any touch input** — purely cosmetic dark overlay
- Move dismiss-on-tap logic to the outer container via `e.target === e.currentTarget`: only fires when the user taps the dark area above the sheet (where no sheet children are), never when tapping inside the sheet

## Test plan
- [ ] `npm run build` passes (already verified)
- [ ] On real iPhone: tap each chat menu button → action fires AND menu closes
- [ ] Tapping the dark area above the sheet still dismisses it
- [ ] Swipe-down on drag handle still dismisses it
- [ ] No regressions on desktop

🤖 Generated with Claude Code