### PR TITLE
fix(ChatOptionsMenu): exclusive mobile/desktop render + remove header history btn

### DIFF
--- a/src/components/chat/ChatOptionsMenu.tsx
+++ b/src/components/chat/ChatOptionsMenu.tsx
@@ -11,6 +11,7 @@
  * live in the inline message action strip directly above the input bar.
  */
 import { useEffect, useRef } from 'react';
+import { useIsMobile } from '../../hooks/useIsMobile';
 import {
   BookOpen, FileText, GitFork, Library, MessageSquare, FolderOpen,
   Trash2, Flag, Users, RefreshCw, ArrowRight, User,
@@ -271,6 +272,7 @@ export function ChatOptionsMenu({
   onImpersonate,
   isGroupChat,
 }: ChatOptionsMenuProps) {
+  const isMobile = useIsMobile();
   const wrap = (fn: () => void) => () => { fn(); onClose(); };
 
   const extensionPanels = [
@@ -326,21 +328,21 @@ export function ChatOptionsMenu({
     />
   );
 
-  return (
-    <>
-      {/* Mobile: bottom sheet */}
-      <div className="lg:hidden">
-        <BottomSheet isOpen={isOpen} onClose={onClose} title="Chat Options">
-          {body}
-        </BottomSheet>
-      </div>
+  // Render only one branch — never both simultaneously. The DesktopDropdown
+  // registers a document-level mousedown listener when open; if it rendered
+  // alongside the BottomSheet (even CSS-hidden), that listener would fire on
+  // every tap inside the sheet and call onClose, closing the menu.
+  if (isMobile) {
+    return (
+      <BottomSheet isOpen={isOpen} onClose={onClose} title="Chat Options">
+        {body}
+      </BottomSheet>
+    );
+  }
 
-      {/* Desktop: anchored dropdown */}
-      <div className="hidden lg:block">
-        <DesktopDropdown isOpen={isOpen} onClose={onClose} anchor={anchor}>
-          {body}
-        </DesktopDropdown>
-      </div>
-    </>
+  return (
+    <DesktopDropdown isOpen={isOpen} onClose={onClose} anchor={anchor}>
+      {body}
+    </DesktopDropdown>
   );
 }

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Download, HelpCircle, Key, Menu, Settings, LogOut, Pencil, History, UserCircle } from 'lucide-react';
+import { Download, HelpCircle, Key, Menu, Settings, LogOut, Pencil, UserCircle } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useAuthStore } from '../../stores/authStore';
 import { useSettingsPanelStore } from '../../stores/settingsPanelStore';
@@ -7,7 +7,6 @@ import { useCharacterStore } from '../../stores/characterStore';
 import { can } from '../../utils/permissions';
 import { Avatar, Button } from '../ui';
 import { CharacterEdit } from '../character/CharacterEdit';
-import { ChatHistoryPanel } from '../chat/ChatHistoryPanel';
 import { HelpChat } from '../help/HelpChat';
 import { PersonaSelector, PersonaManager } from '../persona';
 import { usePwaInstall } from '../../hooks/usePwaInstall';
@@ -20,13 +19,12 @@ interface HeaderProps {
 export function Header({ onMenuClick }: HeaderProps) {
   const navigate = useNavigate();
   const { currentUser, logout } = useAuthStore();
-  const { selectedCharacter, isGroupChatMode, fetchCharacters } = useCharacterStore();
+  const { selectedCharacter, fetchCharacters } = useCharacterStore();
   const userRole = currentUser?.role;
   const canEdit = can(userRole, 'character:edit');
   const canViewSettings = can(userRole, 'settings:view');
   const { canInstall, install: installPwa } = usePwaInstall();
   const [showEditModal, setShowEditModal] = useState(false);
-  const [showHistoryPanel, setShowHistoryPanel] = useState(false);
   const [showHelp, setShowHelp] = useState(false);
   const [convertToPersonaData, setConvertToPersonaData] = useState<
     { name: string; description: string } | null
@@ -89,17 +87,7 @@ export function Header({ onMenuClick }: HeaderProps) {
 
       {/* User Menu */}
       <div className="flex items-center gap-1">
-        {selectedCharacter && !isGroupChatMode && (
-          <Button
-            variant="ghost"
-            size="sm"
-            className="p-2"
-            aria-label="Chat history"
-            onClick={() => setShowHistoryPanel(true)}
-          >
-            <History size={20} />
-          </Button>
-        )}
+
         {canInstall && (
           <Button
             variant="ghost"
@@ -174,11 +162,6 @@ export function Header({ onMenuClick }: HeaderProps) {
         />
       )}
 
-      {/* Chat History Panel */}
-      <ChatHistoryPanel
-        isOpen={showHistoryPanel}
-        onClose={() => setShowHistoryPanel(false)}
-      />
 
       {/* In-app help assistant */}
       <HelpChat isOpen={showHelp} onClose={() => setShowHelp(false)} />


### PR DESCRIPTION
useIsMobile() renders only BottomSheet OR DesktopDropdown. Removes redundant header history button.