### PR TITLE
feat(guides): add character building guide + slide-in panel

### DIFF
--- a/docs/character-guide.md
+++ b/docs/character-guide.md
@@ -1,0 +1,211 @@
+# Character Building Guide
+
+A friendly guide to making characters. It explains what each setting does, how it changes the way your character talks and acts, and how to keep things from getting too long (which costs **tokens** — basically the "fuel" the AI burns each message).
+
+## What's a Token
+
+Every word, space, and punctuation mark you write costs **tokens**. The AI reads all your character info every single message you send. So if your character has 2,000 tokens of stuff written in it, you pay that 2,000 every time you say "hi." Short and clear beats long and rambling.
+
+## The Character Card
+
+These are the boxes in the character editor.
+
+### The Big Boxes (Always Sent to the AI)
+
+**Name** — What your character is called. The AI uses this name when it talks. Keep it short.
+
+**Description** — What your character looks like, where they're from, their backstory.
+- *How it changes behavior:* This is the AI's main "who am I?" reference. If you write "always angry," the AI will play them angry. If you write three pages of every cousin's name, the AI gets confused and forgets the important stuff.
+- *Tip:* Use bullet points instead of paragraphs. Stick to the facts that matter.
+
+**Personality** — How your character talks and acts. Quirks, mood, speech style.
+- *How it changes behavior:* This shapes the *voice*. "Speaks in short sentences. Uses sarcasm. Never says sorry." → The AI will write that way.
+- *Tip:* Don't repeat stuff from Description here. Keep them different jobs.
+
+**Scenario** — Where the story starts. What's happening right now.
+- *How it changes behavior:* Sets up the situation the AI plays out. "You both work at a coffee shop on a slow Tuesday."
+- *Tip:* If your First Message already shows the scene, you can leave Scenario empty.
+
+**First Message** — The first thing your character says when a chat starts.
+- *How it changes behavior:* This is huge. Whatever style and length you use here, the AI will copy it for the whole chat. Write a 6-paragraph epic? Expect 6-paragraph replies. Write 2 short lines? You'll get short replies back.
+- *Tip:* Match the message length to what you want the rest of the chat to feel like.
+
+**Example Messages** — Sample back-and-forth chats showing how your character talks.
+- *How it changes behavior:* The AI studies these like a script. It will copy the rhythm, vocabulary, and length of your examples.
+- *Tip:* Two great examples beat six okay ones. Show the character at their most "them."
+
+### The Hidden Boxes (Only Sent if You Use Them)
+
+**System Prompt Override** — Replaces the main rules the AI follows.
+- *How it changes behavior:* Powerful but risky. It throws out your normal settings and uses this instead. Only use it if your character truly needs different rules (like a video game NPC who must speak in code).
+
+**Post-History Instructions** — A reminder that gets shoved in right before the AI replies.
+- *How it changes behavior:* Because it's the *last* thing the AI reads, it pays extra attention to it. Great for rules like "Keep replies under 3 paragraphs" or "Stay in character."
+- *Tip:* Short and direct works best. One or two sentences.
+
+**Character's Note (Depth Prompt)** — A reminder you slip into the recent chat history.
+- *How it changes behavior:* You tell it how deep to put the reminder (depth 0 is right next to the latest message; depth 4 is four messages back). The AI sees it as if it were just said. Super effective at fixing "the AI forgot they're sad" problems.
+- *Tip:* This is the secret weapon. Use it for "Stay in voice" or "Remember they don't trust strangers."
+
+**Alternate Greetings** — Other possible openings the user can pick.
+- *How it changes behavior:* Only the one chosen gets sent to the AI. So you can have 10 of these without making chats more expensive.
+
+**Talkativeness** — How often this character talks in group chats. Doesn't cost tokens.
+
+**Creator, Notes, Tags, Version** — Just labels for organizing. The AI never sees these. Free.
+
+## Lorebooks
+
+A lorebook is like a folder of index cards. Each card has facts ("Sarah's dog is named Biscuit"). The AI only pulls a card out when something in the chat triggers it.
+
+**Why this saves tokens:** Instead of cramming every single fact into the Description (paid every message), you put facts in lorebook entries that *only* show up when needed.
+
+### Embedded Lorebook (Built Into the Character)
+
+Made through the Character Lorebook section. It's automatically used when this character is selected.
+- **Use it for:** stuff that belongs to this character — their family, their hometown, their pet, items they own.
+
+### Extra Lorebooks (Outside the Character)
+
+Set up in the World Info page. Two ways to use them:
+1. **Always on** — used in every chat with every character (a checkbox).
+2. **Linked to a character** — only used when that character is in the chat.
+
+**Important:** All active lorebooks share one budget (default **1,024 tokens**). If your books have more lore than that, the extra gets cut. More books = more competition.
+
+## Lorebook Entry Settings
+
+Each card in your lorebook has these settings.
+
+### Triggering the Card (When does it show up?)
+
+**Keys** — The trigger words. If anyone in the chat says one of these words, the card activates.
+- Example: keys = "Biscuit, dog, puppy" → the dog card shows up when those words appear.
+- *How it changes behavior:* The AI suddenly "remembers" facts when relevant — and forgets them when not. Realistic.
+
+**Secondary Keys + Selective Logic** — A second list of words to filter the card.
+- `AND_ANY` — needs a primary key AND at least one secondary key.
+- `AND_ALL` — needs a primary key AND ALL secondary keys.
+- `NOT_ANY` — primary key, but NONE of the secondary words.
+- `NOT_ALL` — primary key, but not all secondary words at once.
+- *Use case:* "Mom" card only fires when "mom" appears with "fight" or "argument" — not casual mentions.
+
+**Constant** — The card *always* fires, no triggers needed.
+- *How it changes behavior:* The fact is always in the AI's mind. Use only for stuff that truly always matters.
+
+**Case Sensitive** — Whether "biscuit" and "Biscuit" count as the same. Usually leave off.
+
+**Probability + Use Probability** — A dice roll for whether the card fires.
+- *How it changes behavior:* Set to 30% to add unpredictability. The AI won't always remember, which can feel more human.
+
+**Enabled** — On/off switch.
+
+**Delay / Cooldown / Sticky** — Time-based controls.
+- **Delay**: wait this many turns before the card can ever fire.
+- **Cooldown**: after firing, wait this many turns before it can fire again.
+- **Sticky**: after firing, stay active for this many turns (even without trigger words).
+- *How it changes behavior:* Sticky is great for emotions ("she's been crying for the last 3 messages"). Cooldown stops repetitive lore dumps.
+
+### Where the Card Goes in the AI's "Memory"
+
+**Position** — Where the card text gets inserted:
+- `before_char` — before the character description (default).
+- `after_char` — after the character description.
+- `before_an` — before the author's note.
+- `after_an` — after the author's note.
+- `at_depth` — slipped in N messages back in the chat (use the depth field).
+
+*How position changes behavior:* The AI pays more attention to stuff near the *end* of what it reads. So `at_depth` with a low depth number (close to the latest message) makes the lore feel "fresh" and recent.
+
+**Order** — A number for sorting cards in the same position. Lower = earlier.
+- *How it changes behavior:* If the budget runs out, higher-order cards get cut first. Put your most important cards at order 0–50.
+
+### Scanning (How Far Back the AI Looks)
+
+**Scan Depth** — How many recent chat messages get searched for trigger words. Default **4**.
+- *How it changes behavior:* Higher = more cards activate (because more messages are checked) = more tokens used and more chance of off-topic cards firing.
+
+**Max Recursion** — How many times one card can trigger another card. Default **3**.
+- Example: Card A says "Biscuit lives at the cabin." That triggers Card B about the cabin. That triggers Card C about the woods.
+- Set to 0 if you don't want chain reactions.
+
+**Prevent Recursion** — This card's words can't trigger others.
+
+**Exclude Recursion** — This card can't be triggered *by* other cards (only by chat).
+- *How it changes behavior:* Stops cards from snowballing into a giant lore dump.
+
+### Group Competition
+
+**Group** — Give multiple cards the same group name and only ONE will fire per message.
+
+**Group Weight** — Higher number = better odds of being the chosen one.
+
+**Group Override** — This card always wins, no matter the weight.
+
+*How it changes behavior:* Perfect for moods. Make 5 cards: happy, sad, angry, tired, excited. Put them all in group "mood." Now exactly ONE mood is active at a time, instead of all 5 piling on.
+
+## Smart Tricks That Save Tokens
+
+These are the moves that actually make a difference.
+
+### Trick 1: Use the Depth Prompt Instead of Cramming the Description
+
+If you keep needing to remind the AI "stay grumpy," don't add it to Description (paid every message forever). Put it in **Character's Note** at depth 2 instead. Same effect, way fewer tokens, and the AI listens to it more because it's near recent messages.
+
+### Trick 2: Move Big Lore Into a Lorebook
+
+Got a 200-word "world history" in Description? That's paid every message even when nobody's talking about history. Move it to a lorebook entry. Either:
+- Mark it `constant` if it really should always be there (still costs tokens, but you can swap or disable it).
+- Or add **keys** so it only shows up when history is mentioned.
+
+### Trick 3: Don't Crank Scan Depth Globally
+
+If you set the global scan depth to 20, *every* card now searches 20 messages. Instead, leave the global at 4 and only raise it on the few cards that need long memory.
+
+### Trick 4: Use Order, Not Position, to Pick Favorites
+
+When the token budget runs out, the AI cuts cards starting from the highest order numbers. So your most important cards should be at order 0, 10, 20… and your nice-to-haves at order 200+.
+
+### Trick 5: Use at_depth for "Right Now" Lore
+
+Stuff like "She just got bad news" works better at `at_depth` (depth 2) than at `before_char`. The AI pays more attention to recent stuff and will reflect the mood immediately.
+
+### Trick 6: Group Your Mood Cards
+
+Five mood cards in a group = only one fires per message. Total tokens stay the same no matter how many moods you add.
+
+### Trick 7: Two Example Messages Is Enough
+
+Examples are sent every single message. Two great ones teach the AI the voice better than six average ones — and cost half as much.
+
+### Trick 8: Watch the Token Count on Linked Templates
+
+If you link a prompt template, the editor shows you how many tokens it costs. If it's 500+ tokens, ask yourself: is it doing 500 tokens of work? If not, drop it.
+
+## Other Character Controls
+
+None of these cost prompt tokens.
+
+- **Linked Sampler Preset** — Auto-loads the right "creativity dial" settings when this character is picked.
+- **Linked Prompt Template** — Auto-loads a writing style template (this DOES cost tokens — shown inline).
+- **Visibility** — Share with everyone or keep private.
+- **Expression Sprites** — Picture changes with emotion. Only shown to you, never sent to the AI.
+- **Live Portrait** — Animated video clips for emotions. Made once, replay free.
+- **Regex Scripts** — Auto-fix patterns in the AI's replies (like always replacing "okay" with "okie").
+- **Setup Wizard** — Suggests good settings based on your character.
+- **Duplicate** — Make a copy to mess with safely.
+
+## A Cheap, Sharp Character Recipe
+
+Want a character that's fast, stays in voice, and doesn't drain tokens? Build it like this:
+
+1. **Description**: 300 tokens or less. Bullet points. Looks + one-line backstory. Done.
+2. **Personality**: 150 tokens or less. 3–5 traits. No overlap with Description.
+3. **Scenario**: 80 tokens or empty.
+4. **First Message**: medium length — sets the rhythm for the whole chat.
+5. **Example Messages**: exactly 2. Show the character at their most "them."
+6. **Character's Note**: 1–2 sentences at depth 2. Something like *"Stay in voice. Keep replies under 3 paragraphs."*
+7. **Embedded lorebook**: keyword-triggered cards for friends, places, items. Avoid `constant` unless it's truly always needed.
+8. **Linked template**: skip it unless you really need one.
+
+Every token you save here is a token saved on every message, forever. That's the whole game.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { MainLayout } from './components/layout/MainLayout';
 import { ChatView } from './components/chat/ChatView';
 // Settings pages are now rendered inside the slide-in SettingsPanel (not routes).
 import { InviteAcceptPage } from './components/auth/InviteAcceptPage';
+import { GuidesRouteRedirect } from './components/guides/GuidesRouteRedirect';
 import { ToastProvider } from './components/ui/Toast';
 import { GlobalExtensionHost } from './extensions/sandbox/GlobalExtensionHost';
 import { ExtensionPopupRoot } from './extensions/sandbox/ExtensionPopupRoot';
@@ -26,6 +27,22 @@ function App() {
         <Route path="/" element={<MainLayout />}>
           <Route index element={<ChatView />} />
           <Route path="chat/:characterId" element={<ChatView />} />
+          <Route
+            path="guides"
+            element={
+              <RequireRole minRole="contributor">
+                <GuidesRouteRedirect />
+              </RequireRole>
+            }
+          />
+          <Route
+            path="guides/:slug"
+            element={
+              <RequireRole minRole="contributor">
+                <GuidesRouteRedirect />
+              </RequireRole>
+            }
+          />
         </Route>
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>

--- a/src/components/character/CharacterEdit.tsx
+++ b/src/components/character/CharacterEdit.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Download, FileImage, FileJson, Copy, UserCircle, Globe, Lock, Loader2, Wand2, Link2, Unlink } from 'lucide-react';
+import { BookOpen, Download, FileImage, FileJson, Copy, UserCircle, Globe, Lock, Loader2, Wand2, Link2, Unlink } from 'lucide-react';
 import { useCharacterStore } from '../../stores/characterStore';
 import { useCharacterOwnershipStore } from '../../stores/characterOwnershipStore';
 import { useAuthStore } from '../../stores/authStore';
@@ -9,6 +9,7 @@ import { Modal, Button, Input, TextArea, ImageUpload, ExpressionUpload, TagInput
 import { showToastGlobal } from '../ui/Toast';
 import { AlternateGreetingsEditor } from './AlternateGreetingsEditor';
 import { CharacterLorebookSection } from './CharacterLorebookSection';
+import { GuideDrawer } from '../guides/GuideDrawer';
 import { LivePortraitSetup } from './LivePortraitSetup';
 import { CharacterSetupWizard } from './CharacterSetupWizard';
 import { useLivePortraitStore } from '../../stores/livePortraitStore';
@@ -55,6 +56,12 @@ export function CharacterEdit({
   const [showExportMenu, setShowExportMenu] = useState(false);
   const [showLivePortraitSetup, setShowLivePortraitSetup] = useState(false);
   const [showWizard, setShowWizard] = useState(false);
+  const [guideSection, setGuideSection] = useState<string | undefined>(undefined);
+  const [showGuide, setShowGuide] = useState(false);
+  const openGuide = (sectionId?: string) => {
+    setGuideSection(sectionId);
+    setShowGuide(true);
+  };
   const livePortraitClips = useLivePortraitStore((s) => s.clipsByAvatar[character.avatar]);
   const hasLivePortraitClips = !!livePortraitClips && Object.keys(livePortraitClips).length > 0;
   const linkedPresetId = useGenerationStore((s) => s.linkedPresetByAvatar[character.avatar]);
@@ -312,6 +319,16 @@ export function CharacterEdit({
             <Wand2 size={16} className="mr-1.5" />
             Setup Wizard
           </Button>
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            onClick={() => openGuide()}
+            title="Open the character building guide"
+          >
+            <BookOpen size={16} className="mr-1.5" />
+            Building Guide
+          </Button>
           <div className="relative">
             <Button
               type="button"
@@ -546,6 +563,15 @@ export function CharacterEdit({
         </div>
 
         {/* Phase 4.3: Character lorebooks */}
+        <div className="flex items-center justify-end -mb-2">
+          <button
+            type="button"
+            onClick={() => openGuide('lorebooks')}
+            className="text-xs text-[var(--color-text-secondary)] hover:text-[var(--color-primary)] inline-flex items-center gap-1"
+          >
+            <BookOpen size={12} /> Lorebook guide
+          </button>
+        </div>
         <CharacterLorebookSection
           avatar={character.avatar}
           characterName={formData.name || character.name}
@@ -743,6 +769,12 @@ export function CharacterEdit({
           estimateTokens(formData.scenario) +
           estimateTokens(formData.firstMessage)
         }
+      />
+      <GuideDrawer
+        isOpen={showGuide}
+        onClose={() => setShowGuide(false)}
+        guideSlug="character-guide"
+        sectionId={guideSection}
       />
     </Modal>
   );

--- a/src/components/guides/GuideDrawer.tsx
+++ b/src/components/guides/GuideDrawer.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useState } from 'react';
+import { X, BookOpen, ExternalLink } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { Button } from '../ui';
+import { MarkdownDoc } from '../ui/MarkdownDoc';
+import { getGuide } from './guides';
+
+interface GuideDrawerProps {
+  isOpen: boolean;
+  onClose: () => void;
+  guideSlug: string;
+  /** Optional heading id to scroll to inside the guide. */
+  sectionId?: string;
+}
+
+const EXIT_MS = 220;
+
+export function GuideDrawer({ isOpen, onClose, guideSlug, sectionId }: GuideDrawerProps) {
+  const navigate = useNavigate();
+  const guide = getGuide(guideSlug);
+  const [mounted, setMounted] = useState(isOpen);
+  const [exiting, setExiting] = useState(false);
+
+  useEffect(() => {
+    if (isOpen) {
+      setMounted(true);
+      setExiting(false);
+      return;
+    }
+    if (mounted) {
+      setExiting(true);
+      const t = setTimeout(() => setMounted(false), EXIT_MS);
+      return () => clearTimeout(t);
+    }
+  }, [isOpen, mounted]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [isOpen, onClose]);
+
+  if (!mounted || !guide) return null;
+
+  const openFullPage = () => {
+    onClose();
+    navigate(`/guides/${guide.slug}${sectionId ? `#${sectionId}` : ''}`);
+  };
+
+  return (
+    <div className="fixed inset-0 z-[110] flex justify-end">
+      <div
+        className={`absolute inset-0 bg-black/60 backdrop-blur-sm motion-reduce:transition-none ${
+          exiting
+            ? 'opacity-0 transition-opacity duration-200'
+            : 'opacity-100 animate-guide-drawer-backdrop-in'
+        }`}
+        onClick={onClose}
+      />
+
+      <div
+        className={`relative w-full max-w-md h-full bg-[var(--color-bg-secondary)] border-l border-[var(--color-border)] shadow-2xl flex flex-col safe-top safe-bottom motion-reduce:transition-none motion-reduce:animate-none ${
+          exiting
+            ? 'translate-x-full transition-transform duration-200 ease-out'
+            : 'translate-x-0 animate-guide-drawer-in'
+        }`}
+      >
+        <div className="flex items-center justify-between px-4 py-3 border-b border-[var(--color-border)]">
+          <div className="flex items-center gap-2 min-w-0">
+            <BookOpen size={18} className="text-[var(--color-primary)] shrink-0" />
+            <h2 className="text-sm font-semibold text-[var(--color-text-primary)] truncate">
+              {guide.title}
+            </h2>
+          </div>
+          <div className="flex items-center gap-1">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="p-2"
+              aria-label="Open full guide"
+              onClick={openFullPage}
+            >
+              <ExternalLink size={16} />
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="p-2"
+              aria-label="Close guide"
+              onClick={onClose}
+            >
+              <X size={18} />
+            </Button>
+          </div>
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-4 py-4">
+          <MarkdownDoc source={guide.source} scrollToId={sectionId} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/guides/GuidesPanel.tsx
+++ b/src/components/guides/GuidesPanel.tsx
@@ -1,0 +1,200 @@
+import { useEffect, useMemo, useState } from 'react';
+import { ArrowLeft, BookOpen, Link as LinkIcon, X } from 'lucide-react';
+import { useGuidesPanelStore } from '../../stores/guidesPanelStore';
+import { useAuthStore } from '../../stores/authStore';
+import { hasPermission } from '../../utils/permissions';
+import { MarkdownDoc, type Heading } from '../ui/MarkdownDoc';
+import { showToastGlobal } from '../ui/Toast';
+import { GUIDES, getGuide } from './guides';
+
+export function GuidesPanel() {
+  const { isOpen, slug, sectionId, setGuide, clearGuide, close } = useGuidesPanelStore();
+  const currentUser = useAuthStore((s) => s.currentUser);
+
+  const [mounted, setMounted] = useState(false);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (isOpen) {
+      setMounted(true);
+      requestAnimationFrame(() => requestAnimationFrame(() => setVisible(true)));
+    } else {
+      setVisible(false);
+      const timer = setTimeout(() => setMounted(false), 300);
+      return () => clearTimeout(timer);
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!mounted) return;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [mounted]);
+
+  useEffect(() => {
+    if (!mounted) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') close();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [mounted, close]);
+
+  const visibleGuides = useMemo(
+    () => GUIDES.filter((g) => !g.requiredPermission || hasPermission(currentUser, g.requiredPermission)),
+    [currentUser],
+  );
+
+  const guide = slug ? getGuide(slug) : undefined;
+  const canViewGuide = guide && (!guide.requiredPermission || hasPermission(currentUser, guide.requiredPermission));
+
+  const [headings, setHeadings] = useState<Heading[]>([]);
+  const [scrollToId, setScrollToId] = useState<string | undefined>(sectionId);
+
+  useEffect(() => {
+    setScrollToId(sectionId);
+  }, [sectionId, slug]);
+
+  if (!mounted) return null;
+
+  const tocHeadings = headings.filter((h) => h.level === 2);
+
+  const copyShareLink = async () => {
+    if (!slug) return;
+    const url = `${window.location.origin}/guides/${slug}${scrollToId ? `#${scrollToId}` : ''}`;
+    try {
+      await navigator.clipboard.writeText(url);
+      showToastGlobal('Link copied', 'success');
+    } catch {
+      showToastGlobal('Could not copy link', 'error');
+    }
+  };
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className={`fixed inset-0 z-40 bg-black/40 transition-opacity duration-300 ${
+          visible ? 'opacity-100' : 'opacity-0'
+        }`}
+        onClick={close}
+      />
+
+      {/* Panel */}
+      <div
+        className={`fixed inset-y-0 right-0 z-50 w-full sm:w-[90vw] sm:max-w-4xl
+          bg-[var(--color-bg-primary)] border-l border-[var(--color-border)] shadow-2xl
+          flex flex-col overflow-hidden
+          transform transition-transform duration-300 ease-in-out
+          ${visible ? 'translate-x-0' : 'translate-x-full'}
+        `}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between gap-2 px-4 py-3 border-b border-[var(--color-border)] flex-shrink-0">
+          <div className="flex items-center gap-2 min-w-0">
+            {slug && (
+              <button
+                onClick={clearGuide}
+                className="p-1.5 rounded-lg text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-tertiary)]"
+                aria-label="Back to all guides"
+              >
+                <ArrowLeft size={18} />
+              </button>
+            )}
+            <BookOpen size={18} className="text-[var(--color-primary)] shrink-0" />
+            <h2 className="text-sm font-semibold text-[var(--color-text-primary)] truncate">
+              {guide ? guide.title : 'Guides'}
+            </h2>
+          </div>
+          <div className="flex items-center gap-1">
+            {slug && (
+              <button
+                onClick={copyShareLink}
+                className="p-1.5 rounded-lg text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-tertiary)]"
+                aria-label="Copy link to this guide"
+                title="Copy shareable link"
+              >
+                <LinkIcon size={16} />
+              </button>
+            )}
+            <button
+              onClick={close}
+              className="p-1.5 rounded-lg text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-tertiary)]"
+              aria-label="Close guides"
+            >
+              <X size={18} />
+            </button>
+          </div>
+        </div>
+
+        {/* Body */}
+        {!slug || !canViewGuide ? (
+          <div className="flex-1 overflow-y-auto p-6">
+            <div className="max-w-2xl mx-auto">
+              <header className="mb-4">
+                <p className="text-sm text-[var(--color-text-secondary)]">
+                  Walkthroughs and references for building characters, lorebooks, and more.
+                </p>
+              </header>
+              {visibleGuides.length === 0 ? (
+                <p className="text-sm text-[var(--color-text-secondary)]">
+                  No guides available for your role yet.
+                </p>
+              ) : (
+                <ul className="space-y-2">
+                  {visibleGuides.map((g) => (
+                    <li key={g.slug}>
+                      <button
+                        type="button"
+                        onClick={() => setGuide(g.slug)}
+                        className="w-full text-left rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-secondary)] hover:border-[var(--color-primary)]/60 transition-colors p-4"
+                      >
+                        <p className="text-sm font-semibold text-[var(--color-text-primary)]">
+                          {g.title}
+                        </p>
+                        <p className="text-xs text-[var(--color-text-secondary)] mt-1">
+                          {g.summary}
+                        </p>
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </div>
+        ) : (
+          <div className="flex-1 flex overflow-hidden">
+            <aside className="hidden lg:block w-60 shrink-0 border-r border-[var(--color-border)] overflow-y-auto p-4">
+              <p className="text-xs uppercase tracking-wide text-[var(--color-text-secondary)] mb-2">
+                On this page
+              </p>
+              <nav className="space-y-1">
+                {tocHeadings.map((h) => (
+                  <button
+                    key={h.id}
+                    type="button"
+                    onClick={() => setScrollToId(h.id)}
+                    className="block w-full text-left text-xs text-[var(--color-text-secondary)] hover:text-[var(--color-primary)] py-1"
+                  >
+                    {h.text}
+                  </button>
+                ))}
+              </nav>
+            </aside>
+
+            <main className="flex-1 overflow-y-auto p-6">
+              <div key={guide!.slug} className="max-w-3xl mx-auto animate-guide-fade-in">
+                <header className="mb-4">
+                  <p className="text-sm text-[var(--color-text-secondary)]">{guide!.summary}</p>
+                </header>
+                <MarkdownDoc source={guide!.source} scrollToId={scrollToId} onHeadings={setHeadings} />
+              </div>
+            </main>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/src/components/guides/GuidesRouteRedirect.tsx
+++ b/src/components/guides/GuidesRouteRedirect.tsx
@@ -1,0 +1,30 @@
+import { useEffect, useRef } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useGuidesPanelStore } from '../../stores/guidesPanelStore';
+
+/**
+ * Renders nothing visible. When mounted because the user landed on
+ * /guides or /guides/:slug, opens the GuidesPanel to that guide and
+ * replaces the URL with `/` so the chat canvas stays present underneath.
+ */
+export function GuidesRouteRedirect() {
+  const navigate = useNavigate();
+  const { slug } = useParams<{ slug: string }>();
+  // Guard against React StrictMode's double-invoked effect: the second run
+  // would read window.location.hash AFTER the first run already navigated
+  // away, losing the section anchor.
+  const handled = useRef(false);
+
+  useEffect(() => {
+    if (handled.current) return;
+    handled.current = true;
+    const sectionId =
+      typeof window !== 'undefined' && window.location.hash
+        ? window.location.hash.slice(1)
+        : undefined;
+    useGuidesPanelStore.getState().open(slug, sectionId);
+    navigate('/', { replace: true });
+  }, [slug, navigate]);
+
+  return null;
+}

--- a/src/components/guides/guides.ts
+++ b/src/components/guides/guides.ts
@@ -1,0 +1,26 @@
+import characterGuideMd from '../../../docs/character-guide.md?raw';
+import type { Permission } from '../../types';
+
+export interface Guide {
+  slug: string;
+  title: string;
+  summary: string;
+  source: string;
+  /** If set, the user must hold this permission to view the guide. */
+  requiredPermission?: Permission;
+}
+
+export const GUIDES: Guide[] = [
+  {
+    slug: 'character-guide',
+    title: 'Character Building',
+    summary:
+      'How character fields, embedded lorebooks, and entry settings shape behavior — and how to keep token usage low.',
+    source: characterGuideMd,
+    requiredPermission: 'character:edit',
+  },
+];
+
+export function getGuide(slug: string): Guide | undefined {
+  return GUIDES.find((g) => g.slug === slug);
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react';
-import { Download, HelpCircle, Key, Menu, Settings, LogOut, Pencil, UserCircle } from 'lucide-react';
+import { BookOpen, Download, HelpCircle, Key, Menu, Settings, LogOut, Pencil, UserCircle } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useAuthStore } from '../../stores/authStore';
 import { useSettingsPanelStore } from '../../stores/settingsPanelStore';
+import { useGuidesPanelStore } from '../../stores/guidesPanelStore';
 import { useCharacterStore } from '../../stores/characterStore';
 import { can } from '../../utils/permissions';
 import { Avatar, Button } from '../ui';
@@ -23,6 +24,7 @@ export function Header({ onMenuClick }: HeaderProps) {
   const userRole = currentUser?.role;
   const canEdit = can(userRole, 'character:edit');
   const canViewSettings = can(userRole, 'settings:view');
+  const canViewGuides = canEdit;
   const { canInstall, install: installPwa } = usePwaInstall();
   const [showEditModal, setShowEditModal] = useState(false);
   const [showHelp, setShowHelp] = useState(false);
@@ -100,6 +102,17 @@ export function Header({ onMenuClick }: HeaderProps) {
           </Button>
         )}
         <PersonaSelector />
+        {canViewGuides && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="p-2"
+            aria-label="Guides"
+            onClick={() => useGuidesPanelStore.getState().open()}
+          >
+            <BookOpen size={20} />
+          </Button>
+        )}
         <Button
           variant="ghost"
           size="sm"

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -6,6 +6,7 @@ import { useSwipeSidebar } from '../../hooks/useSwipeSidebar';
 import { Header } from './Header';
 import { Sidebar } from './Sidebar';
 import { SettingsPanel } from '../settings/SettingsPanel';
+import { GuidesPanel } from '../guides/GuidesPanel';
 import { OnboardingWalkthrough } from '../onboarding/OnboardingWalkthrough';
 import { useOnboardingStore } from '../../stores/onboardingStore';
 
@@ -79,6 +80,9 @@ export function MainLayout() {
 
       {/* Settings Panel — slides in from right, overlays chat */}
       <SettingsPanel />
+
+      {/* Guides Panel — slides in from right, overlays chat */}
+      <GuidesPanel />
 
       {/* Onboarding Walkthrough */}
       <OnboardingWalkthrough />

--- a/src/components/ui/MarkdownDoc.tsx
+++ b/src/components/ui/MarkdownDoc.tsx
@@ -1,0 +1,104 @@
+import { useMemo, useEffect, useRef } from 'react';
+import { marked } from 'marked';
+
+interface MarkdownDocProps {
+  source: string;
+  /** If set, scroll the heading with this id into view after render. */
+  scrollToId?: string;
+  /** Called once with the list of {id, text, level} for each heading. */
+  onHeadings?: (headings: Heading[]) => void;
+  className?: string;
+}
+
+export interface Heading {
+  id: string;
+  text: string;
+  level: number;
+}
+
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, '')
+    .trim()
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-');
+}
+
+function renderMarkdown(source: string): { html: string; headings: Heading[] } {
+  const headings: Heading[] = [];
+  const seen = new Map<string, number>();
+
+  const renderer = new marked.Renderer();
+  renderer.heading = ({ tokens, depth }) => {
+    const text = tokens.map((t) => ('text' in t ? t.text : '')).join('');
+    let id = slugify(text);
+    const count = seen.get(id) ?? 0;
+    seen.set(id, count + 1);
+    if (count > 0) id = `${id}-${count}`;
+    headings.push({ id, text, level: depth });
+    return `<h${depth} id="${id}">${text}</h${depth}>`;
+  };
+
+  const html = marked.parse(source, { renderer, async: false }) as string;
+  return { html, headings };
+}
+
+export function MarkdownDoc({ source, scrollToId, onHeadings, className }: MarkdownDocProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const { html, headings } = useMemo(() => renderMarkdown(source), [source]);
+
+  useEffect(() => {
+    onHeadings?.(headings);
+  }, [headings, onHeadings]);
+
+  useEffect(() => {
+    if (!scrollToId || !containerRef.current) return;
+    // Defer the scroll until after layout settles — when MarkdownDoc lives
+    // inside a panel that's still sliding in, an immediate scrollIntoView can
+    // no-op against the in-flight transform.
+    const scrollTimer = setTimeout(() => {
+      const el = containerRef.current?.querySelector<HTMLElement>(`#${CSS.escape(scrollToId)}`);
+      if (!el) return;
+      el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+
+      const reduceMotion =
+        typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      if (reduceMotion) return;
+
+      const reset = () => {
+        el.style.transition = '';
+        el.style.backgroundColor = '';
+      };
+      el.style.transition = 'background-color 0ms';
+      el.style.backgroundColor = 'rgba(168, 85, 247, 0.22)';
+      requestAnimationFrame(() => {
+        el.style.transition = 'background-color 1100ms ease-out';
+        el.style.backgroundColor = 'transparent';
+      });
+      setTimeout(reset, 1300);
+    }, 50);
+    return () => clearTimeout(scrollTimer);
+  }, [scrollToId, html]);
+
+  return (
+    <div
+      ref={containerRef}
+      className={`text-sm text-[var(--color-text-primary)] leading-relaxed
+        [&_h1]:text-2xl [&_h1]:font-bold [&_h1]:mt-6 [&_h1]:mb-3 [&_h1]:text-[var(--color-text-primary)]
+        [&_h2]:text-lg [&_h2]:font-semibold [&_h2]:mt-6 [&_h2]:mb-2 [&_h2]:text-[var(--color-text-primary)] [&_h2]:scroll-mt-4
+        [&_h3]:text-base [&_h3]:font-semibold [&_h3]:mt-4 [&_h3]:mb-2 [&_h3]:text-[var(--color-text-primary)] [&_h3]:scroll-mt-4
+        [&_p]:my-2
+        [&_ul]:my-2 [&_ul]:pl-5 [&_ul]:list-disc
+        [&_ol]:my-2 [&_ol]:pl-5 [&_ol]:list-decimal
+        [&_li]:my-1
+        [&_strong]:font-semibold [&_strong]:text-[var(--color-text-primary)]
+        [&_em]:italic [&_em]:text-[var(--color-text-secondary)]
+        [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:rounded [&_code]:bg-[var(--color-bg-tertiary)] [&_code]:text-xs [&_code]:font-mono
+        [&_a]:text-[var(--color-primary)] [&_a]:underline
+        ${className ?? ''}`}
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+}

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,4 +1,5 @@
-import { type ReactNode, useEffect } from 'react';
+import { type ReactNode, useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { X } from 'lucide-react';
 import { Button } from './Button';
 
@@ -10,25 +11,40 @@ interface ModalProps {
   size?: 'sm' | 'md' | 'lg';
 }
 
+const EXIT_MS = 180;
+
 export function Modal({ isOpen, onClose, title, children, size = 'md' }: ModalProps) {
-  // Close on escape key
+  const [mounted, setMounted] = useState(isOpen);
+  const [exiting, setExiting] = useState(false);
+
   useEffect(() => {
+    if (isOpen) {
+      setMounted(true);
+      setExiting(false);
+      return;
+    }
+    if (mounted) {
+      setExiting(true);
+      const t = setTimeout(() => setMounted(false), EXIT_MS);
+      return () => clearTimeout(t);
+    }
+  }, [isOpen, mounted]);
+
+  // Body scroll lock + escape handler — active while mounted (covers exit anim).
+  useEffect(() => {
+    if (!mounted) return;
     const handleEscape = (e: KeyboardEvent) => {
       if (e.key === 'Escape') onClose();
     };
-
-    if (isOpen) {
-      document.addEventListener('keydown', handleEscape);
-      document.body.style.overflow = 'hidden';
-    }
-
+    document.addEventListener('keydown', handleEscape);
+    document.body.style.overflow = 'hidden';
     return () => {
       document.removeEventListener('keydown', handleEscape);
       document.body.style.overflow = '';
     };
-  }, [isOpen, onClose]);
+  }, [mounted, onClose]);
 
-  if (!isOpen) return null;
+  if (!mounted) return null;
 
   const sizes = {
     sm: 'max-w-sm',
@@ -36,11 +52,13 @@ export function Modal({ isOpen, onClose, title, children, size = 'md' }: ModalPr
     lg: 'max-w-2xl',
   };
 
-  return (
+  return createPortal(
     <div className="fixed inset-0 z-[100] flex items-center justify-center p-4">
       {/* Backdrop */}
       <div
-        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        className={`absolute inset-0 bg-black/60 backdrop-blur-sm motion-reduce:animate-none ${
+          exiting ? 'animate-modal-backdrop-out' : 'animate-modal-backdrop-in'
+        }`}
         onClick={onClose}
       />
 
@@ -53,6 +71,8 @@ export function Modal({ isOpen, onClose, title, children, size = 'md' }: ModalPr
           rounded-xl shadow-2xl
           max-h-[90vh] overflow-hidden
           flex flex-col
+          motion-reduce:animate-none
+          ${exiting ? 'animate-modal-out' : 'animate-modal-in'}
         `}
       >
         {/* Header */}
@@ -76,6 +96,7 @@ export function Modal({ isOpen, onClose, title, children, size = 'md' }: ModalPr
           {children}
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -416,3 +416,76 @@ body {
 .animate-fade-in-up {
   animation: fade-in-up 0.35s ease-out;
 }
+
+/* --- Guide page fade-in -------------------------------------------- */
+@keyframes guide-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+.animate-guide-fade-in {
+  animation: guide-fade-in 0.22s ease-out;
+}
+
+/* --- Guide drawer entrance ----------------------------------------- */
+@keyframes guide-drawer-in {
+  from { transform: translateX(100%); }
+  to   { transform: translateX(0); }
+}
+.animate-guide-drawer-in {
+  animation: guide-drawer-in 0.22s ease-out;
+}
+@keyframes guide-drawer-backdrop-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+.animate-guide-drawer-backdrop-in {
+  animation: guide-drawer-backdrop-in 0.2s ease-out;
+}
+
+/* --- Modal entrance / exit ----------------------------------------- */
+@keyframes modal-in {
+  from { opacity: 0; transform: scale(0.96); }
+  to   { opacity: 1; transform: scale(1); }
+}
+.animate-modal-in {
+  animation: modal-in 0.2s ease-out;
+}
+@keyframes modal-out {
+  from { opacity: 1; transform: scale(1); }
+  to   { opacity: 0; transform: scale(0.96); }
+}
+.animate-modal-out {
+  animation: modal-out 0.18s ease-in forwards;
+}
+@keyframes modal-backdrop-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+.animate-modal-backdrop-in {
+  animation: modal-backdrop-in 0.2s ease-out;
+}
+@keyframes modal-backdrop-out {
+  from { opacity: 1; }
+  to   { opacity: 0; }
+}
+.animate-modal-backdrop-out {
+  animation: modal-backdrop-out 0.18s ease-in forwards;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-guide-fade-in,
+  .animate-guide-drawer-in,
+  .animate-guide-drawer-backdrop-in,
+  .animate-modal-in,
+  .animate-modal-out,
+  .animate-modal-backdrop-in,
+  .animate-modal-backdrop-out {
+    animation: none;
+  }
+}

--- a/src/stores/guidesPanelStore.ts
+++ b/src/stores/guidesPanelStore.ts
@@ -1,0 +1,32 @@
+import { create } from 'zustand';
+
+interface GuidesPanelState {
+  isOpen: boolean;
+  /** Currently displayed guide slug; null = index view. */
+  slug: string | null;
+  /** Optional heading id to scroll to inside the displayed guide. */
+  sectionId?: string;
+
+  open: (slug?: string, sectionId?: string) => void;
+  openIndex: () => void;
+  setGuide: (slug: string, sectionId?: string) => void;
+  clearGuide: () => void;
+  close: () => void;
+}
+
+export const useGuidesPanelStore = create<GuidesPanelState>((set) => ({
+  isOpen: false,
+  slug: null,
+  sectionId: undefined,
+
+  open: (slug, sectionId) =>
+    set({ isOpen: true, slug: slug ?? null, sectionId }),
+
+  openIndex: () => set({ isOpen: true, slug: null, sectionId: undefined }),
+
+  setGuide: (slug, sectionId) => set({ slug, sectionId }),
+
+  clearGuide: () => set({ slug: null, sectionId: undefined }),
+
+  close: () => set({ isOpen: false }),
+}));


### PR DESCRIPTION
## Summary
- Adds a plain-language Character Building guide explaining every character field, embedded/extra lorebooks, entry settings, and token-efficiency tricks.
- Builds a Settings-style slide-in `GuidesPanel` (right side, `max-w-4xl`) with an index view, reader view with sidebar TOC, and a copy-shareable-link button.
- Adds a narrow in-modal `GuideDrawer` for the CharacterEdit context, opened from a new "Building Guide" button and a deep-link near the lorebook section.
- Converts `/guides` and `/guides/:slug` routes into redirects that auto-open the panel and replace the URL with `/` so the chat canvas stays underneath.
- Polishes modal animations across the app: scale+fade entrance/exit, backdrop fade, `prefers-reduced-motion` opt-out, and portals modals to `document.body` so they escape sticky-header stacking contexts.

## Test plan
- [ ] Open the panel via the BookOpen icon in the header — slides in over chat
- [ ] Click into Character Building, scroll, click TOC links — smooth scroll + highlight flash
- [ ] Copy share link, open in a new tab — panel auto-opens to that section, URL replaces with `/`
- [ ] Open CharacterEdit modal, click Building Guide — narrow drawer slides in
- [ ] Click "Lorebook guide" near the lorebook section — drawer opens scrolled to Lorebooks heading
- [ ] Smaller-than-lg viewport: modal no longer obscured by sidebar
- [ ] `prefers-reduced-motion: reduce` disables animations

🤖 Generated with [Claude Code](https://claude.com/claude-code)