### PR TITLE
feat: surface multi-variant generation in chat menu + swipe counter

### DIFF
--- a/src/components/chat/ChatOptionsMenu.tsx
+++ b/src/components/chat/ChatOptionsMenu.tsx
@@ -173,7 +173,7 @@ function MenuBody({
         <>
           <Divider />
           <div className="py-1">
-            {onRegenerate && <ActionRow icon={RefreshCw} label="Regenerate" onClick={wrap(onRegenerate)} />}
+            {onRegenerate && <ActionRow icon={RefreshCw} label="Generate alternative" onClick={wrap(onRegenerate)} />}
             {onContinue && <ActionRow icon={ArrowRight} label="Continue" onClick={wrap(onContinue)} />}
             {onImpersonate && <ActionRow icon={User} label="Impersonate" onClick={wrap(onImpersonate)} />}
           </div>

--- a/src/components/chat/SwipeControl.tsx
+++ b/src/components/chat/SwipeControl.tsx
@@ -23,6 +23,10 @@ export function SwipeControl({
   const atLastSwipe = swipeId === swipesCount - 1;
   const canSwipeRight = !disabled && (!atLastSwipe || canGenerate);
   const current = swipeId + 1;
+  const showHint = swipesCount === 1 && canGenerate;
+  const counterText = swipesCount > 1
+    ? `Variant ${current} of ${swipesCount}`
+    : showHint ? 'Tap → for alternative' : `${current} of ${swipesCount}`;
 
   return (
     <div className="flex items-center gap-1 mt-1 text-[var(--color-text-secondary)]">
@@ -34,15 +38,20 @@ export function SwipeControl({
       >
         <ChevronLeft size={16} />
       </button>
-      <span className="text-xs font-medium min-w-[2.5rem] text-center tabular-nums">
-        {current}/{swipesCount}
+      <span
+        aria-live="polite"
+        className={`text-xs px-1 text-center ${
+          showHint ? 'italic' : 'font-medium tabular-nums'
+        }`}
+      >
+        {counterText}
       </span>
       <button
         onClick={() => { haptic(); onSwipeRight(); }}
         disabled={!canSwipeRight}
         className="p-1 rounded hover:bg-[var(--color-bg-tertiary)] disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
-        aria-label={atLastSwipe ? 'Generate new response' : 'Next response'}
-        title={atLastSwipe ? 'Generate new response' : 'Next response'}
+        aria-label={atLastSwipe ? 'Generate alternative response' : 'Next response'}
+        title={atLastSwipe ? 'Generate alternative response' : 'Next response'}
       >
         <ChevronRight size={16} />
       </button>


### PR DESCRIPTION
## Summary
Implements #153.

The "swipes" infrastructure was already built — every AI message has \`swipes: string[]\` + \`swipeId\`, "Regenerate" appends a new variant (preserves the old one), the SwipeControl chevrons under the last AI message let you navigate between variants, and chats persist all variants. The user filed this issue because none of that was discoverable: "Regenerate" sounds like overwrite, the \`1/2\` counter is gnomic, and the chevrons aren't labeled.

This PR is a discoverability fix on top of the existing capability. **No data model / persistence / generation pipeline changes.**

## Changes
- **ChatOptionsMenu**: \`Regenerate\` → \`Generate alternative\` ([ChatOptionsMenu.tsx](src/components/chat/ChatOptionsMenu.tsx)).
- **SwipeControl** ([SwipeControl.tsx](src/components/chat/SwipeControl.tsx)):
  - Counter now reads \`Variant 1 of 2\` instead of \`1/2\` when there's more than one variant.
  - When a message has exactly one variant and the user can still generate (last AI message), the counter region shows an italic \`Tap → for alternative\` hint — the user immediately knows what the right chevron does.
  - Right-chevron \`aria-label\` / tooltip at end is now \`Generate alternative response\` (matches the menu wording).
  - Counter span gets \`aria-live="polite"\` so screen readers announce variant changes.

## Test plan
- [x] \`npm run build\` passes
- [x] Verified the menu now reads "Generate alternative" (replaces "Regenerate")
- [x] Verified the SwipeControl counter renders \`Variant 1 of 6\` for a message with 6 swipes
- [x] No console errors
- [ ] Reviewer: open a chat with a single-variant AI message → confirm counter region reads \`Tap → for alternative\` (italic)
- [ ] Reviewer: tap the right chevron OR the menu's "Generate alternative" → confirm a new variant streams in and counter updates to \`Variant 2 of 2\`
- [ ] Reviewer: tap left chevron → confirm navigation back to original

## Out of scope
- Batch generation (e.g., "generate 3 alternatives at once") — separate enhancement worth filing if you want it.
- Side-by-side comparison view — current UX is sequential navigation; not changed here.

🤖 Draft opened by the build-next-issue skill. Human review required before merge.