### PR TITLE
feat(character): transfer ownership of global characters

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -116,6 +116,11 @@ export interface CharacterMetadataEntry {
 
 export type CharacterMetadataMap = Record<string, CharacterMetadataEntry>;
 
+export interface UserHandleSummary {
+  handle: string;
+  name: string;
+}
+
 export interface CharacterInfo {
   name: string;
   avatar: string; // filename like "CharacterName.png"
@@ -511,6 +516,28 @@ export const api = {
       method: 'POST',
       body: JSON.stringify({ avatar_url: avatarUrl, visibility }),
     });
+  },
+
+  /**
+   * Transfers ownership of a global character to another user. The current
+   * owner must be the requester; metadata-only update on the server.
+   */
+  async transferCharacterOwnership(avatarUrl: string, newOwnerHandle: string): Promise<void> {
+    await apiRequest('/api/characters/transfer-ownership', {
+      method: 'POST',
+      body: JSON.stringify({ avatar_url: avatarUrl, new_owner_handle: newOwnerHandle }),
+    });
+  },
+
+  /**
+   * Returns enabled users' handles + display names (excluding the caller),
+   * for recipient pickers. Authenticated request, no special permission.
+   */
+  async listUserHandles(): Promise<UserHandleSummary[]> {
+    const result = await apiRequest<UserHandleSummary[]>('/api/users/handles', {
+      method: 'POST',
+    });
+    return Array.isArray(result) ? result : [];
   },
 
   // Chat endpoints - use avatar filename directly for consistency

--- a/src/components/character/CharacterEdit.tsx
+++ b/src/components/character/CharacterEdit.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { BookOpen, Download, FileImage, FileJson, Copy, UserCircle, Globe, Lock, Loader2, Wand2, Link2, Unlink } from 'lucide-react';
+import { BookOpen, Download, FileImage, FileJson, Copy, UserCircle, Globe, Lock, Loader2, Wand2, Link2, Unlink, ArrowRightLeft } from 'lucide-react';
 import { useCharacterStore } from '../../stores/characterStore';
 import { useCharacterOwnershipStore } from '../../stores/characterOwnershipStore';
 import { useAuthStore } from '../../stores/authStore';
@@ -12,6 +12,7 @@ import { CharacterLorebookSection } from './CharacterLorebookSection';
 import { GuideDrawer } from '../guides/GuideDrawer';
 import { LivePortraitSetup } from './LivePortraitSetup';
 import { CharacterSetupWizard } from './CharacterSetupWizard';
+import { TransferOwnershipModal } from './TransferOwnershipModal';
 import { useLivePortraitStore } from '../../stores/livePortraitStore';
 import { useGenerationStore } from '../../stores/generationStore';
 import { usePromptTemplateStore } from '../../stores/promptTemplateStore';
@@ -53,6 +54,10 @@ export function CharacterEdit({
   const canSetGlobal = hasPermission(currentUser, 'character:set_global');
   const visibility = ownershipStore.getVisibility(character.avatar);
   const [isTogglingVisibility, setIsTogglingVisibility] = useState(false);
+  const [showTransferModal, setShowTransferModal] = useState(false);
+  const isCharacterOwner =
+    !!currentUser && ownershipStore.isOwnedBy(character.avatar, currentUser.handle);
+  const canTransferOwnership = visibility === 'global' && isCharacterOwner;
   const [showExportMenu, setShowExportMenu] = useState(false);
   const [showLivePortraitSetup, setShowLivePortraitSetup] = useState(false);
   const [showWizard, setShowWizard] = useState(false);
@@ -470,6 +475,30 @@ export function CharacterEdit({
           </div>
         )}
 
+        {/* Transfer Ownership — only the current owner of a global character can hand it off */}
+        {canTransferOwnership && (
+          <div className="flex items-center justify-between rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-tertiary)] px-3 py-2">
+            <div className="min-w-0">
+              <p className="text-sm font-medium text-[var(--color-text-primary)]">
+                You own this character
+              </p>
+              <p className="text-xs text-[var(--color-text-secondary)]">
+                Transfer ownership to another user. The character stays global.
+              </p>
+            </div>
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              onClick={() => setShowTransferModal(true)}
+              className="shrink-0"
+            >
+              <ArrowRightLeft size={14} className="mr-1.5" />
+              Transfer
+            </Button>
+          </div>
+        )}
+
         {/* Name - Required */}
         <Input
           label="Name *"
@@ -775,6 +804,16 @@ export function CharacterEdit({
         onClose={() => setShowGuide(false)}
         guideSlug="character-guide"
         sectionId={guideSection}
+      />
+      <TransferOwnershipModal
+        isOpen={showTransferModal}
+        onClose={() => setShowTransferModal(false)}
+        character={character}
+        onTransferred={() => {
+          // After a successful transfer the caller is no longer the owner —
+          // close the editor so the UI re-checks permissions on next open.
+          onClose();
+        }}
       />
     </Modal>
   );

--- a/src/components/character/TransferOwnershipModal.tsx
+++ b/src/components/character/TransferOwnershipModal.tsx
@@ -1,0 +1,202 @@
+import { useEffect, useState } from 'react';
+import { Loader2, UserCircle } from 'lucide-react';
+import { api, type CharacterInfo, type UserHandleSummary } from '../../api/client';
+import { useCharacterOwnershipStore } from '../../stores/characterOwnershipStore';
+import { Modal, Button, Input } from '../ui';
+import { showToastGlobal } from '../ui/Toast';
+
+interface TransferOwnershipModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  character: CharacterInfo;
+  /** Called after a successful transfer so the parent can close itself / refetch. */
+  onTransferred?: () => void;
+}
+
+export function TransferOwnershipModal({
+  isOpen,
+  onClose,
+  character,
+  onTransferred,
+}: TransferOwnershipModalProps) {
+  const transferOwnership = useCharacterOwnershipStore((s) => s.transferOwnership);
+  const [users, setUsers] = useState<UserHandleSummary[] | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [filter, setFilter] = useState('');
+  const [selectedHandle, setSelectedHandle] = useState<string | null>(null);
+  const [confirming, setConfirming] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  // Reset transient state every open and load users.
+  useEffect(() => {
+    if (!isOpen) return;
+    setFilter('');
+    setSelectedHandle(null);
+    setConfirming(false);
+    setSubmitting(false);
+    setLoadError(null);
+    setUsers(null);
+    let cancelled = false;
+    api
+      .listUserHandles()
+      .then((list) => {
+        if (!cancelled) setUsers(list);
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setLoadError(err instanceof Error ? err.message : 'Failed to load users');
+          setUsers([]);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen]);
+
+  const filtered = (users ?? []).filter((u) => {
+    if (!filter.trim()) return true;
+    const q = filter.toLowerCase();
+    return u.name.toLowerCase().includes(q) || u.handle.toLowerCase().includes(q);
+  });
+
+  const selected = users?.find((u) => u.handle === selectedHandle) ?? null;
+
+  const handleConfirm = async () => {
+    if (!selected) return;
+    setSubmitting(true);
+    try {
+      await transferOwnership(character.avatar, selected.handle);
+      showToastGlobal(`Transferred ${character.name} to ${selected.name}`, 'success');
+      onTransferred?.();
+      onClose();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Transfer failed';
+      showToastGlobal(msg, 'error');
+      setConfirming(false);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Transfer Ownership" size="sm">
+      <div className="flex flex-col gap-3">
+        <p className="text-sm text-[var(--color-text-secondary)]">
+          Hand <span className="font-semibold text-[var(--color-text-primary)]">{character.name}</span> off
+          to another user. They become the new owner; the character stays global so everyone keeps
+          seeing it.
+        </p>
+
+        {!confirming && (
+          <>
+            <Input
+              type="text"
+              placeholder="Search users…"
+              value={filter}
+              onChange={(e) => setFilter(e.target.value)}
+              autoFocus
+            />
+
+            <div className="max-h-64 overflow-y-auto rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-tertiary)] divide-y divide-[var(--color-border)]">
+              {users === null && (
+                <div className="flex items-center justify-center gap-2 px-3 py-6 text-xs text-[var(--color-text-secondary)]">
+                  <Loader2 size={14} className="animate-spin" />
+                  Loading users…
+                </div>
+              )}
+              {users !== null && filtered.length === 0 && (
+                <p className="px-3 py-6 text-center text-xs text-[var(--color-text-secondary)]">
+                  {loadError ?? (filter ? 'No users match.' : 'No other users on this server.')}
+                </p>
+              )}
+              {filtered.map((u) => {
+                const isSelected = u.handle === selectedHandle;
+                return (
+                  <button
+                    key={u.handle}
+                    type="button"
+                    onClick={() => setSelectedHandle(u.handle)}
+                    className={`w-full flex items-center gap-3 px-3 py-2 text-left transition-colors ${
+                      isSelected
+                        ? 'bg-[var(--color-primary)]/15'
+                        : 'hover:bg-[var(--color-bg-secondary)]'
+                    }`}
+                  >
+                    <UserCircle
+                      size={20}
+                      className={`shrink-0 ${
+                        isSelected
+                          ? 'text-[var(--color-primary)]'
+                          : 'text-[var(--color-text-secondary)]'
+                      }`}
+                    />
+                    <div className="min-w-0 flex-1">
+                      <p className="text-sm font-medium text-[var(--color-text-primary)] truncate">
+                        {u.name}
+                      </p>
+                      <p className="text-xs text-[var(--color-text-secondary)] truncate">
+                        @{u.handle}
+                      </p>
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+
+            <div className="flex justify-end gap-2 pt-1">
+              <Button type="button" variant="ghost" size="sm" onClick={onClose}>
+                Cancel
+              </Button>
+              <Button
+                type="button"
+                variant="primary"
+                size="sm"
+                onClick={() => setConfirming(true)}
+                disabled={!selected}
+              >
+                Continue
+              </Button>
+            </div>
+          </>
+        )}
+
+        {confirming && selected && (
+          <div className="flex flex-col gap-3">
+            <div className="rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-tertiary)] px-3 py-3">
+              <p className="text-sm text-[var(--color-text-primary)]">
+                Transfer <span className="font-semibold">{character.name}</span> to{' '}
+                <span className="font-semibold">{selected.name}</span>{' '}
+                <span className="text-[var(--color-text-secondary)]">(@{selected.handle})</span>?
+              </p>
+              <p className="mt-2 text-xs text-[var(--color-text-secondary)]">
+                You will no longer be able to edit this character. They will see it as theirs on
+                their next refresh.
+              </p>
+            </div>
+            <div className="flex justify-end gap-2">
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => setConfirming(false)}
+                disabled={submitting}
+              >
+                Back
+              </Button>
+              <Button
+                type="button"
+                variant="primary"
+                size="sm"
+                onClick={handleConfirm}
+                disabled={submitting}
+              >
+                {submitting ? <Loader2 size={14} className="animate-spin mr-1.5" /> : null}
+                Confirm Transfer
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/src/stores/characterOwnershipStore.ts
+++ b/src/stores/characterOwnershipStore.ts
@@ -38,6 +38,7 @@ export interface CharacterOwnershipState {
   // Mutations — these hit the server. On success the cache is updated in
   // place; on failure the error field is set and the cache is left alone.
   setVisibility: (avatar: string, visibility: 'global' | 'personal') => Promise<void>;
+  transferOwnership: (avatar: string, newOwnerHandle: string) => Promise<void>;
 
   // Queries — synchronous against the in-memory cache.
   getOwner: (avatar: string) => string | null;
@@ -89,6 +90,19 @@ export const useCharacterOwnershipStore = create<CharacterOwnershipState>((set, 
     } catch (err) {
       set({
         error: err instanceof Error ? err.message : 'Failed to update visibility',
+      });
+      throw err;
+    }
+  },
+
+  transferOwnership: async (avatar, newOwnerHandle) => {
+    set({ error: null });
+    try {
+      await api.transferCharacterOwnership(avatar, newOwnerHandle);
+      await get().fetchOwnership();
+    } catch (err) {
+      set({
+        error: err instanceof Error ? err.message : 'Failed to transfer ownership',
       });
       throw err;
     }


### PR DESCRIPTION
## Summary
Lets the current owner of a global character hand it off to another user from the character editor. Metadata-only on the backend — the PNG stays in \`_global/characters/\`.

- **New "Transfer Ownership" card** in the character editor, only shown when the character is global AND the signed-in user is its current owner.
- **Two-step modal:** search/pick a recipient (loaded from \`/api/users/handles\`), then explicit confirm with clear consequence ("you will no longer be able to edit this character").
- **API client + store:** \`transferCharacterOwnership\`, \`listUserHandles\`, plus a \`transferOwnership\` action that refetches the authoritative ownership map after success.

Pairs with backend PR sammygallo/SillyTavern#23 (\`POST /api/characters/transfer-ownership\`, \`POST /api/users/handles\`).

Personal-character transfer is intentionally out of scope for now.

## Test plan
- [x] \`npm run build\` green locally (matches Dockerfile CI build)
- [x] Manual end-to-end in dev: card appears for owner of global → pick recipient → confirm → metadata flips on the server, editor closes, card disappears on re-open
- [x] Card hidden for non-owners and personal characters
- [x] Backend negative paths return correct status codes

🤖 Generated with [Claude Code](https://claude.com/claude-code)