### PR TITLE
feat: add Enter-key send mode setting

### DIFF
--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -11,6 +11,7 @@ import {
 import { useSpeechRecognition } from '../../hooks/useSpeechRecognition';
 import { haptic } from '../../utils/haptics';
 import { getSpeechLanguage } from '../../hooks/speechLanguage';
+import { getEnterToSendMode } from '../../hooks/displayPreferences';
 
 interface ChatInputProps {
   /** Called with the trimmed text plus any staged image data URLs. */
@@ -327,9 +328,17 @@ export function ChatInput({
         /Android|iPhone|iPad|iPod|Mobile/i.test(navigator.userAgent)));
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' && !e.shiftKey && !isTouchDevice) {
-      e.preventDefault();
-      handleSubmit(e);
+    if (e.key === 'Enter' && !e.shiftKey) {
+      // 'auto' (default): keep prior heuristic — desktop sends, touch devices newline.
+      // 'always': Enter sends on every device. Shift+Enter still inserts a newline.
+      // 'never': Enter always inserts a newline; user must tap the send button.
+      const mode = getEnterToSendMode();
+      const shouldSend =
+        mode === 'always' || (mode === 'auto' && !isTouchDevice);
+      if (shouldSend) {
+        e.preventDefault();
+        handleSubmit(e);
+      }
     }
     if (e.key === 'ArrowUp' && !message.trim() && onEditLast) {
       e.preventDefault();

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -33,8 +33,11 @@ import {
   setVnMode,
   getStandardizeMessageFormatting,
   setStandardizeMessageFormatting,
+  getEnterToSendMode,
+  setEnterToSendMode,
   type ChatLayoutMode,
   type AvatarShape,
+  type EnterToSendMode,
 } from '../../hooks/displayPreferences';
 import {
   THEME_PRESETS,
@@ -82,6 +85,7 @@ export function SettingsPage(_props?: { params?: Record<string, string> }) {
   // Phase 6.4: VN mode
   const [vnModeOn, setVnModeState] = useState<boolean>(() => getVnMode());
   const [standardizeFmt, setStandardizeFmtState] = useState<boolean>(() => getStandardizeMessageFormatting());
+  const [enterToSendMode, setEnterToSendModeState] = useState<EnterToSendMode>(() => getEnterToSendMode());
 
   // Phase 6.3: TTS settings state
   const { isSupported: isTtsSupported, voices: ttsVoices } = useSpeechSynthesis();
@@ -664,6 +668,27 @@ export function SettingsPage(_props?: { params?: Record<string, string> }) {
                     }`}
                   />
                 </button>
+              </div>
+
+              {/* Enter Key Behavior */}
+              <div className="mt-4">
+                <p className="text-xs font-medium text-[var(--color-text-primary)]">Enter Key Sends Message</p>
+                <p className="text-[10px] text-[var(--color-text-secondary)] mt-0.5 mb-2">
+                  Auto: send on desktop, newline on phones/tablets. Always: Enter sends everywhere (Shift+Enter for newline). Never: Enter is always a newline; tap the send button to send.
+                </p>
+                <select
+                  value={enterToSendMode}
+                  onChange={(e) => {
+                    const next = e.target.value as EnterToSendMode;
+                    setEnterToSendModeState(next);
+                    setEnterToSendMode(next);
+                  }}
+                  className="w-full bg-[var(--color-bg-tertiary)] text-[var(--color-text-primary)] text-xs rounded px-2 py-1.5 border border-[var(--color-border)]"
+                >
+                  <option value="auto">Auto (device-aware)</option>
+                  <option value="always">Always send on Enter</option>
+                  <option value="never">Never send on Enter</option>
+                </select>
               </div>
 
               {/* Visual Novel Mode */}

--- a/src/hooks/displayPreferences.ts
+++ b/src/hooks/displayPreferences.ts
@@ -137,6 +137,25 @@ export function setStandardizeMessageFormatting(on: boolean): void {
   try { localStorage.setItem(STANDARDIZE_FMT_KEY, on ? 'true' : 'false'); } catch { /* ignore */ }
 }
 
+// ---- Enter Key Send Behavior ----------------------------------------
+
+export type EnterToSendMode = 'auto' | 'always' | 'never';
+
+const ENTER_TO_SEND_KEY = 'stm:enter-to-send-mode';
+const VALID_ENTER_MODES: EnterToSendMode[] = ['auto', 'always', 'never'];
+
+export function getEnterToSendMode(): EnterToSendMode {
+  try {
+    const v = localStorage.getItem(ENTER_TO_SEND_KEY);
+    if (v && VALID_ENTER_MODES.includes(v as EnterToSendMode)) return v as EnterToSendMode;
+  } catch { /* ignore */ }
+  return 'auto';
+}
+
+export function setEnterToSendMode(mode: EnterToSendMode): void {
+  try { localStorage.setItem(ENTER_TO_SEND_KEY, mode); } catch { /* ignore */ }
+}
+
 // ---- Sprite Costume -------------------------------------------------
 
 export function getCostume(avatar: string): string | null {


### PR DESCRIPTION
## Summary
Closes #138.

- New chat preference **Enter Key Sends Message** with three modes:
  - `auto` (default, current behavior): desktop sends on Enter, touch devices insert a newline
  - `always`: Enter sends on every device (Shift+Enter for newline)
  - `never`: Enter is always a newline; user taps the send button to send
- Persisted in `localStorage` (`stm:enter-to-send-mode`) alongside other chat display prefs
- UI control sits in **Settings → Chat Display** between *Standardize Message Formatting* and *Visual Novel Mode*
- `ChatInput.tsx` reads the mode in its `keydown` handler instead of hard-coding the touch-device heuristic

## Test plan
- [x] Local `npm run build` passes (verified)
- [x] No console errors at preview startup
- [x] localStorage round-trip works for `stm:enter-to-send-mode`
- [ ] Reviewer toggles each mode in Settings and confirms expected Enter behavior on desktop and mobile
- [ ] Edge case: Shift+Enter still inserts a newline in `always` mode
- [ ] Edge case: send button still works in `never` mode

🤖 Draft opened by the build-next-issue skill. Human review required before merge.