### PR TITLE
fix(character): prevent expression upload from closing edit modal

### DIFF
--- a/src/components/ui/ExpressionUpload.tsx
+++ b/src/components/ui/ExpressionUpload.tsx
@@ -178,6 +178,7 @@ export function ExpressionUpload({ characterName, onExpressionsChange }: Express
               />
             </div>
             <Button
+              type="button"
               variant="secondary"
               size="sm"
               onClick={() => newFileInputRef.current?.click()}


### PR DESCRIPTION
## Summary
Closes #167.

- Root cause: the **Add** button in `ExpressionUpload.tsx` had no `type` attribute. Since the component is rendered inside a `<form>` in both `CharacterEdit` and `CharacterCreation`, the default `type=\"submit\"` caused clicks to submit the form, run `handleSubmit`, and call `onClose()` — dismissing the modal as soon as the user tried to upload an expression.
- Fix: explicit `type=\"button\"` on the Add button. One-line change.
- The image-slot click handlers are `<div>` elements (not buttons) so they aren't affected.

The bug reproduces on every browser, but the user reported it on Windows and mobile because that's where they tested expression uploads.

## Test plan
- [x] Local `npm run build` passes
- [ ] Reviewer opens Edit Character → Expression Images, types an emotion name, clicks Add, picks an image — modal stays open and the image appears in the grid
- [ ] Same flow in Create Character
- [ ] Edge case: pressing Enter in the emotion-name field still opens the file picker (existing `e.preventDefault()` on the input still works)

🤖 Draft opened by the build-next-issue skill. Human review required before merge.