### PR TITLE
feat(lorebook): edit persona-linked books, surface character lorebook quick-link

### DIFF
--- a/src/components/character/CharacterEdit.tsx
+++ b/src/components/character/CharacterEdit.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { BookOpen, Download, FileImage, FileJson, Copy, UserCircle, Globe, Lock, Loader2, Wand2, Link2, Unlink, ArrowRightLeft } from 'lucide-react';
 import { useCharacterStore } from '../../stores/characterStore';
 import { useCharacterOwnershipStore } from '../../stores/characterOwnershipStore';
@@ -9,6 +9,7 @@ import { Modal, Button, Input, TextArea, ImageUpload, ExpressionUpload, TagInput
 import { showToastGlobal } from '../ui/Toast';
 import { AlternateGreetingsEditor } from './AlternateGreetingsEditor';
 import { CharacterLorebookSection } from './CharacterLorebookSection';
+import { useWorldInfoStore } from '../../stores/worldInfoStore';
 import { GuideDrawer } from '../guides/GuideDrawer';
 import { LivePortraitSetup } from './LivePortraitSetup';
 import { CharacterSetupWizard } from './CharacterSetupWizard';
@@ -79,6 +80,13 @@ export function CharacterEdit({
     linkedTemplateId ? s.templates.find((t) => t.id === linkedTemplateId) : undefined
   );
   const setLinkedTemplate = usePromptTemplateStore((s) => s.setLinkedTemplate);
+
+  const lorebookSectionRef = useRef<HTMLDivElement>(null);
+  const embeddedBook = useWorldInfoStore((s) =>
+    s.books.find((b) => b.ownerCharacterAvatar === character.avatar)
+  );
+  const hasEmbeddedLorebook = !!embeddedBook;
+  const embeddedEntryCount = embeddedBook?.entries.length ?? 0;
 
   const [avatarFile, setAvatarFile] = useState<File | null>(null);
   const [expressionFiles, setExpressionFiles] = useState<Map<string, File>>(new Map());
@@ -334,6 +342,20 @@ export function CharacterEdit({
             <BookOpen size={16} className="mr-1.5" />
             Building Guide
           </Button>
+          {hasEmbeddedLorebook && (
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              onClick={() => {
+                lorebookSectionRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+              }}
+              title="Jump to this character's lorebook"
+            >
+              <BookOpen size={16} className="mr-1.5" />
+              Lorebook ({embeddedEntryCount})
+            </Button>
+          )}
           <div className="relative">
             <Button
               type="button"
@@ -592,21 +614,23 @@ export function CharacterEdit({
         </div>
 
         {/* Phase 4.3: Character lorebooks */}
-        <div className="flex items-center justify-end -mb-2">
-          <button
-            type="button"
-            onClick={() => openGuide('lorebooks')}
-            className="text-xs text-[var(--color-text-secondary)] hover:text-[var(--color-primary)] inline-flex items-center gap-1"
-          >
-            <BookOpen size={12} /> Lorebook guide
-          </button>
+        <div ref={lorebookSectionRef} className="scroll-mt-16 space-y-2">
+          <div className="flex items-center justify-end -mb-2">
+            <button
+              type="button"
+              onClick={() => openGuide('lorebooks')}
+              className="text-xs text-[var(--color-text-secondary)] hover:text-[var(--color-primary)] inline-flex items-center gap-1"
+            >
+              <BookOpen size={12} /> Lorebook guide
+            </button>
+          </div>
+          <CharacterLorebookSection
+            avatar={character.avatar}
+            characterName={formData.name || character.name}
+            linkedBookIds={linkedBookIds}
+            onLinkedBookIdsChange={setLinkedBookIdsLocal}
+          />
         </div>
-        <CharacterLorebookSection
-          avatar={character.avatar}
-          characterName={formData.name || character.name}
-          linkedBookIds={linkedBookIds}
-          onLinkedBookIdsChange={setLinkedBookIdsLocal}
-        />
 
         {/* Collapsible Advanced Section */}
         <details className="group">

--- a/src/components/persona/PersonaForm.tsx
+++ b/src/components/persona/PersonaForm.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useRef, useState } from 'react';
-import { BookOpen, Upload, User } from 'lucide-react';
+import { BookOpen, Edit2, Upload, User } from 'lucide-react';
 import { usePersonaStore, type PersonaDescriptionPosition, type PersonaDescriptionRole, type Persona } from '../../stores/personaStore';
 import { useWorldInfoStore } from '../../stores/worldInfoStore';
 import { extractCharacterFromPNG, parseCharacterFromJSON } from '../../utils/characterCard';
 import { Button, Input, TextArea, ImageUpload } from '../ui';
+import { WorldInfoBookEditor } from '../worldinfo/WorldInfoBookEditor';
 
 interface PersonaFormProps {
   persona?: Persona | null;
@@ -30,6 +31,7 @@ export function PersonaForm({ persona, onClose, onSaved, initialValues }: Person
   const [linkedBookIds, setLinkedBookIds] = useState<string[]>([]);
   const [importError, setImportError] = useState<string | null>(null);
   const [importNotice, setImportNotice] = useState<string | null>(null);
+  const [editingBookId, setEditingBookId] = useState<string | null>(null);
 
   const personaImportInputRef = useRef<HTMLInputElement>(null);
   const lorebookImportInputRef = useRef<HTMLInputElement>(null);
@@ -390,8 +392,8 @@ export function PersonaForm({ persona, onClose, onSaved, initialValues }: Person
               {candidateBooks.map((book) => {
                 const checked = linkedBookIds.includes(book.id);
                 return (
-                  <li key={book.id}>
-                    <label className="flex items-center gap-2.5 cursor-pointer rounded-md px-1.5 py-1 hover:bg-[var(--color-bg-secondary)]">
+                  <li key={book.id} className="flex items-center gap-1">
+                    <label className="flex-1 flex items-center gap-2.5 cursor-pointer rounded-md px-1.5 py-1 hover:bg-[var(--color-bg-secondary)] min-w-0">
                       <input
                         type="checkbox"
                         checked={checked}
@@ -411,6 +413,16 @@ export function PersonaForm({ persona, onClose, onSaved, initialValues }: Person
                         {book.entries.length}
                       </span>
                     </label>
+                    <button
+                      type="button"
+                      onClick={() => setEditingBookId(book.id)}
+                      className="shrink-0 flex items-center gap-1 px-2 py-1 rounded-md text-xs text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-secondary)]"
+                      aria-label={`Edit ${book.name}`}
+                      title="Edit lorebook entries"
+                    >
+                      <Edit2 size={12} />
+                      Edit
+                    </button>
                   </li>
                 );
               })}
@@ -435,6 +447,17 @@ export function PersonaForm({ persona, onClose, onSaved, initialValues }: Person
           {persona ? 'Save Changes' : 'Create Persona'}
         </Button>
       </div>
+
+      {editingBookId && (() => {
+        const editing = books.find((b) => b.id === editingBookId);
+        return editing ? (
+          <WorldInfoBookEditor
+            isOpen={true}
+            onClose={() => setEditingBookId(null)}
+            book={editing}
+          />
+        ) : null;
+      })()}
     </form>
   );
 }


### PR DESCRIPTION
## Summary
Closes #170.
Closes #171.

Two related lorebook discoverability/editability fixes from the same user, bundled into one PR since they touch the same surface area.

### #170 — Persona-linked lorebooks were view-only

`PersonaForm` rendered each linked book as a checkbox row with the entry count, but there was no way to open the entries. So a user who imported a persona with an attached lorebook had no way to edit it.

- Added an **Edit** button beside each book row in PersonaForm (matches the `CharacterLorebookSection` pattern).
- Clicking it opens `WorldInfoBookEditor` inline so the user can edit entries without leaving the persona dialog.

### #171 — Character lorebook section was hard to find

The lorebook section lives ~600 lines into the CharacterEdit form, after avatar / description / scenario / expressions / live portrait. Users with an embedded lorebook didn't realize where to scroll.

- Added a **Lorebook (N)** button to the Character Actions strip at the top of the CharacterEdit modal — only renders when the character actually has an embedded book.
- Click smooth-scrolls to the lorebook section (which already has the existing Edit button to open the entries editor).
- Did not change discoverability for characters without an embedded lorebook (no surface action needed).

## Test plan
- [x] Local `npm run build` passes
- [ ] Reviewer opens **Persona** with a linked lorebook → clicks Edit → entries editor opens; saving writes back; closing returns to persona form
- [ ] Reviewer opens a character that has an embedded lorebook → top "Lorebook (N)" button is visible → click smooth-scrolls to the section
- [ ] Reviewer opens a character WITHOUT an embedded lorebook → top button is hidden (regression check)

🤖 Draft opened by the build-next-issue skill (bundled at user request). Human review required before merge.