### PR TITLE
fix(persona): reset manager state, allow deselect, scope persona lorebook entries

### DIFF
--- a/src/components/persona/PersonaManager.tsx
+++ b/src/components/persona/PersonaManager.tsx
@@ -38,6 +38,15 @@ export function PersonaManager({ isOpen, onClose, initialPersona }: PersonaManag
     setIsCreating(false);
   };
 
+  // Reset internal form state whenever the manager modal is closed, so
+  // reopening it always lands on the persona list — not stale form contents
+  // from a previous edit session that the user dismissed via the X button.
+  const handleManagerClose = () => {
+    setEditingPersona(null);
+    setIsCreating(false);
+    onClose();
+  };
+
   const handleDelete = (persona: Persona) => {
     setConfirmDelete(persona);
   };
@@ -57,7 +66,7 @@ export function PersonaManager({ isOpen, onClose, initialPersona }: PersonaManag
 
   return (
     <>
-      <Modal isOpen={isOpen} onClose={onClose} title={title} size="lg">
+      <Modal isOpen={isOpen} onClose={handleManagerClose} title={title} size="lg">
         {isCreating ? (
           <PersonaForm
             persona={editingPersona}

--- a/src/components/persona/PersonaSelector.tsx
+++ b/src/components/persona/PersonaSelector.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
-import { User, ChevronDown, Check, Plus, Settings } from 'lucide-react';
+import { User, ChevronDown, Check, Plus, Settings, X } from 'lucide-react';
 import { usePersonaStore } from '../../stores/personaStore';
 import { PersonaManager } from './PersonaManager';
 
@@ -33,7 +33,7 @@ export function PersonaSelector({ className = '' }: PersonaSelectorProps) {
     setShowManager(true);
   };
 
-  const handleSelect = (id: string) => {
+  const handleSelect = (id: string | null) => {
     setActivePersona(id);
     setIsOpen(false);
   };
@@ -118,6 +118,15 @@ export function PersonaSelector({ className = '' }: PersonaSelectorProps) {
             )}
 
             <div className="border-t border-[var(--color-border)]">
+              {activePersonaId && (
+                <button
+                  onClick={() => handleSelect(null)}
+                  className="w-full flex items-center gap-2 px-3 py-2 text-xs text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-tertiary)] border-b border-[var(--color-border)]"
+                >
+                  <X size={14} />
+                  Clear active persona
+                </button>
+              )}
               <button
                 onClick={handleManage}
                 className="w-full flex items-center gap-2 px-3 py-2 text-xs text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-tertiary)]"

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -750,9 +750,23 @@ function buildConversationContext(
   for (const m of matchedEntries) {
     wiByPosition[m.entry.position].push(m);
   }
+  // Persona-linked book ids — entries from these books describe the USER, not
+  // the bot. Without a label the model often absorbs them as bot identity
+  // (e.g. "the bot now thinks it IS the persona"). Prefixing each persona
+  // entry with a user-context tag keeps the source semantically scoped.
+  const personaBookIdSet = new Set(personaBookIds);
+  const wrapWiContent = (m: MatchedEntry): string => {
+    const content = sub(m.entry.content);
+    if (!content.trim()) return '';
+    if (personaBookIdSet.has(m.bookId)) {
+      const subject = personaName || 'the user';
+      return `[Information about ${subject}, the user you're talking to]\n${content}`;
+    }
+    return content;
+  };
   const joinWi = (list: MatchedEntry[]): string =>
     list
-      .map((m) => sub(m.entry.content))
+      .map(wrapWiContent)
       .filter((c) => c.trim().length > 0)
       .join('\n\n');
 


### PR DESCRIPTION
## Summary
Closes #172.
Closes #174.

Two persona bugs from the same user, bundled at user request.

### #172 — New Persona dialog showed "Edit <last persona>"

`PersonaManager` kept `isCreating` and `editingPersona` in component state. Closing the modal via the X button (instead of an in-form Cancel) didn't reset that state, so the next open landed on the old form contents. Wrapping `onClose` resets both flags before delegating to the parent.

### #174 — Persona issues (two parts)

1. **Couldn't unselect persona.** Dropdown only allowed switching personas or creating new ones. Added a **Clear active persona** entry to the selector that calls `setActivePersona(null)`, visible only when a persona is currently active.

2. **Persona lorebook entries leaked into bot identity.** Persona-linked WI entries were injected raw into the prompt at the same positions as character/global entries, so the model routinely absorbed user-describing content ("Mina literally thinks she is my persona"). Persona-sourced matches are now wrapped with `[Information about <persona>, the user you're talking to]` before being concatenated. Detection uses the existing `MatchedEntry.bookId` against the active persona's `linkedBookIds`.

## Files
- `src/components/persona/PersonaManager.tsx` — reset state on close
- `src/components/persona/PersonaSelector.tsx` — Clear active persona option
- `src/stores/chatStore.ts` — wrap persona-sourced WI entries

## Test plan
- [x] Local `npm run build` passes
- [ ] Reviewer edits a persona, closes the manager via X, reopens, clicks New Persona — form is blank and titled "Create Persona" (not "Edit X")
- [ ] Reviewer with an active persona opens the selector and clicks "Clear active persona" → no persona is active afterwards
- [ ] Reviewer with a persona-linked lorebook chats with a character, observes that persona WI entries are clearly framed as user info (model no longer mirrors persona identity)
- [ ] Reviewer without a persona-linked book sees no behavior change in WI injection

🤖 Draft opened by the build-next-issue skill (bundled at user request). Human review required before merge.