### PR TITLE
fix(chat): drop empty dialogue segments between italic RP markers

### DIFF
--- a/src/components/chat/MarkdownContent.tsx
+++ b/src/components/chat/MarkdownContent.tsx
@@ -205,6 +205,16 @@ export function MarkdownContent({ content, isUser, isStreaming }: MarkdownConten
       {segments.map((segment, index) => {
         const isLast = index === segments.length - 1;
 
+        // Skip dialogue segments that are only whitespace (typically the
+        // "\n\n" gap between two adjacent italic RP segments). Without this
+        // they render as an empty block <div><p></p></div> that adds a
+        // visible blank line between the two italics. RP-marker segments
+        // always render so we never accidentally drop user-meaningful
+        // content.
+        if (segment.type === 'dialogue' && !segment.content.trim()) {
+          return null;
+        }
+
         if (segment.type === 'action') {
           return (
             <span


### PR DESCRIPTION
## Summary
Closes #173.

When a bot message places paragraph breaks between adjacent italic RP segments — e.g.

```
*She paused.*

*Her eyes narrowed.*
```

`parseRPSegments` produces three segments: `action`, then a `dialogue` segment containing only `\n\n`, then another `action`. The whitespace-only dialogue trips the block-pattern heuristic (because of `\n\n`) and renders as `<div class=\"md-segment\"><p></p></div>` — an empty block element that adds a visible blank line between the two italics. That's the "big gap" the user reported.

Fix: skip rendering dialogue segments whose `.content.trim()` is empty. RP-marker segments (`action` / `thought`) always render so we never accidentally drop user-meaningful content; non-empty dialogue still renders unchanged.

## Test plan
- [x] Local `npm run build` passes
- [ ] Reviewer chats with a bot that emits adjacent italics separated by paragraph breaks — there's no longer a blank line between them
- [ ] Regression check: ordinary multi-paragraph messages still render with proper spacing
- [ ] Regression check: a single-segment message with leading/trailing whitespace still renders normally

🤖 Draft opened by the build-next-issue skill. Human review required before merge.