### PR TITLE
fix(chat): make rename actually rename the file

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -735,12 +735,18 @@ export const api = {
   },
 
   async renameChat(avatarUrl: string, originalFile: string, renamedFile: string): Promise<string> {
+    // Upstream /api/chats/rename does not auto-append the extension the way
+    // /delete does, so it fails with "Source file not available" when the
+    // client passes the bare basename (which is what we list everywhere
+    // else). Append .jsonl client-side until the server is patched.
+    const withExt = (name: string): string =>
+      /\.jsonl$/i.test(name) ? name : `${name}.jsonl`;
     const result = await apiRequest<{ ok: boolean; sanitizedFileName: string }>('/api/chats/rename', {
       method: 'POST',
       body: JSON.stringify({
         avatar_url: avatarUrl,
-        original_file: originalFile,
-        renamed_file: renamedFile,
+        original_file: withExt(originalFile),
+        renamed_file: withExt(renamedFile),
       }),
     });
     return result.sanitizedFileName;

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -2369,8 +2369,14 @@ export const useChatStore = create<ChatState>((set, get) => ({
   // ---- Rename Chat File ----
   renameChat: async (avatarUrl: string, originalFile: string, renamedFile: string) => {
     try {
-      await api.renameChat(avatarUrl, originalFile, renamedFile);
-      const { fetchChatFiles } = get();
+      const sanitized = await api.renameChat(avatarUrl, originalFile, renamedFile);
+      // If the renamed chat is the one currently loaded, update the
+      // in-memory pointer so subsequent saves target the new filename
+      // instead of the (now non-existent) original file.
+      const { currentChatFile, fetchChatFiles } = get();
+      if (currentChatFile === originalFile) {
+        set({ currentChatFile: sanitized });
+      }
       await fetchChatFiles(avatarUrl);
     } catch (error) {
       set({ error: error instanceof Error ? error.message : 'Failed to rename chat' });


### PR DESCRIPTION
## Summary
Closes #175.

Renaming a chat from the chat history panel was a no-op. Two problems:

### 1. Server rejects the request
Upstream SillyTavern's `/api/chats/rename` calls `fs.existsSync` directly on the basename the client sends:

```js
const pathToOriginalFile = path.join(pathToFolder, sanitize(request.body.original_file));
if (!fs.existsSync(pathToOriginalFile) || ...) { return 400; }
```

…but the client lists / sends chat filenames without the `.jsonl` extension everywhere else (because `/delete` and `/save` auto-append it server-side). So `existsSync('MyChat')` is false even though `MyChat.jsonl` is on disk. Rename fails silently from the user's POV.

The proper fix is on the SillyTavern side, mirroring `/delete`'s `if (!path.extname(...)) chatfile += '.jsonl'`. We don't own that repo from this PR, so the client-side workaround appends `.jsonl` before sending. The check is idempotent — if the input already has `.jsonl` (defensive against future server fixes) it isn't doubled.

### 2. currentChatFile pointer goes stale
Even when the rename succeeded, if the user renamed the chat they were currently viewing, the in-memory `currentChatFile` still pointed to the old name. The next message save would try to write to the now-deleted file. Fix: update `currentChatFile` from the sanitized name returned by the server when it matches the renamed file.

## Test plan
- [x] Local `npm run build` passes
- [ ] Reviewer renames a chat from history panel → list refreshes with the new name and the file on disk reflects it
- [ ] Reviewer renames the *currently loaded* chat → can continue chatting and the next message persists to the renamed file
- [ ] Reviewer attempts to rename to an existing chat name → server still 400s (existing behavior preserved)

## Follow-up
The proper fix is in upstream SillyTavern's `/api/chats/rename`. Worth filing an upstream issue/PR — listed in test plan as a future TODO if the team wants to remove the client workaround.

🤖 Draft opened by the build-next-issue skill. Human review required before merge.