### PR TITLE
fix(theme-editor): rainbow effects toggle thumb rendering

### DIFF
--- a/src/components/settings/ThemeEditorPage.tsx
+++ b/src/components/settings/ThemeEditorPage.tsx
@@ -248,13 +248,13 @@ export function ThemeEditorPage({ params: pageParams }: { params?: Record<string
             role="switch"
             aria-checked={rainbowEffects}
             onClick={() => setRainbowEffectsState(v => !v)}
-            className={`shrink-0 w-10 h-6 rounded-full transition-colors relative ${
+            className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors flex-shrink-0 ${
               rainbowEffects ? 'bg-[var(--color-primary)]' : 'bg-[var(--color-bg-tertiary)]'
             }`}
           >
             <span
-              className={`absolute top-0.5 w-5 h-5 rounded-full bg-white transition-transform ${
-                rainbowEffects ? 'translate-x-[1.125rem]' : 'translate-x-0.5'
+              className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                rainbowEffects ? 'translate-x-6' : 'translate-x-1'
               }`}
             />
           </button>


### PR DESCRIPTION
## Summary

The Rainbow Effects switch in the Theme Editor rendered with the white thumb escaping the right edge of the track and the track itself stretched horizontally (see screenshot below).

Root cause: the thumb was positioned with `absolute top-0.5` but never set `left-0`, so its static origin depended on the button's layout context and the translate-x landed outside the visible track.

Fix: swap to the `inline-flex items-center` + `inline-block` thumb pattern that every other toggle in `SettingsPage` already uses (Standardize Formatting, VN Mode). One-line class change to the button + thumb.

## Test plan

- [x] Local `npm run build` passes
- [ ] Reviewer opens **Settings → Theme Editor → custom theme** → confirms the Rainbow Effects toggle now renders with the thumb sitting cleanly inside the track in both on/off states (matches the other toggles in the app)

🤖 Drafted as a standalone follow-up after a UI bug surfaced during review of the recent sprint.