### PR TITLE
fix(chat): keep italics inline by splitting paragraphs before RP parsing

### DIFF
--- a/src/components/chat/MarkdownContent.tsx
+++ b/src/components/chat/MarkdownContent.tsx
@@ -155,6 +155,36 @@ const SANITIZE_CONFIG = {
 const BLOCK_PATTERN = /\n\n|^#{1,6}\s|^```|^>\s|^[-*+]\s|^\d+\.\s|^\|.+\|/m;
 
 /**
+ * Split text into paragraphs on `\n\n` boundaries while keeping fenced code
+ * blocks intact (a fenced block can legitimately contain blank lines and
+ * must NOT be split). Returns one entry per paragraph, in order; empty
+ * paragraphs are dropped.
+ *
+ * Splitting first — then parsing RP markers inside each paragraph — is what
+ * keeps inline italics anchored to their paragraph instead of appearing as
+ * orphan inline content sandwiched between two block-level dialogue
+ * segments.
+ */
+function splitParagraphs(text: string): string[] {
+  const codePH: Map<string, string> = new Map();
+  let n = 0;
+  // Shelter fenced code blocks (only these can contain \n\n we must preserve).
+  const safe = text.replace(/```[\s\S]*?```/g, (m) => {
+    const k = `\x00P${n++}\x00`;
+    codePH.set(k, m);
+    return k;
+  });
+  const paragraphs = safe.split(/\n{2,}/);
+  return paragraphs
+    .map((p) => {
+      let restored = p;
+      for (const [k, v] of codePH) restored = restored.replaceAll(k, v);
+      return restored;
+    })
+    .filter((p) => p.trim().length > 0);
+}
+
+/**
  * Close any unclosed fenced code blocks so the markdown parser treats them as
  * code instead of leaking raw backticks into the output.  Only needed while
  * streaming — once the response is complete the fences are balanced.
@@ -186,7 +216,7 @@ export function MarkdownContent({ content, isUser, isStreaming }: MarkdownConten
     () => (standardize ? normalizeForDisplay(content) : content),
     [content, standardize]
   );
-  const segments = useMemo(() => parseRPSegments(prepared), [prepared]);
+  const paragraphs = useMemo(() => splitParagraphs(prepared), [prepared]);
 
   /** Copy-button click handler — uses event delegation. */
   const handleClick = useCallback((e: React.MouseEvent) => {
@@ -202,57 +232,81 @@ export function MarkdownContent({ content, isUser, isStreaming }: MarkdownConten
 
   return (
     <div className="markdown-content" onClick={handleClick}>
-      {segments.map((segment, index) => {
-        const isLast = index === segments.length - 1;
+      {paragraphs.map((paragraph, paraIdx) => {
+        const isLastPara = paraIdx === paragraphs.length - 1;
+        const paraIsBlockMarkdown = BLOCK_PATTERN.test(paragraph);
 
-        // Skip dialogue segments that are only whitespace (typically the
-        // "\n\n" gap between two adjacent italic RP segments). Without this
-        // they render as an empty block <div><p></p></div> that adds a
-        // visible blank line between the two italics. RP-marker segments
-        // always render so we never accidentally drop user-meaningful
-        // content.
-        if (segment.type === 'dialogue' && !segment.content.trim()) {
-          return null;
-        }
-
-        if (segment.type === 'action') {
+        // Block-level markdown paragraphs (lists, headings, blockquotes,
+        // code blocks, tables) bypass the RP parser — those structures and
+        // *italic* markers don't compose well, and the RP regex can grab
+        // list-bullet asterisks unintentionally.
+        if (paraIsBlockMarkdown) {
+          const dialogueContent = standardize ? wrapDialogue(paragraph) : paragraph;
+          const { html } = renderMarkdown(dialogueContent, isStreaming && isLastPara);
+          const cursorHtml = isStreaming && isLastPara
+            ? html + '<span class="streaming-cursor"></span>'
+            : html;
           return (
-            <span
-              key={index}
-              className={`italic ${isUser ? 'text-white/70' : 'rp-action'}`}
-            >
-              {segment.content}
-              {isStreaming && isLast && <span className="streaming-cursor" />}
-            </span>
-          );
-        }
-        if (segment.type === 'thought') {
-          return (
-            <span
-              key={index}
-              className={`italic ${isUser ? 'text-white/60' : 'rp-thought'}`}
-            >
-              {segment.content}
-              {isStreaming && isLast && <span className="streaming-cursor" />}
-            </span>
+            <div
+              key={paraIdx}
+              className="md-paragraph md-segment"
+              dangerouslySetInnerHTML={{ __html: cursorHtml }}
+            />
           );
         }
 
-        // Dialogue → markdown. When standardization is on, wrap "…" in
-        // <span class="dialogue"> before marked parses so themes can style
-        // quoted speech distinctly.
-        const dialogueContent = standardize ? wrapDialogue(segment.content) : segment.content;
-        const { html, isBlock } = renderMarkdown(dialogueContent, isStreaming && isLast);
-        const cursorHtml = isStreaming && isLast
-          ? html + '<span class="streaming-cursor"></span>'
-          : html;
-        const Tag = isBlock ? 'div' : 'span';
+        // Inline paragraph: parse RP markers, render each segment inline so
+        // surrounding dialogue, *actions*, and {{thoughts}} all flow on the
+        // same line(s) within this paragraph.
+        const segments = parseRPSegments(paragraph);
         return (
-          <Tag
-            key={index}
-            className="md-segment"
-            dangerouslySetInnerHTML={{ __html: cursorHtml }}
-          />
+          <div key={paraIdx} className="md-paragraph">
+            {segments.map((segment, segIdx) => {
+              const isLastSeg = isLastPara && segIdx === segments.length - 1;
+
+              if (segment.type === 'dialogue' && !segment.content.trim()) {
+                return null;
+              }
+
+              if (segment.type === 'action') {
+                return (
+                  <span
+                    key={segIdx}
+                    className={`italic ${isUser ? 'text-white/70' : 'rp-action'}`}
+                  >
+                    {segment.content}
+                    {isStreaming && isLastSeg && <span className="streaming-cursor" />}
+                  </span>
+                );
+              }
+              if (segment.type === 'thought') {
+                return (
+                  <span
+                    key={segIdx}
+                    className={`italic ${isUser ? 'text-white/60' : 'rp-thought'}`}
+                  >
+                    {segment.content}
+                    {isStreaming && isLastSeg && <span className="streaming-cursor" />}
+                  </span>
+                );
+              }
+
+              // Dialogue inside an inline paragraph — render via parseInline
+              // (no block-level parsing since we already filtered those out).
+              const dialogueContent = standardize ? wrapDialogue(segment.content) : segment.content;
+              const { html } = renderMarkdown(dialogueContent, isStreaming && isLastSeg);
+              const cursorHtml = isStreaming && isLastSeg
+                ? html + '<span class="streaming-cursor"></span>'
+                : html;
+              return (
+                <span
+                  key={segIdx}
+                  className="md-segment"
+                  dangerouslySetInnerHTML={{ __html: cursorHtml }}
+                />
+              );
+            })}
+          </div>
         );
       })}
     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -72,6 +72,12 @@ body {
 .markdown-content .md-segment p + p {
   margin-top: 0.5em;
 }
+/* Inter-paragraph spacing for the per-paragraph wrappers emitted by
+   MarkdownContent. Each visual paragraph is its own .md-paragraph div so
+   inline italics stay anchored to the right paragraph. */
+.markdown-content .md-paragraph + .md-paragraph {
+  margin-top: 0.5em;
+}
 
 /* --- Headers ------------------------------------------------------ */
 .markdown-content .md-segment h1,


### PR DESCRIPTION
## Summary

Follow-up to #181 — that PR fixed the empty-dialogue-between-italics case. This one fixes the related but distinct case the user surfaced post-deploy: italics in the middle of a paragraph being yanked onto their own line.

### What the user saw

A bot response like:

> "You literally walked into a lawnmower. On *purpose*. For a *bet*." She glanced sideways…

…rendered as:

```
"You literally walked into a lawnmower. On
*purpose*. For a *bet*
." She glanced sideways…
```

The italic phrase was pulled out onto its own line, with the surrounding sentence broken in three.

### Root cause

`parseRPSegments` ran on the full message text. The dialogue segment before the FIRST italic in paragraph N included all of paragraphs 1..N-1 plus the start of paragraph N (with `\n\n` glue). That dialogue segment matched `BLOCK_PATTERN` (because of the `\n\n`) and rendered as a `<div>` via `marked.parse`. The italic spans were now sandwiched between two block `<div>`s — block-flow layout forced them onto their own line.

### Fix

Split the message on `\n\n` FIRST (sheltering fenced code blocks so they aren't broken), then parse RP markers within each paragraph. Each paragraph renders as its own `<div class=\"md-paragraph\">` containing inline children. Italics now flow inline with the dialogue around them.

Block-level markdown paragraphs (lists, headings, blockquotes, code, tables) skip the RP parser entirely — that prevents the regex from grabbing list-bullet asterisks and matches the prior block-rendering path.

### Trade-off

Italics that span a `\n\n` paragraph break (e.g. `*This\n\nspans paragraphs*`) will no longer be detected — both asterisks render literally. This is rare in practice; bots typically use italics for inline actions (`*she smiled*`) rather than multi-paragraph descriptive italics. The common-case win (italics flowing inline) is worth the regression.

## Files

- `src/components/chat/MarkdownContent.tsx` — new `splitParagraphs` helper, restructured render to per-paragraph
- `src/index.css` — `.md-paragraph + .md-paragraph` inter-paragraph spacing rule

## Test plan

- [x] Local `npm run build` passes
- [x] No console errors at preview load
- [ ] Reviewer checks the original problem message — italics flow inline within their paragraph instead of being orphaned on their own line
- [ ] Reviewer verifies multi-paragraph bot messages still have visible spacing between paragraphs (the new `.md-paragraph + .md-paragraph` margin)
- [ ] Reviewer verifies block markdown (lists, headings, code blocks) still renders correctly inside bot messages
- [ ] Streaming cursor still appears at the end of the latest token while a message streams in

🤖 Drafted as a follow-up to the just-deployed sprint.