### PR TITLE
fix(character): allow non-Latin1 characters in PNG export

### DIFF
--- a/src/utils/characterCard.ts
+++ b/src/utils/characterCard.ts
@@ -433,10 +433,18 @@ export async function embedCharacterInPNG(
     }
   }
 
-  // Convert character to V2 card and encode as base64
+  // Convert character to V2 card and encode as base64. Mirror the decode
+  // path: encode the JSON to UTF-8 bytes first, then base64. Raw btoa()
+  // throws on any character above U+00FF (em-dashes, smart quotes, emoji,
+  // CJK), which is exactly what real character cards contain.
   const cardData = characterToCardV2(character, characterBook);
   const jsonString = JSON.stringify(cardData);
-  const base64Data = btoa(jsonString);
+  const utf8Bytes = new TextEncoder().encode(jsonString);
+  let binary = '';
+  for (let i = 0; i < utf8Bytes.length; i++) {
+    binary += String.fromCharCode(utf8Bytes[i]);
+  }
+  const base64Data = btoa(binary);
 
   // Create the tEXt chunk
   const textChunk = createTextChunk('chara', base64Data);


### PR DESCRIPTION
## Summary

User report: exporting a character to PNG fails with

> Failed to execute 'btoa' on 'Window': The string to be encoded contains characters outside of the Latin1 range.

`btoa()` only accepts code points 0–255. Any em-dash, smart quote, emoji, accented character, or CJK in the card JSON crashes the export. Real character cards routinely contain these — Lady Gleannloch's description above had an em-dash and that was enough.

## Fix

The **decode** side of this file (line 350) already handled Unicode correctly via `TextDecoder('utf-8')`. The **encode** side was raw `btoa(jsonString)`. Mirroring the decode pattern: encode JSON to UTF-8 bytes first via `TextEncoder`, then base64.

```ts
const utf8Bytes = new TextEncoder().encode(jsonString);
let binary = '';
for (let i = 0; i < utf8Bytes.length; i++) {
  binary += String.fromCharCode(utf8Bytes[i]);
}
const base64Data = btoa(binary);
```

A `for` loop instead of `String.fromCharCode(...utf8Bytes)` to stay safe on large card payloads (the spread can blow the call stack on big arrays).

## Verification

- [x] Local `npm run build` passes
- [x] Round-trip test in preview: encoded a payload containing em-dash, smart quote, CJK (`美しい`), and emoji (`😎`) → base64 → decoded via the existing import path → byte-for-byte identical to the original.
- [x] Confirmed raw `btoa(jsonString)` reproduces the user's exact error string.
- [ ] Reviewer exports a character whose description has Unicode → PNG downloads → re-import the same PNG → fields preserved.

🤖 Hotfix opened from a user report.