### PR TITLE
feat: add no-fallback toggle to expressions extension

### DIFF
--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -22,6 +22,7 @@ import { TypingIndicator } from './TypingIndicator';
 import { ImageGenModal } from './ImageGenModal';
 import { QuickReplyBar } from './QuickReplyBar';
 import { useExtensionStore } from '../../stores/extensionStore';
+import { useExpressionsStore } from '../../stores/expressionsStore';
 import { useIsMobile } from '../../hooks/useIsMobile';
 import { useOrientation } from '../../hooks/useOrientation';
 import { useKeyboardHeight } from '../../hooks/useKeyboardHeight';
@@ -218,12 +219,37 @@ export function ChatView() {
   const highlightTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const { getSpritePath, availableEmotions } = useCharacterSprites(selectedCharacter?.avatar, activeCostume);
+  const noExpressionFallback = useExpressionsStore((s) => s.noFallback);
 
   const latestEmotion = useMemo(() => {
     const characterMessages = messages.filter((m) => !m.isUser && !m.isSystem);
     if (characterMessages.length === 0) return null;
     return characterMessages[characterMessages.length - 1].emotion ?? null;
   }, [messages]);
+
+  // When the "no fallback" toggle is on and a sprite is missing, walk back
+  // through the chat to find the most recent emotion whose sprite still
+  // resolves — so the previous expression sticks instead of snapping to the
+  // default avatar. Returns the resolved sprite URL, or null if none found.
+  const findPreviousValidSpritePath = useCallback(
+    (avatar: string): string | null => {
+      for (let i = messages.length - 1; i >= 0; i--) {
+        const m = messages[i];
+        if (m.isUser || m.isSystem || !m.emotion) continue;
+        const msgAvatar = isGroupChatMode && m.characterAvatar
+          ? m.characterAvatar
+          : selectedCharacter?.avatar;
+        if (msgAvatar !== avatar) continue;
+        const key = `${avatar}-${m.emotion}`;
+        if (failedExpressions.has(key)) continue;
+        const mapped = mapEmotionToAvailable(m.emotion, availableEmotions);
+        const path = getSpritePath(mapped || m.emotion);
+        if (path) return path;
+      }
+      return null;
+    },
+    [messages, failedExpressions, availableEmotions, getSpritePath, isGroupChatMode, selectedCharacter?.avatar]
+  );
 
   const livePortraitEnabled = useLivePortraitStore((s) => s.enabled);
   const livePortraitClips = useLivePortraitStore((s) =>
@@ -383,24 +409,29 @@ export function ChatView() {
           if (spritePath) return spritePath;
         }
       }
+      if (noExpressionFallback) {
+        const prev = findPreviousValidSpritePath(avatar);
+        if (prev) return prev;
+      }
       return getExpressionThumbnailUrl(avatar, null);
     },
-    [getSpritePath, failedExpressions, availableEmotions]
+    [getSpritePath, failedExpressions, availableEmotions, noExpressionFallback, findPreviousValidSpritePath]
   );
 
   const getFullImageUrl = useCallback(
     (avatar: string, emotion?: Emotion | null) => {
       const expressionKey = `${avatar}-${emotion}`;
-      if (emotion && failedExpressions.has(expressionKey)) {
-        return getDefaultAvatarUrl(avatar);
-      }
-      if (emotion) {
+      if (emotion && !failedExpressions.has(expressionKey)) {
         const spritePath = getSpritePath(emotion);
         if (spritePath) return spritePath;
       }
+      if (noExpressionFallback) {
+        const prev = findPreviousValidSpritePath(avatar);
+        if (prev) return prev;
+      }
       return getDefaultAvatarUrl(avatar);
     },
-    [getSpritePath, failedExpressions]
+    [getSpritePath, failedExpressions, noExpressionFallback, findPreviousValidSpritePath]
   );
 
   // Phase 9.1: focus the search input when the bar opens

--- a/src/extensions/builtins/expressions.tsx
+++ b/src/extensions/builtins/expressions.tsx
@@ -1,0 +1,53 @@
+import { Smile } from 'lucide-react';
+import { extensionRegistry } from '../registry';
+import { useExpressionsStore } from '../../stores/expressionsStore';
+import type { ExtensionManifest } from '../types';
+
+function ExpressionsSettings() {
+  const noFallback = useExpressionsStore((s) => s.noFallback);
+  const setNoFallback = useExpressionsStore((s) => s.setNoFallback);
+
+  const labelClass =
+    'flex items-start justify-between gap-3 text-xs text-[var(--color-text-secondary)]';
+
+  return (
+    <div className="space-y-3">
+      <div className={labelClass}>
+        <span className="flex-1">
+          No fallback
+          <span className="block text-[10px] text-[var(--color-text-secondary)]/60 mt-0.5">
+            When a matching expression sprite isn't available, keep showing the previous expression instead of switching to the default avatar.
+          </span>
+        </span>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={noFallback}
+          onClick={() => setNoFallback(!noFallback)}
+          className={`relative w-9 h-5 rounded-full transition-colors flex-shrink-0 ${
+            noFallback ? 'bg-[var(--color-primary)]' : 'bg-[var(--color-bg-tertiary)]'
+          }`}
+        >
+          <span
+            className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform ${
+              noFallback ? 'translate-x-4' : 'translate-x-0'
+            }`}
+          />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+const manifest: ExtensionManifest = {
+  id: 'expressions',
+  displayName: 'Expressions',
+  description:
+    'Show character expression sprites in chat based on detected emotion. Configure how missing expressions are handled.',
+  version: '1.0.0',
+  icon: Smile,
+  defaultEnabled: true,
+  settingsPanel: ExpressionsSettings,
+};
+
+extensionRegistry.register(manifest);

--- a/src/extensions/index.ts
+++ b/src/extensions/index.ts
@@ -5,6 +5,7 @@ import './builtins/imageGen';
 import './builtins/translate';
 import './builtins/summarize';
 import './builtins/autoMemory';
+import './builtins/expressions';
 
 // Re-export for external consumption.
 export { extensionRegistry } from './registry';

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -10,6 +10,7 @@ import { useSummarizeStore } from './summarizeStore';
 import { useAutoMemoryStore } from './autoMemoryStore';
 import { useTranslateStore } from './translateStore';
 import { useQuickReplyStore } from './quickReplyStore';
+import { useExpressionsStore } from './expressionsStore';
 import type { UserRole, Permission } from '../types';
 
 interface CurrentUser {
@@ -60,6 +61,7 @@ export const useAuthStore = create<AuthState>((set) => ({
         useAutoMemoryStore.getState().initForUser(user.handle);
         useTranslateStore.getState().initForUser(user.handle);
         useQuickReplyStore.getState().initForUser(user.handle);
+        useExpressionsStore.getState().initForUser(user.handle);
         set({
           isAuthenticated: true,
           currentUser: {
@@ -111,6 +113,7 @@ export const useAuthStore = create<AuthState>((set) => ({
       useAutoMemoryStore.getState().initForUser(loginResult.handle);
       useTranslateStore.getState().initForUser(loginResult.handle);
       useQuickReplyStore.getState().initForUser(loginResult.handle);
+      useExpressionsStore.getState().initForUser(loginResult.handle);
       set({
         isAuthenticated: true,
         currentUser: { handle: loginResult.handle, name, role: 'end_user' },
@@ -139,6 +142,7 @@ export const useAuthStore = create<AuthState>((set) => ({
       useAutoMemoryStore.getState().initForUser(h);
       useTranslateStore.getState().initForUser(h);
       useQuickReplyStore.getState().initForUser(h);
+      useExpressionsStore.getState().initForUser(h);
       set({
         isAuthenticated: true,
         currentUser: user
@@ -208,6 +212,7 @@ export const useAuthStore = create<AuthState>((set) => ({
       useAutoMemoryStore.getState().resetUser();
       useTranslateStore.getState().resetUser();
       useQuickReplyStore.getState().resetUser();
+      useExpressionsStore.getState().resetUser();
 
       // Clear persisted localStorage data
       localStorage.removeItem('sillytavern_group_chats');

--- a/src/stores/expressionsStore.ts
+++ b/src/stores/expressionsStore.ts
@@ -1,0 +1,48 @@
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+
+let _currentHandle: string | null = null;
+
+const scopedLocalStorage = {
+  getItem: (name: string) => {
+    const key = _currentHandle ? `${name}_${_currentHandle}` : name;
+    return localStorage.getItem(key);
+  },
+  setItem: (name: string, value: string) => {
+    const key = _currentHandle ? `${name}_${_currentHandle}` : name;
+    localStorage.setItem(key, value);
+  },
+  removeItem: (name: string) => {
+    const key = _currentHandle ? `${name}_${_currentHandle}` : name;
+    localStorage.removeItem(key);
+  },
+};
+
+interface ExpressionsState {
+  /** When true, keep the previous valid expression instead of falling back to the default avatar when a sprite is missing. */
+  noFallback: boolean;
+  setNoFallback: (on: boolean) => void;
+  initForUser: (handle: string) => void;
+  resetUser: () => void;
+}
+
+export const useExpressionsStore = create<ExpressionsState>()(
+  persist(
+    (set) => ({
+      noFallback: false,
+      setNoFallback: (on) => set({ noFallback: on }),
+      initForUser: (handle) => {
+        _currentHandle = handle;
+        useExpressionsStore.persist.rehydrate();
+      },
+      resetUser: () => {
+        _currentHandle = null;
+        set({ noFallback: false });
+      },
+    }),
+    {
+      name: 'st-mobile-expressions',
+      storage: createJSONStorage(() => scopedLocalStorage),
+    }
+  )
+);


### PR DESCRIPTION
## Summary
Closes #187.

- New built-in **Expressions** extension card on the Extensions page (default-enabled, smile icon).
- Adds a `noFallback` setting (per-user, persisted to `localStorage`) — when on, missing expression sprites no longer snap to the default avatar; the previous valid expression is kept instead.
- Wired into `ChatView`'s `getAvatarUrl` and `getFullImageUrl` via a new `findPreviousValidSpritePath` helper that walks back through chat messages for the same character to find the most recent renderable emotion.

## Test plan
- [x] Local `npm run build` passes.
- [x] Extensions page renders the new "Expressions" card with the "No fallback" toggle inside its Settings section. Toggle persists to `st-mobile-expressions_<handle>` in localStorage.
- [ ] Reviewer test: load a character with at least two distinct expression sprites available. With the toggle **off**, generate a reply whose detected emotion has no matching sprite — portrait should snap to the default avatar (existing behavior). With the toggle **on**, the previous expression should remain on screen instead.
- [ ] Reviewer test: edge case — first message in a chat with no prior valid emotion still falls back to the default avatar (helper returns null).
- [ ] Reviewer test: group chat — each character independently keeps its own previous expression (helper filters by avatar).

🤖 Draft opened by the build-next-issue skill. Human review required before merge.