### PR TITLE
fix(sidebar): keep Clear filter button inside the column

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -365,7 +365,7 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
               </div>
 
               {/* Filter controls */}
-              <div className="flex items-center gap-1">
+              <div className="flex flex-wrap items-center gap-1">
                 <button
                   onClick={() => setShowFavoritesOnly(!showFavoritesOnly)}
                   className={`flex items-center gap-1 px-2 py-1 text-xs rounded-md transition-colors ${
@@ -395,17 +395,19 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
                     </span>
                   )}
                 </button>
-                <select
-                  value={sortMode}
-                  onChange={(e) => setSortMode(e.target.value as never)}
-                  className="flex items-center gap-1 px-2 py-1 text-xs rounded-md text-[var(--color-text-secondary)] bg-transparent hover:bg-[var(--color-bg-tertiary)] cursor-pointer appearance-none focus:outline-none"
-                  title="Sort mode"
-                >
-                  <option value="name">Name</option>
-                  <option value="date_added">Recently added</option>
-                  <option value="date_last_chat">Recent chat</option>
-                </select>
-                <ArrowUpDown size={12} className="text-[var(--color-text-secondary)] -ml-1" />
+                <span className="flex items-center">
+                  <select
+                    value={sortMode}
+                    onChange={(e) => setSortMode(e.target.value as never)}
+                    className="flex items-center gap-1 px-2 py-1 text-xs rounded-md text-[var(--color-text-secondary)] bg-transparent hover:bg-[var(--color-bg-tertiary)] cursor-pointer appearance-none focus:outline-none"
+                    title="Sort mode"
+                  >
+                    <option value="name">Name</option>
+                    <option value="date_added">Recently added</option>
+                    <option value="date_last_chat">Recent chat</option>
+                  </select>
+                  <ArrowUpDown size={12} className="text-[var(--color-text-secondary)] -ml-1" />
+                </span>
                 {activeFilterCount > 0 && (
                   <button
                     onClick={() => {


### PR DESCRIPTION
## Summary
The Clear button in the sidebar's character filter row could push past the sidebar's right edge once active filters surfaced it (overflow ~11px on a 288px sidebar at viewport ≥ sm).

- Add `flex-wrap` to the filter row so Clear can wrap to its own line when there's no horizontal room.
- Wrap the sort `<select>` and its `ArrowUpDown` icon in a single inline span so they stay paired on the first line — without this, only the icon would wrap and visually detach from "Name".

## Test plan
- [x] Local `npm run build` passes.
- [x] Verified in preview: filter row no longer overflows; Clear sits inside the column on a new row when active.
- [ ] Reviewer test: hide all filters → Clear disappears, row collapses back to single line.