### PR TITLE
fix(chat): keep dialogue highlighting on the right text when italics are inside quotes

### DIFF
--- a/src/components/chat/MarkdownContent.tsx
+++ b/src/components/chat/MarkdownContent.tsx
@@ -216,7 +216,15 @@ export function MarkdownContent({ content, isUser, isStreaming }: MarkdownConten
     () => (standardize ? normalizeForDisplay(content) : content),
     [content, standardize]
   );
-  const paragraphs = useMemo(() => splitParagraphs(prepared), [prepared]);
+  const paragraphs = useMemo(() => {
+    const split = splitParagraphs(prepared);
+    // Wrap "…" dialogue per paragraph BEFORE the RP parser splits at italic
+    // markers. Otherwise an italic inside a quote (e.g. "Hello *world*.")
+    // splits the quote across segments — the orphaned closing " can pair
+    // with a later opening " from another quote, wrapping the plain text
+    // between them instead of the actual quotation.
+    return standardize ? split.map(wrapDialogue) : split;
+  }, [prepared, standardize]);
 
   /** Copy-button click handler — uses event delegation. */
   const handleClick = useCallback((e: React.MouseEvent) => {
@@ -241,8 +249,7 @@ export function MarkdownContent({ content, isUser, isStreaming }: MarkdownConten
         // *italic* markers don't compose well, and the RP regex can grab
         // list-bullet asterisks unintentionally.
         if (paraIsBlockMarkdown) {
-          const dialogueContent = standardize ? wrapDialogue(paragraph) : paragraph;
-          const { html } = renderMarkdown(dialogueContent, isStreaming && isLastPara);
+          const { html } = renderMarkdown(paragraph, isStreaming && isLastPara);
           const cursorHtml = isStreaming && isLastPara
             ? html + '<span class="streaming-cursor"></span>'
             : html;
@@ -293,8 +300,10 @@ export function MarkdownContent({ content, isUser, isStreaming }: MarkdownConten
 
               // Dialogue inside an inline paragraph — render via parseInline
               // (no block-level parsing since we already filtered those out).
-              const dialogueContent = standardize ? wrapDialogue(segment.content) : segment.content;
-              const { html } = renderMarkdown(dialogueContent, isStreaming && isLastSeg);
+              // wrapDialogue already ran at the paragraph level, so this
+              // segment's content may contain partial <span class="dialogue">
+              // markup that the browser will auto-balance.
+              const { html } = renderMarkdown(segment.content, isStreaming && isLastSeg);
               const cursorHtml = isStreaming && isLastSeg
                 ? html + '<span class="streaming-cursor"></span>'
                 : html;


### PR DESCRIPTION
## Summary
Closes #188.

When italics appeared inside a quotation (e.g. `"He said *something*." Then "another quote here."`), the RP parser split the paragraph at the italic markers BEFORE `wrapDialogue` ran. That orphaned the closing `"` of the first quote and the opening `"` of the next into the same dialogue segment, where `wrapDialogue`'s `/"([^"\n]+)"/g` matched the gap between them — wrapping the plain text "Then" instead of either real quotation.

- `wrapDialogue` now runs **once per paragraph in the `paragraphs` memo**, before `parseRPSegments` ever splits at italic markers, while quote pairs are still intact.
- The two `wrapDialogue(segment.content)` / `wrapDialogue(paragraph)` calls inside the render loop are removed.
- Partial `<span class="dialogue">` tags that end up split across an italic segment are auto-balanced by the browser when each segment's HTML is set via `dangerouslySetInnerHTML`.

## Test plan
- [x] Local `npm run build` passes.
- [x] Manual check: `wrapDialogue` of `"He said *something* important." Then "another quote here."` produces two separate dialogue spans around the actual quotations and leaves "Then" as plain text.
- [x] Existing chat with the dialogue + italic + dialogue pattern (e.g. *She speaks.* / "She says...") still renders both quotes highlighted; no console errors after preview reload.
- [ ] Reviewer test: send a message with italics inside a single quotation — `"He whispered *quietly*."` — confirm the closing `."` is no longer mis-paired with another `"` later in the paragraph (cosmetic note: only the opening fragment of that quote stays in a dialogue span; the post-italic remainder may render unwrapped, which is acceptable vs. the original mis-highlight).
- [ ] Reviewer test: regression — multi-quote paragraphs without italics still wrap each quote individually.

🤖 Draft opened by the build-next-issue skill. Human review required before merge.