### PR TITLE
fix(chat): keep VN background visible when character has no expression sprites

### DIFF
--- a/docs/v2/ROADMAP.md
+++ b/docs/v2/ROADMAP.md
@@ -2,7 +2,7 @@
 
 > **Status:** Idea-shaping. No code yet. This doc is the living capture of decisions, open questions, and the idea backlog so we don't re-decide the same things.
 >
-> **Last updated:** 2026-05-02 (added: pgvector decision, Rive motion tier, Film Creation, deepfake risk)
+> **Last updated:** 2026-05-02 (added: pgvector decision, Rive motion tier, Film Creation, deepfake risk, intake bot conversational refinement)
 
 ## One-liner
 
@@ -203,6 +203,7 @@ Capture freely. Promotion to Phase X requires a real argument.
 - **Plugin runtime in mobile app** for ST-compat extensions — maybe just a WebView shim.
 - **"Bring your own key" tier** for power users on a free plan; managed-key tier as paid default.
 - **End-to-end encrypted human↔human DMs** as a paid feature differentiator.
+- **Conversational feature-request refinement (intake bot evolution)** — extend `ggbc-intake-bot` so that on a new feature request, an agent opens a reply thread and asks clarifying questions (problem, acceptance criteria, edge cases, who benefits) until the request is well-scoped, *then* files the GH issue with the synthesized scope. Better issue quality → better `/build-next-issue` runs → less rework. Lives in the intake bot repo, not the app, but tracked here because it's part of the GGBC product line.
 
 ---
 

--- a/docs/v2/ROADMAP.md
+++ b/docs/v2/ROADMAP.md
@@ -2,7 +2,7 @@
 
 > **Status:** Idea-shaping. No code yet. This doc is the living capture of decisions, open questions, and the idea backlog so we don't re-decide the same things.
 >
-> **Last updated:** 2026-05-02 (added: pgvector decision, Rive motion tier, Film Creation, deepfake risk, intake bot conversational refinement)
+> **Last updated:** 2026-05-02 (added: pgvector decision, Rive motion tier, Film Creation, deepfake risk)
 
 ## One-liner
 
@@ -203,7 +203,6 @@ Capture freely. Promotion to Phase X requires a real argument.
 - **Plugin runtime in mobile app** for ST-compat extensions — maybe just a WebView shim.
 - **"Bring your own key" tier** for power users on a free plan; managed-key tier as paid default.
 - **End-to-end encrypted human↔human DMs** as a paid feature differentiator.
-- **Conversational feature-request refinement (intake bot evolution)** — extend `ggbc-intake-bot` so that on a new feature request, an agent opens a reply thread and asks clarifying questions (problem, acceptance criteria, edge cases, who benefits) until the request is well-scoped, *then* files the GH issue with the synthesized scope. Better issue quality → better `/build-next-issue` runs → less rework. Lives in the intake bot repo, not the app, but tracked here because it's part of the GGBC product line.
 
 ---
 

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -225,6 +225,18 @@ export function ChatView() {
     return characterMessages[characterMessages.length - 1].emotion ?? null;
   }, [messages]);
 
+  // Whether a real expression sprite (typically a transparent PNG) resolves
+  // for the current latest emotion. Used to decide if it's safe to render
+  // the full-screen VN sprite layer over a chat background — falling back
+  // to the opaque default avatar would otherwise obscure the background.
+  const hasRealSpriteForLatest = useMemo(() => {
+    if (!selectedCharacter || !latestEmotion) return false;
+    const key = `${selectedCharacter.avatar}-${latestEmotion}`;
+    if (failedExpressions.has(key)) return false;
+    const mapped = mapEmotionToAvailable(latestEmotion, availableEmotions);
+    return !!getSpritePath(mapped || latestEmotion);
+  }, [selectedCharacter, latestEmotion, failedExpressions, availableEmotions, getSpritePath]);
+
   const livePortraitEnabled = useLivePortraitStore((s) => s.enabled);
   const livePortraitClips = useLivePortraitStore((s) =>
     selectedCharacter ? s.getClips(selectedCharacter.avatar) : null,
@@ -863,8 +875,13 @@ export function ChatView() {
         />
       )}
 
-      {/* Phase 6.4: VN sprite layer — single character (z-1) */}
-      {isVnMode && !isGroupChatMode && selectedCharacter && (
+      {/* Phase 6.4: VN sprite layer — single character (z-1).
+          Skip when a background image is set AND no real sprite resolves
+          for the current emotion — otherwise the opaque default-avatar
+          fallback would full-screen-cover the background image. Real
+          (transparent-PNG) expression sprites render normally and let the
+          background show through. */}
+      {isVnMode && !isGroupChatMode && selectedCharacter && (!vnBg || hasLivePortrait || hasRealSpriteForLatest) && (
         hasLivePortrait ? (
           <div
             className="absolute inset-0 pointer-events-none"


### PR DESCRIPTION
## Summary
Closes #189.

When a user sets a chat background, VN mode auto-enables so the new image renders. But the VN sprite layer was always mounted in single-character mode — and when the character had no expression sprite for the current emotion, it fell back to the opaque default avatar via `getDefaultAvatarUrl`. That full-screen fallback covered the just-set background, while text bubbles (z-10) covered the avatar — net result: neither was usefully visible.

- Add a `hasRealSpriteForLatest` memo that's true only when the current `latestEmotion` resolves to an actual sprite path (not the default-avatar fallback).
- Gate the single-character VN sprite render with `(!vnBg || hasLivePortrait || hasRealSpriteForLatest)` — only mount the sprite layer over a background when there's a real (typically transparent-PNG) sprite or a Live Portrait video to show.

## Test plan
- [x] Local `npm run build` passes.
- [x] Verified in preview with a character that has no expression sprites (Seraphina → default avatar): with VN bg set + VN mode on, the bg image is visible, no full-screen avatar overlay, no console errors.
- [x] Regression: with bg cleared, the default-avatar VN sprite layer mounts as before.
- [ ] Reviewer test: character WITH transparent-PNG expression sprites — the bg should show through the sprite as designed.
- [ ] Reviewer test: Live Portrait active — sprite/video continues to render even with a bg (gate explicitly allows `hasLivePortrait`).
- [ ] Reviewer test: group chat — out of scope here (group sprites use sized positions, not full-screen `inset-0`); behavior unchanged.

🤖 Draft opened by the build-next-issue skill. Human review required before merge.