### PR TITLE
feat(character): AI helper menu on character-creation text fields

### DIFF
--- a/docs/v2/ROADMAP.md
+++ b/docs/v2/ROADMAP.md
@@ -2,7 +2,7 @@
 
 > **Status:** Idea-shaping. No code yet. This doc is the living capture of decisions, open questions, and the idea backlog so we don't re-decide the same things.
 >
-> **Last updated:** 2026-05-02 (added: intake bot conversational refinement)
+> **Last updated:** 2026-05-02 (added: pgvector decision, Rive motion tier, Film Creation, deepfake risk)
 
 ## One-liner
 
@@ -203,7 +203,6 @@ Capture freely. Promotion to Phase X requires a real argument.
 - **Plugin runtime in mobile app** for ST-compat extensions — maybe just a WebView shim.
 - **"Bring your own key" tier** for power users on a free plan; managed-key tier as paid default.
 - **End-to-end encrypted human↔human DMs** as a paid feature differentiator.
-- **Conversational feature-request refinement (intake bot evolution)** — extend `ggbc-intake-bot` so that on a new feature request, an agent opens a reply thread and asks clarifying questions (problem, acceptance criteria, edge cases, who benefits) until the request is well-scoped, *then* files the GH issue with the synthesized scope. Better issue quality → better `/build-next-issue` runs → less rework. Lives in the intake bot repo, not the app, but tracked here because it's part of the GGBC product line.
 
 ---
 

--- a/docs/v2/ROADMAP.md
+++ b/docs/v2/ROADMAP.md
@@ -2,7 +2,7 @@
 
 > **Status:** Idea-shaping. No code yet. This doc is the living capture of decisions, open questions, and the idea backlog so we don't re-decide the same things.
 >
-> **Last updated:** 2026-05-02 (added: pgvector decision, Rive motion tier, Film Creation, deepfake risk)
+> **Last updated:** 2026-05-02 (added: intake bot conversational refinement)
 
 ## One-liner
 
@@ -203,6 +203,7 @@ Capture freely. Promotion to Phase X requires a real argument.
 - **Plugin runtime in mobile app** for ST-compat extensions — maybe just a WebView shim.
 - **"Bring your own key" tier** for power users on a free plan; managed-key tier as paid default.
 - **End-to-end encrypted human↔human DMs** as a paid feature differentiator.
+- **Conversational feature-request refinement (intake bot evolution)** — extend `ggbc-intake-bot` so that on a new feature request, an agent opens a reply thread and asks clarifying questions (problem, acceptance criteria, edge cases, who benefits) until the request is well-scoped, *then* files the GH issue with the synthesized scope. Better issue quality → better `/build-next-issue` runs → less rework. Lives in the intake bot repo, not the app, but tracked here because it's part of the GGBC product line.
 
 ---
 

--- a/src/components/character/AIHelperButton.tsx
+++ b/src/components/character/AIHelperButton.tsx
@@ -1,0 +1,106 @@
+import { useState, useRef, useEffect } from 'react';
+import { Sparkles, Loader2 } from 'lucide-react';
+import { showToastGlobal } from '../ui/Toast';
+import {
+  runAIHelperAction,
+  type AIHelperAction,
+  type CharacterFieldsSnapshot,
+} from '../../utils/aiCharacterHelper';
+
+interface AIHelperButtonProps {
+  field: keyof CharacterFieldsSnapshot;
+  /** Latest snapshot of every field. The component reads its own field's
+   *  value from here and passes the rest as context for "Suggest". */
+  fields: CharacterFieldsSnapshot;
+  /** Called with the AI's output to overwrite the field's current value. */
+  onResult: (text: string) => void;
+}
+
+const ACTION_LABELS: Record<AIHelperAction, string> = {
+  polish: 'Polish',
+  reformat: 'Reformat',
+  suggest: 'Suggest from other fields',
+};
+
+const ACTION_DESCRIPTIONS: Record<AIHelperAction, string> = {
+  polish: 'Smooth grammar and prose, keep meaning',
+  reformat: 'Restructure into prompt-friendly form',
+  suggest: 'Draft this field using the rest of the profile',
+};
+
+export function AIHelperButton({ field, fields, onResult }: AIHelperButtonProps) {
+  const [open, setOpen] = useState(false);
+  const [busy, setBusy] = useState<AIHelperAction | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Close the menu when clicking outside.
+  useEffect(() => {
+    if (!open) return;
+    const onDocClick = (e: MouseEvent) => {
+      if (!containerRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', onDocClick);
+    return () => document.removeEventListener('mousedown', onDocClick);
+  }, [open]);
+
+  async function run(action: AIHelperAction) {
+    setOpen(false);
+    setBusy(action);
+    try {
+      const result = await runAIHelperAction(action, field, fields);
+      if (result) {
+        onResult(result);
+        showToastGlobal(`AI ${ACTION_LABELS[action].toLowerCase()} done`, 'success');
+      } else {
+        showToastGlobal('AI returned an empty response', 'warning');
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'AI helper failed';
+      showToastGlobal(msg, 'error');
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  const isBusy = busy !== null;
+
+  return (
+    <div ref={containerRef} className="relative inline-block">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        disabled={isBusy}
+        className="flex items-center gap-1 text-xs px-2 py-0.5 rounded-md text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-tertiary)] hover:text-[var(--color-primary)] disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+        title="AI helper"
+        aria-haspopup="menu"
+        aria-expanded={open}
+      >
+        {isBusy ? <Loader2 size={12} className="animate-spin" /> : <Sparkles size={12} />}
+        <span>{isBusy ? ACTION_LABELS[busy!] + '…' : 'AI'}</span>
+      </button>
+      {open && !isBusy && (
+        <div
+          role="menu"
+          className="absolute left-0 top-full mt-1 z-20 min-w-[14rem] rounded-md border border-[var(--color-border)] bg-[var(--color-bg-secondary)] shadow-lg overflow-hidden"
+        >
+          {(Object.keys(ACTION_LABELS) as AIHelperAction[]).map((action) => (
+            <button
+              key={action}
+              type="button"
+              role="menuitem"
+              onClick={() => run(action)}
+              className="w-full text-left px-3 py-2 hover:bg-[var(--color-bg-tertiary)] transition-colors"
+            >
+              <div className="text-sm text-[var(--color-text-primary)]">
+                {ACTION_LABELS[action]}
+              </div>
+              <div className="text-[11px] text-[var(--color-text-secondary)]/70">
+                {ACTION_DESCRIPTIONS[action]}
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/character/CharacterCreation.tsx
+++ b/src/components/character/CharacterCreation.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useCharacterStore } from '../../stores/characterStore';
 import { Modal, Button, Input, TextArea, ImageUpload, ExpressionUpload, TagInput } from '../ui';
 import { AlternateGreetingsEditor } from './AlternateGreetingsEditor';
+import { AIHelperButton } from './AIHelperButton';
 import { spritesApi } from '../../api/client';
 
 interface CharacterCreationProps {
@@ -63,6 +64,19 @@ export function CharacterCreation({ isOpen, onClose, onCreated, initialData }: C
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
   ) => {
     setFormData((prev) => ({ ...prev, [field]: e.target.value }));
+    if (error) clearError();
+  };
+
+  const aiFieldsSnapshot = {
+    name: formData.name,
+    description: formData.description,
+    personality: formData.personality,
+    firstMessage: formData.firstMessage,
+    scenario: formData.scenario,
+    exampleMessages: formData.exampleMessages,
+  };
+  const setAIResult = (field: keyof typeof aiFieldsSnapshot) => (value: string) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
     if (error) clearError();
   };
 
@@ -175,6 +189,13 @@ export function CharacterCreation({ isOpen, onClose, onCreated, initialData }: C
         {/* Description */}
         <TextArea
           label="Description"
+          labelExtra={
+            <AIHelperButton
+              field="description"
+              fields={aiFieldsSnapshot}
+              onResult={setAIResult('description')}
+            />
+          }
           placeholder="Describe the character's appearance, background, and other details..."
           value={formData.description}
           onChange={handleChange('description')}
@@ -184,6 +205,13 @@ export function CharacterCreation({ isOpen, onClose, onCreated, initialData }: C
         {/* Personality */}
         <TextArea
           label="Personality"
+          labelExtra={
+            <AIHelperButton
+              field="personality"
+              fields={aiFieldsSnapshot}
+              onResult={setAIResult('personality')}
+            />
+          }
           placeholder="Character's personality traits, mannerisms, speech patterns..."
           value={formData.personality}
           onChange={handleChange('personality')}
@@ -193,6 +221,13 @@ export function CharacterCreation({ isOpen, onClose, onCreated, initialData }: C
         {/* First Message */}
         <TextArea
           label="First Message"
+          labelExtra={
+            <AIHelperButton
+              field="firstMessage"
+              fields={aiFieldsSnapshot}
+              onResult={setAIResult('firstMessage')}
+            />
+          }
           placeholder="The character's opening message when starting a new chat..."
           value={formData.firstMessage}
           onChange={handleChange('firstMessage')}
@@ -208,6 +243,13 @@ export function CharacterCreation({ isOpen, onClose, onCreated, initialData }: C
         {/* Scenario */}
         <TextArea
           label="Scenario"
+          labelExtra={
+            <AIHelperButton
+              field="scenario"
+              fields={aiFieldsSnapshot}
+              onResult={setAIResult('scenario')}
+            />
+          }
           placeholder="The setting or context for conversations..."
           value={formData.scenario}
           onChange={handleChange('scenario')}
@@ -227,6 +269,13 @@ export function CharacterCreation({ isOpen, onClose, onCreated, initialData }: C
             {/* Example Messages */}
             <TextArea
               label="Example Messages"
+              labelExtra={
+                <AIHelperButton
+                  field="exampleMessages"
+                  fields={aiFieldsSnapshot}
+                  onResult={setAIResult('exampleMessages')}
+                />
+              }
               placeholder="Example dialogue to help the AI understand the character's voice..."
               value={formData.exampleMessages}
               onChange={handleChange('exampleMessages')}

--- a/src/utils/aiCharacterHelper.ts
+++ b/src/utils/aiCharacterHelper.ts
@@ -1,0 +1,167 @@
+import { api } from '../api/client';
+import { useSettingsStore } from '../stores/settingsStore';
+
+export type AIHelperAction = 'polish' | 'reformat' | 'suggest';
+
+/** Snapshot of all character-creation fields. The "suggest" action uses the
+ *  other (non-target) fields as context so the AI can draft something that
+ *  fits the rest of the profile. */
+export interface CharacterFieldsSnapshot {
+  name?: string;
+  description?: string;
+  personality?: string;
+  firstMessage?: string;
+  scenario?: string;
+  exampleMessages?: string;
+}
+
+const FIELD_LABELS: Record<keyof CharacterFieldsSnapshot, string> = {
+  name: 'Name',
+  description: 'Description',
+  personality: 'Personality',
+  firstMessage: 'First Message',
+  scenario: 'Scenario',
+  exampleMessages: 'Example Messages',
+};
+
+async function* parseSSEStream(
+  stream: ReadableStream<Uint8Array>,
+): AsyncGenerator<string> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop() || '';
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed === 'data: [DONE]') continue;
+        if (trimmed.startsWith('data: ')) {
+          const data = trimmed.slice(6);
+          if (!data || data === '[DONE]') continue;
+          try {
+            const json = JSON.parse(data);
+            const content =
+              json.choices?.[0]?.delta?.content ||
+              json.choices?.[0]?.text ||
+              json.delta?.text ||
+              (json.type === 'content_block_delta' ? json.delta?.text : null) ||
+              json.content ||
+              json.message?.content?.[0]?.text ||
+              '';
+            if (content) yield content;
+          } catch {
+            if (data.length > 0 && data !== 'undefined') yield data;
+          }
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+async function generateCompletion(
+  systemPrompt: string,
+  userPrompt: string,
+  signal?: AbortSignal,
+): Promise<string> {
+  const { activeProvider, activeModel } = useSettingsStore.getState();
+  const messages: { role: 'system' | 'user' | 'assistant'; content: string }[] = [
+    { role: 'system', content: systemPrompt },
+    { role: 'user', content: userPrompt },
+  ];
+  const stream = await api.generateMessage(
+    messages,
+    'CharacterHelper',
+    activeProvider,
+    activeModel,
+    signal,
+  );
+  if (!stream) throw new Error('No response from AI');
+
+  let text = '';
+  for await (const token of parseSSEStream(stream)) text += token;
+  return stripWrappingMarkers(text.trim());
+}
+
+/** Models sometimes echo the field label, surround the answer in quotes, or
+ *  prepend "Here is the polished version:". Trim those defensive wrappers so
+ *  the result drops cleanly into a textarea. */
+function stripWrappingMarkers(text: string): string {
+  let out = text;
+  out = out.replace(/^```[a-z]*\n?/i, '').replace(/\n?```$/i, '');
+  out = out.replace(/^(here(?:\s+is|'s)|sure|certainly|of course)[^\n]*[:.]\s*\n?/i, '');
+  if (
+    (out.startsWith('"') && out.endsWith('"')) ||
+    (out.startsWith("'") && out.endsWith("'"))
+  ) {
+    out = out.slice(1, -1);
+  }
+  return out.trim();
+}
+
+function buildOtherFieldsContext(
+  fields: CharacterFieldsSnapshot,
+  exclude: keyof CharacterFieldsSnapshot,
+): string {
+  const lines: string[] = [];
+  for (const key of Object.keys(FIELD_LABELS) as (keyof CharacterFieldsSnapshot)[]) {
+    if (key === exclude) continue;
+    const value = fields[key]?.trim();
+    if (value) lines.push(`${FIELD_LABELS[key]}:\n${value}`);
+  }
+  return lines.join('\n\n');
+}
+
+/** Run an AI helper action against a single character-creation field.
+ *  Returns the rewritten / generated text, ready to drop back into the form. */
+export async function runAIHelperAction(
+  action: AIHelperAction,
+  field: keyof CharacterFieldsSnapshot,
+  fields: CharacterFieldsSnapshot,
+  signal?: AbortSignal,
+): Promise<string> {
+  const fieldLabel = FIELD_LABELS[field];
+  const currentValue = (fields[field] ?? '').trim();
+
+  if (action === 'polish') {
+    if (!currentValue) {
+      throw new Error('Field is empty — nothing to polish.');
+    }
+    const system =
+      'You are an editor refining character profile text. Lightly polish the user\'s draft for grammar, spelling, and clarity while preserving their voice, intent, and content. Do not add new facts or change the meaning. Output ONLY the revised text — no preamble, no quotes, no commentary.';
+    const user = `Field: ${fieldLabel}\n\nDraft:\n${currentValue}`;
+    return generateCompletion(system, user, signal);
+  }
+
+  if (action === 'reformat') {
+    if (!currentValue) {
+      throw new Error('Field is empty — nothing to reformat.');
+    }
+    const system =
+      'You are an editor reformatting character profile text into a structured, prompt-friendly form. When useful, convert prose traits into compact bracketed blocks like [Trait= "value", "value"]. Keep narrative form for fields that need it (first message, scenario). Preserve all factual content. Output ONLY the reformatted text — no preamble, no commentary.';
+    const user = `Field: ${fieldLabel}\n\nCurrent draft:\n${currentValue}`;
+    return generateCompletion(system, user, signal);
+  }
+
+  // suggest from other fields
+  const context = buildOtherFieldsContext(fields, field);
+  if (!context) {
+    throw new Error(
+      'No other fields are filled in yet — fill in at least the Name and Description first.',
+    );
+  }
+  const system =
+    'You are a creative collaborator helping draft a character profile. Generate the requested field, drawing on the other fields the author has already filled in. Match their tone and voice. If the author already has a partial draft for this field, refine it rather than starting over. Output ONLY the field\'s content — no preamble, no field labels, no commentary.';
+  const user = currentValue
+    ? `Generate the **${fieldLabel}** for this character.\n\nOther fields:\n${context}\n\nExisting draft to refine:\n${currentValue}`
+    : `Generate the **${fieldLabel}** for this character.\n\nOther fields:\n${context}`;
+  return generateCompletion(system, user, signal);
+}


### PR DESCRIPTION
## Summary
Closes #190.

A new `AI` button sits in the label row of each major character-creation field. Clicking it opens a small dropdown with three actions:

- **Polish** — light grammar / prose pass; preserves voice and content.
- **Reformat** — restructure into prompt-friendly form (e.g. compact `[Trait= \"value\", \"value\"]` blocks where appropriate).
- **Suggest from other fields** — draft this field using whatever the author has already filled in elsewhere; refines an existing partial draft if one is present.

Affordance is wired into 5 fields: **Description, Personality, First Message, Scenario, Example Messages**.

### Files added
- `src/utils/aiCharacterHelper.ts` — calls `api.generateMessage()` with the user's active chat provider/model (same path the summarize feature uses); contains the three prompt templates and a small SSE parser. Strips defensive wrappers (markdown fences, leading "Sure, here is…", surrounding quotes) from model output before returning.
- `src/components/character/AIHelperButton.tsx` — the dropdown button + menu, with click-outside dismissal, busy state, and toast-based success/error surfacing.

### Default decisions (per user agreement before build)
1. Five main content fields, not all 13. Easy to expand later.
2. Single dropdown button per field, not three side-by-side buttons.
3. Reuses the existing chat provider/model — no separate AI-helper settings.
4. Hard-coded prompt templates; no user customization in v1.
5. \"Suggest\" with no other fields filled → friendly toast asking the user to fill Name + Description first, instead of a silent failure.

## Test plan
- [x] Local `npm run build` passes.
- [x] AI button renders next to each of the 5 field labels in the Create Character modal.
- [x] Menu opens, doesn't get clipped by the modal edge (left-aligned dropdown).
- [x] \"Suggest from other fields\" with an empty form surfaces a friendly toast (\"No other fields are filled in yet — fill in at least the Name and Description first.\").
- [x] No console errors after the menu interactions.
- [ ] Reviewer test: Polish on a draft \"Description\" produces lightly cleaned-up prose that preserves the original facts.
- [ ] Reviewer test: Reformat on a free-form Personality produces a compact `[Trait= …]` style block.
- [ ] Reviewer test: Suggest on Personality with Name + Description filled in drafts something on-tone for the rest of the profile.
- [ ] Reviewer test: With no active chat provider configured, the toast surfaces a clear error rather than silently hanging.

### Out of scope (intentionally)
- AI helper on `CharacterEdit` (existing-character editing). Could be a follow-up if useful — would be a 5-line change importing the same component.
- Per-action prompt customization, separate model picker, streamed UI feedback. Easy to layer on once shape of v1 is settled.

🤖 Draft opened by the build-next-issue skill. Human review required before merge.