### PR TITLE
feat(chat): per-character motion mode picker (Auto / Expressions / Live Portrait / None)

### DIFF
--- a/src/components/character/MotionModePicker.tsx
+++ b/src/components/character/MotionModePicker.tsx
@@ -1,0 +1,93 @@
+import { useMotionModeStore, type MotionMode } from '../../stores/motionModeStore';
+
+interface MotionModePickerProps {
+  avatar: string;
+  hasLivePortraitClips: boolean;
+  hasExpressionSprites: boolean;
+  variant?: 'panel' | 'overlay';
+  className?: string;
+}
+
+interface Option {
+  value: MotionMode;
+  label: string;
+  available: boolean;
+  unavailableHint: string;
+}
+
+export function MotionModePicker({
+  avatar,
+  hasLivePortraitClips,
+  hasExpressionSprites,
+  variant = 'panel',
+  className = '',
+}: MotionModePickerProps) {
+  const mode = useMotionModeStore((s) => s.modesByAvatar[avatar] ?? 'auto');
+  const setMode = useMotionModeStore((s) => s.setMode);
+
+  const options: Option[] = [
+    { value: 'auto', label: 'Auto', available: true, unavailableHint: '' },
+    {
+      value: 'expressions',
+      label: 'Expressions',
+      available: hasExpressionSprites,
+      unavailableHint: 'No expression sprites uploaded — add them in character edit.',
+    },
+    {
+      value: 'liveportrait',
+      label: 'Live Portrait',
+      available: hasLivePortraitClips,
+      unavailableHint: 'No clips generated yet — set up Live Portrait in character edit.',
+    },
+    { value: 'none', label: 'None', available: true, unavailableHint: '' },
+  ];
+
+  const isOverlay = variant === 'overlay';
+  const containerStyles = isOverlay
+    ? 'bg-black/40 backdrop-blur-sm border border-white/10'
+    : 'bg-[var(--color-bg-tertiary)] border border-[var(--color-border)]';
+
+  const segmentBase =
+    'flex-1 px-2 py-1 text-[11px] font-medium rounded transition-colors disabled:cursor-not-allowed text-center';
+  const activeStyles = isOverlay
+    ? 'bg-white/25 text-white'
+    : 'bg-[var(--color-primary)] text-white';
+  const idleStyles = isOverlay
+    ? 'text-white/70 hover:text-white hover:bg-white/10'
+    : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-secondary)]';
+  const disabledStyles = isOverlay
+    ? 'text-white/30 hover:bg-transparent hover:text-white/30'
+    : 'text-[var(--color-text-tertiary)] opacity-50';
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Avatar motion mode"
+      className={`flex items-center gap-1 p-1 rounded-lg ${containerStyles} ${className}`}
+    >
+      {options.map((opt) => {
+        const selected = mode === opt.value;
+        const disabled = !opt.available;
+        const title = disabled
+          ? opt.unavailableHint
+          : opt.value === 'auto'
+            ? 'Pick the best available automatically'
+            : `Use ${opt.label.toLowerCase()}`;
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            disabled={disabled}
+            onClick={() => setMode(avatar, opt.value)}
+            title={title}
+            className={`${segmentBase} ${selected ? activeStyles : disabled ? disabledStyles : idleStyles}`}
+          >
+            {opt.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -31,6 +31,8 @@ import { useAutoMemoryStore } from '../../stores/autoMemoryStore';
 import { useCharacterSprites } from '../../hooks/useCharacterSprites';
 import { LivePortraitVideo } from './LivePortraitVideo';
 import { useLivePortraitStore } from '../../stores/livePortraitStore';
+import { useMotionModeStore, resolveMotionMode } from '../../stores/motionModeStore';
+import { MotionModePicker } from '../character/MotionModePicker';
 import { useGenerationStore } from '../../stores/generationStore';
 import { usePromptTemplateStore } from '../../stores/promptTemplateStore';
 import { usePortraitPositionStore } from '../../stores/portraitPositionStore';
@@ -267,7 +269,20 @@ export function ChatView() {
   const livePortraitClips = useLivePortraitStore((s) =>
     selectedCharacter ? s.getClips(selectedCharacter.avatar) : null,
   );
-  const hasLivePortrait = livePortraitEnabled && !!livePortraitClips && 'idle' in livePortraitClips;
+  const hasLivePortraitClips =
+    livePortraitEnabled && !!livePortraitClips && 'idle' in livePortraitClips;
+  const hasExpressionSprites = availableEmotions.length > 0;
+  const motionMode = useMotionModeStore((s) =>
+    selectedCharacter ? s.modesByAvatar[selectedCharacter.avatar] ?? 'auto' : 'auto',
+  );
+  const resolvedMotionMode = resolveMotionMode(
+    motionMode,
+    hasLivePortraitClips,
+    hasExpressionSprites,
+  );
+  const hasLivePortrait = resolvedMotionMode === 'liveportrait';
+  const expressionsActive = resolvedMotionMode === 'expressions';
+  const portraitEmotion = expressionsActive ? latestEmotion : null;
 
   // Auto-discover server-side clips when a character is selected so users
   // see Live Portrait on any device — not just the one that ran generation.
@@ -912,7 +927,7 @@ export function ChatView() {
           fallback would full-screen-cover the background image. Real
           (transparent-PNG) expression sprites render normally and let the
           background show through. */}
-      {isVnMode && !isGroupChatMode && selectedCharacter && (!vnBg || hasLivePortrait || hasRealSpriteForLatest) && (
+      {isVnMode && !isGroupChatMode && selectedCharacter && (resolvedMotionMode !== 'none') && (!vnBg || hasLivePortrait || (expressionsActive && hasRealSpriteForLatest)) && (
         hasLivePortrait ? (
           <div
             className="absolute inset-0 pointer-events-none"
@@ -927,8 +942,8 @@ export function ChatView() {
           </div>
         ) : (
           <img
-            key={`vn-sprite-${selectedCharacter.avatar}-${latestEmotion ?? 'neutral'}`}
-            src={getFullImageUrl(selectedCharacter.avatar, latestEmotion)}
+            key={`vn-sprite-${selectedCharacter.avatar}-${portraitEmotion ?? 'neutral'}`}
+            src={getFullImageUrl(selectedCharacter.avatar, portraitEmotion)}
             alt=""
             aria-hidden
             className="absolute inset-0 w-full h-full object-contain object-bottom pointer-events-none"
@@ -1122,8 +1137,8 @@ export function ChatView() {
                   />
                 ) : (
                   <img
-                    key={`${selectedCharacter.avatar}-${latestEmotion ?? 'neutral'}`}
-                    src={getFullImageUrl(selectedCharacter.avatar, latestEmotion)}
+                    key={`${selectedCharacter.avatar}-${portraitEmotion ?? 'neutral'}`}
+                    src={getFullImageUrl(selectedCharacter.avatar, portraitEmotion)}
                     alt={selectedCharacter.name}
                     draggable={false}
                     className="w-full h-full object-cover transition-opacity duration-300 select-none pointer-events-none"
@@ -1136,26 +1151,34 @@ export function ChatView() {
                     }}
                   />
                 )}
-                <div className="absolute inset-x-0 bottom-0 h-16 bg-gradient-to-t from-[var(--color-bg-primary)] to-transparent" />
-                <div className="absolute bottom-2 left-4 right-4 flex items-center justify-between">
-                  <h2 className="text-lg font-semibold text-[var(--color-text-primary)] drop-shadow-lg">
-                    {selectedCharacter.name}
-                  </h2>
-                  <div className="flex items-center gap-2">
-                    {latestEmotion && (
-                      <span className="text-xs px-2 py-1 rounded-full bg-black/30 text-white/80 backdrop-blur-sm capitalize">
-                        {latestEmotion}
-                      </span>
-                    )}
-                    <button
-                      onClick={openSearch}
-                      className="p-1.5 rounded-full bg-black/30 text-white/80 backdrop-blur-sm hover:bg-black/50 transition-colors"
-                      aria-label="Search messages"
-                      title="Search messages"
-                    >
-                      <Search size={15} />
-                    </button>
+                <div className="absolute inset-x-0 bottom-0 h-24 bg-gradient-to-t from-[var(--color-bg-primary)] to-transparent" />
+                <div className="absolute bottom-2 left-4 right-4 flex flex-col gap-2">
+                  <div className="flex items-center justify-between">
+                    <h2 className="text-lg font-semibold text-[var(--color-text-primary)] drop-shadow-lg">
+                      {selectedCharacter.name}
+                    </h2>
+                    <div className="flex items-center gap-2">
+                      {latestEmotion && (
+                        <span className="text-xs px-2 py-1 rounded-full bg-black/30 text-white/80 backdrop-blur-sm capitalize">
+                          {latestEmotion}
+                        </span>
+                      )}
+                      <button
+                        onClick={openSearch}
+                        className="p-1.5 rounded-full bg-black/30 text-white/80 backdrop-blur-sm hover:bg-black/50 transition-colors"
+                        aria-label="Search messages"
+                        title="Search messages"
+                      >
+                        <Search size={15} />
+                      </button>
+                    </div>
                   </div>
+                  <MotionModePicker
+                    avatar={selectedCharacter.avatar}
+                    hasLivePortraitClips={hasLivePortraitClips}
+                    hasExpressionSprites={hasExpressionSprites}
+                    variant="overlay"
+                  />
                 </div>
               </div>
               <div
@@ -1444,10 +1467,12 @@ export function ChatView() {
               const charAvatar = isGroupChatMode && message.characterAvatar
                 ? message.characterAvatar
                 : selectedCharacter?.avatar;
+              const useEmotionForThisMsg =
+                charAvatar === selectedCharacter?.avatar ? expressionsActive : true;
               const messageAvatar = message.isUser
                 ? undefined
                 : charAvatar
-                  ? getAvatarUrl(charAvatar, message.emotion)
+                  ? getAvatarUrl(charAvatar, useEmotionForThisMsg ? message.emotion : null)
                   : undefined;
               // Fallback: default avatar thumbnail (no expression) when sprite 404s
               const fallbackAvatar = !message.isUser && charAvatar

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -28,6 +28,8 @@ import { useCharacterSprites } from '../../hooks/useCharacterSprites';
 import { getDefaultAvatarUrl, type Emotion } from '../../utils/emotions';
 import { LivePortraitVideo } from '../chat/LivePortraitVideo';
 import { useLivePortraitStore } from '../../stores/livePortraitStore';
+import { MotionModePicker } from '../character/MotionModePicker';
+import { useMotionModeStore, resolveMotionMode } from '../../stores/motionModeStore';
 
 interface SidebarProps {
   isOpen: boolean;
@@ -78,7 +80,7 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
     selectedTags.size + (showFavoritesOnly ? 1 : 0) + (searchQuery.trim() ? 1 : 0);
 
   // Fetch actual sprite paths from API (hook extracts character name from avatar filename)
-  const { getSpritePath } = useCharacterSprites(selectedCharacter?.avatar);
+  const { getSpritePath, availableEmotions } = useCharacterSprites(selectedCharacter?.avatar);
 
   // Get the latest character message's emotion for the portrait
   const latestEmotion = useMemo(() => {
@@ -91,7 +93,19 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
   const livePortraitClips = useLivePortraitStore((s) =>
     selectedCharacter ? s.getClips(selectedCharacter.avatar) : null,
   );
-  const hasLivePortrait = livePortraitEnabled && !!livePortraitClips && 'idle' in livePortraitClips;
+  const hasLivePortraitClips =
+    livePortraitEnabled && !!livePortraitClips && 'idle' in livePortraitClips;
+  const hasExpressionSprites = availableEmotions.length > 0;
+  const motionMode = useMotionModeStore((s) =>
+    selectedCharacter ? s.modesByAvatar[selectedCharacter.avatar] ?? 'auto' : 'auto',
+  );
+  const resolvedMotionMode = resolveMotionMode(
+    motionMode,
+    hasLivePortraitClips,
+    hasExpressionSprites,
+  );
+  const hasLivePortrait = resolvedMotionMode === 'liveportrait';
+  const portraitEmotion = resolvedMotionMode === 'expressions' ? latestEmotion : null;
 
   useEffect(() => {
     fetchCharacters();
@@ -241,8 +255,8 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
                   />
                 ) : (
                   <img
-                    key={`${selectedCharacter.avatar}-${latestEmotion ?? 'neutral'}`}
-                    src={getFullImageUrl(selectedCharacter.avatar, latestEmotion)}
+                    key={`${selectedCharacter.avatar}-${portraitEmotion ?? 'neutral'}`}
+                    src={getFullImageUrl(selectedCharacter.avatar, portraitEmotion)}
                     alt={selectedCharacter.name}
                     className="w-full h-full object-cover transition-opacity duration-300"
                     onLoad={(e) => {
@@ -259,8 +273,17 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
                 )}
               </div>
 
+              {/* Motion mode picker */}
+              <div className="mt-3 w-full px-2">
+                <MotionModePicker
+                  avatar={selectedCharacter.avatar}
+                  hasLivePortraitClips={hasLivePortraitClips}
+                  hasExpressionSprites={hasExpressionSprites}
+                />
+              </div>
+
               {/* Character Info */}
-              <div className="mt-4 text-center w-full px-2">
+              <div className="mt-3 text-center w-full px-2">
                 <h3 className="text-lg font-semibold text-[var(--color-text-primary)]">
                   {selectedCharacter.name}
                 </h3>

--- a/src/stores/motionModeStore.ts
+++ b/src/stores/motionModeStore.ts
@@ -1,0 +1,42 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export type MotionMode = 'auto' | 'none' | 'expressions' | 'liveportrait';
+
+interface MotionModeState {
+  modesByAvatar: Record<string, MotionMode>;
+  setMode: (avatar: string, mode: MotionMode) => void;
+  getMode: (avatar: string) => MotionMode;
+}
+
+export const useMotionModeStore = create<MotionModeState>()(
+  persist(
+    (set, get) => ({
+      modesByAvatar: {},
+      setMode(avatar, mode) {
+        set((s) => ({ modesByAvatar: { ...s.modesByAvatar, [avatar]: mode } }));
+      },
+      getMode(avatar) {
+        return get().modesByAvatar[avatar] ?? 'auto';
+      },
+    }),
+    { name: 'st-mobile-motion-mode', version: 1 },
+  ),
+);
+
+export type ResolvedMotionMode = 'none' | 'expressions' | 'liveportrait';
+
+export function resolveMotionMode(
+  mode: MotionMode,
+  hasLivePortraitClips: boolean,
+  hasExpressionSprites: boolean,
+): ResolvedMotionMode {
+  if (mode === 'auto') {
+    if (hasLivePortraitClips) return 'liveportrait';
+    if (hasExpressionSprites) return 'expressions';
+    return 'none';
+  }
+  if (mode === 'liveportrait') return hasLivePortraitClips ? 'liveportrait' : 'none';
+  if (mode === 'expressions') return hasExpressionSprites ? 'expressions' : 'none';
+  return 'none';
+}


### PR DESCRIPTION
## Summary

Adds a small 4-segment picker so users can choose how each character's avatar reacts to detected emotions. Picker mounts under the avatar in the desktop sidebar and at the bottom of the mobile portrait pane.

- **Auto** (default) — picks the best available: Live Portrait clips → expression sprites → none.
- **Expressions** — emotion-based sprite swapping (disabled with a tooltip if no sprites are uploaded).
- **Live Portrait** — animated clips (disabled with a tooltip if no clips have been generated).
- **None** — static default avatar; disables emotion-driven swapping for this character everywhere it appears.

State is per-character (keyed by avatar filename) and persisted to localStorage. Resolved mode gates the mobile portrait, desktop sidebar portrait, VN sprite layer, and inline message avatars for the selected character.

## Test plan

- [x] `npm run build` is green
- [x] Picker renders on desktop sidebar (under the avatar) and mobile portrait (overlay at bottom)
- [x] Disabled options show explanatory tooltips
- [x] Selection persists in localStorage under `st-mobile-motion-mode`
- [x] Picker reflects state across both mounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)