### PR TITLE
chore: rename repo references to goodgirlsbotclub

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 ## Current State Summary
 
-**sillytavern-mobile** is a React/Vite/Zustand web app with:
+**goodgirlsbotclub** is a React/Vite/Zustand web app with:
 - Basic auth (login/register, multi-user)
 - Character CRUD + import/export (PNG Card V2, JSON)
 - Single & group chat with streaming (SSE)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     # on its single vCPU. If you need a local image for dev, uncomment `build: .`
     # below — docker compose will prefer a registry pull unless you run
     # `docker compose build` explicitly.
-    image: ghcr.io/sammygallo/sillytavern-mobile:latest
+    image: ghcr.io/sammygallo/goodgirlsbotclub:latest
     # build: .
     ports:
       - "${PORT:-80}:80"


### PR DESCRIPTION
## Summary

Companion to the GitHub repo rename from `sillytavern-mobile` to `goodgirlsbotclub`.

- `docker-compose.yml`: GHCR image updated to `ghcr.io/sammygallo/goodgirlsbotclub:latest`
- `ROADMAP.md`: project name in summary line

The `docker-publish.yml` workflow already uses `${{ github.repository }}` so it auto-tracks the new repo name — no change needed there. After merge, the next workflow run will publish to the new GHCR package.

## Test plan
- [x] Renamed repo on GitHub (auto-redirects from old URL)
- [x] Local origin remote auto-updated
- [ ] After merge, new GHCR image publishes at `ghcr.io/sammygallo/goodgirlsbotclub:latest`
- [ ] Droplet pulls new image and runs cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)