### PR TITLE
fix(persona): show avatar on user messages and clamp selector dropdown to viewport

### DIFF
--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -1470,7 +1470,7 @@ export function ChatView() {
               const useEmotionForThisMsg =
                 charAvatar === selectedCharacter?.avatar ? expressionsActive : true;
               const messageAvatar = message.isUser
-                ? undefined
+                ? displayPersona?.avatarDataUrl
                 : charAvatar
                   ? getAvatarUrl(charAvatar, useEmotionForThisMsg ? message.emotion : null)
                   : undefined;

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
-import { BookOpen, Download, HelpCircle, Key, Menu, Settings, LogOut, Pencil, UserCircle } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import { BookOpen, Download, HelpCircle, Key, Menu, MoreVertical, Settings, LogOut, Pencil, UserCircle } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useAuthStore } from '../../stores/authStore';
 import { useSettingsPanelStore } from '../../stores/settingsPanelStore';
@@ -28,9 +28,27 @@ export function Header({ onMenuClick }: HeaderProps) {
   const { canInstall, install: installPwa } = usePwaInstall();
   const [showEditModal, setShowEditModal] = useState(false);
   const [showHelp, setShowHelp] = useState(false);
+  const [overflowOpen, setOverflowOpen] = useState(false);
+  const overflowRef = useRef<HTMLDivElement>(null);
   const [convertToPersonaData, setConvertToPersonaData] = useState<
     { name: string; description: string } | null
   >(null);
+
+  useEffect(() => {
+    if (!overflowOpen) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (overflowRef.current && !overflowRef.current.contains(e.target as Node)) {
+        setOverflowOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [overflowOpen]);
+
+  const runAndCloseOverflow = (action: () => void) => {
+    setOverflowOpen(false);
+    action();
+  };
 
   const handleConvertToPersona = (character: CharacterInfo) => {
     const desc =
@@ -74,7 +92,7 @@ export function Header({ onMenuClick }: HeaderProps) {
               <Button
                 variant="ghost"
                 size="sm"
-                className="p-2"
+                className="p-2 flex-shrink-0"
                 aria-label="Edit character"
                 onClick={() => setShowEditModal(true)}
               >
@@ -88,7 +106,7 @@ export function Header({ onMenuClick }: HeaderProps) {
       </div>
 
       {/* User Menu */}
-      <div className="flex items-center gap-1">
+      <div className="flex items-center gap-1 flex-shrink-0">
 
         {canInstall && (
           <Button
@@ -102,66 +120,139 @@ export function Header({ onMenuClick }: HeaderProps) {
           </Button>
         )}
         <PersonaSelector />
-        {canViewGuides && (
+
+        {/* Below sm the secondary actions collapse into a kebab so the row
+            doesn't bleed off the right edge of narrow viewports. */}
+        <div className="hidden sm:contents">
+          {canViewGuides && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="p-2"
+              aria-label="Guides"
+              onClick={() => useGuidesPanelStore.getState().open()}
+            >
+              <BookOpen size={20} />
+            </Button>
+          )}
           <Button
             variant="ghost"
             size="sm"
             className="p-2"
-            aria-label="Guides"
-            onClick={() => useGuidesPanelStore.getState().open()}
+            aria-label="Help"
+            onClick={() => setShowHelp(true)}
           >
-            <BookOpen size={20} />
+            <HelpCircle size={20} />
           </Button>
-        )}
-        <Button
-          variant="ghost"
-          size="sm"
-          className="p-2"
-          aria-label="Help"
-          onClick={() => setShowHelp(true)}
-        >
-          <HelpCircle size={20} />
-        </Button>
-        {canViewSettings && (
+          {canViewSettings && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="p-2"
+              aria-label="Settings"
+              onClick={() => useSettingsPanelStore.getState().open()}
+            >
+              <Settings size={20} />
+            </Button>
+          )}
+          {!canViewSettings && can(userRole, 'settings:personal') && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="p-2"
+              aria-label="My API Keys"
+              onClick={() => useSettingsPanelStore.getState().openToPage('my-keys')}
+            >
+              <Key size={20} />
+            </Button>
+          )}
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => navigate('/profile')}
+            className="p-2"
+            aria-label="Profile"
+          >
+            <UserCircle size={20} />
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={logout}
+            className="p-2"
+            aria-label="Logout"
+          >
+            <LogOut size={20} />
+          </Button>
+        </div>
+
+        {/* Mobile-only overflow menu */}
+        <div ref={overflowRef} className="relative sm:hidden">
           <Button
             variant="ghost"
             size="sm"
             className="p-2"
-            aria-label="Settings"
-            onClick={() => useSettingsPanelStore.getState().open()}
+            aria-label="More actions"
+            aria-expanded={overflowOpen}
+            onClick={() => setOverflowOpen((o) => !o)}
           >
-            <Settings size={20} />
+            <MoreVertical size={20} />
           </Button>
-        )}
-        {!canViewSettings && can(userRole, 'settings:personal') && (
-          <Button
-            variant="ghost"
-            size="sm"
-            className="p-2"
-            aria-label="My API Keys"
-            onClick={() => useSettingsPanelStore.getState().openToPage('my-keys')}
-          >
-            <Key size={20} />
-          </Button>
-        )}
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => navigate('/profile')}
-          className="p-2"
-          aria-label="Profile"
-        >
-          <UserCircle size={20} />
-        </Button>
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={logout}
-          className="p-2"
-          aria-label="Logout"
-        >
-          <LogOut size={20} />
-        </Button>
+          {overflowOpen && (
+            <div className="fixed right-2 top-[3.75rem] w-[calc(100vw-1rem)] max-h-[calc(100vh-4.5rem)] bg-[var(--color-bg-secondary)] border border-[var(--color-border)] rounded-lg shadow-xl overflow-hidden z-50 flex flex-col">
+              <div className="overflow-y-auto py-1">
+                {canViewGuides && (
+                  <button
+                    onClick={() => runAndCloseOverflow(() => useGuidesPanelStore.getState().open())}
+                    className="w-full flex items-center gap-3 px-4 py-3 text-sm text-[var(--color-text-primary)] hover:bg-[var(--color-bg-tertiary)]"
+                  >
+                    <BookOpen size={18} className="text-[var(--color-text-secondary)]" />
+                    Guides
+                  </button>
+                )}
+                <button
+                  onClick={() => runAndCloseOverflow(() => setShowHelp(true))}
+                  className="w-full flex items-center gap-3 px-4 py-3 text-sm text-[var(--color-text-primary)] hover:bg-[var(--color-bg-tertiary)]"
+                >
+                  <HelpCircle size={18} className="text-[var(--color-text-secondary)]" />
+                  Help
+                </button>
+                {canViewSettings && (
+                  <button
+                    onClick={() => runAndCloseOverflow(() => useSettingsPanelStore.getState().open())}
+                    className="w-full flex items-center gap-3 px-4 py-3 text-sm text-[var(--color-text-primary)] hover:bg-[var(--color-bg-tertiary)]"
+                  >
+                    <Settings size={18} className="text-[var(--color-text-secondary)]" />
+                    Settings
+                  </button>
+                )}
+                {!canViewSettings && can(userRole, 'settings:personal') && (
+                  <button
+                    onClick={() => runAndCloseOverflow(() => useSettingsPanelStore.getState().openToPage('my-keys'))}
+                    className="w-full flex items-center gap-3 px-4 py-3 text-sm text-[var(--color-text-primary)] hover:bg-[var(--color-bg-tertiary)]"
+                  >
+                    <Key size={18} className="text-[var(--color-text-secondary)]" />
+                    My API Keys
+                  </button>
+                )}
+                <button
+                  onClick={() => runAndCloseOverflow(() => navigate('/profile'))}
+                  className="w-full flex items-center gap-3 px-4 py-3 text-sm text-[var(--color-text-primary)] hover:bg-[var(--color-bg-tertiary)]"
+                >
+                  <UserCircle size={18} className="text-[var(--color-text-secondary)]" />
+                  Profile
+                </button>
+                <button
+                  onClick={() => runAndCloseOverflow(logout)}
+                  className="w-full flex items-center gap-3 px-4 py-3 text-sm text-[var(--color-text-primary)] hover:bg-[var(--color-bg-tertiary)] border-t border-[var(--color-border)]"
+                >
+                  <LogOut size={18} className="text-[var(--color-text-secondary)]" />
+                  Logout
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
       </div>
 
       {/* Character Edit Modal */}

--- a/src/components/persona/PersonaSelector.tsx
+++ b/src/components/persona/PersonaSelector.tsx
@@ -62,8 +62,8 @@ export function PersonaSelector({ className = '' }: PersonaSelectorProps) {
         </button>
 
         {isOpen && (
-          <div className="absolute right-0 top-full mt-1 min-w-[240px] bg-[var(--color-bg-secondary)] border border-[var(--color-border)] rounded-lg shadow-xl overflow-hidden z-50">
-            <div className="px-3 py-2 text-xs font-medium text-[var(--color-text-secondary)] border-b border-[var(--color-border)]">
+          <div className="fixed right-2 top-[3.75rem] w-[calc(100vw-1rem)] max-h-[calc(100vh-4.5rem)] sm:absolute sm:right-0 sm:top-full sm:mt-1 sm:w-auto sm:min-w-[240px] sm:max-w-[calc(100vw-1rem)] bg-[var(--color-bg-secondary)] border border-[var(--color-border)] rounded-lg shadow-xl overflow-hidden z-50 flex flex-col">
+            <div className="px-3 py-2 text-xs font-medium text-[var(--color-text-secondary)] border-b border-[var(--color-border)] flex-shrink-0">
               Persona
             </div>
             {personas.length === 0 ? (
@@ -79,7 +79,7 @@ export function PersonaSelector({ className = '' }: PersonaSelectorProps) {
                 </button>
               </div>
             ) : (
-              <ul className="max-h-[300px] overflow-y-auto">
+              <ul className="flex-1 min-h-0 max-h-[300px] overflow-y-auto">
                 {personas.map((persona) => {
                   const isActive = persona.id === activePersonaId;
                   return (
@@ -117,7 +117,7 @@ export function PersonaSelector({ className = '' }: PersonaSelectorProps) {
               </ul>
             )}
 
-            <div className="border-t border-[var(--color-border)]">
+            <div className="border-t border-[var(--color-border)] flex-shrink-0">
               {activePersonaId && (
                 <button
                   onClick={() => handleSelect(null)}


### PR DESCRIPTION
## Summary
Implements #199. User reported two persona-display bugs; review surfaced two more header overflow issues that share the same UX context, all bundled here.

**Persona display (original report)**
- **User messages had no avatar.** `ChatView` hard-coded `messageAvatar = undefined` for any `message.isUser`, so the active persona's image never appeared next to the user's chat bubble. Now passes `displayPersona?.avatarDataUrl` (the same value the PersonaSelector header button renders).
- **PersonaSelector dropdown was cut off on mobile.** It was anchored `absolute right-0` to a button in the middle of the header's right-side icon row, and its `min-w-[240px]` width extended off the LEFT edge of the viewport on phones. Switched to viewport-fixed positioning under the header at small breakpoints, kept the original `sm:absolute sm:right-0` anchor on tablet+, and bounded max-height with `flex-col` so the bottom action buttons stay visible.

**Header overflow (surfaced during review)**
- **Logout bled off the right edge** on narrow viewports. The right-side icon row (Persona, Guides, Help, Settings, Profile, Logout, plus optional Download) had no breakpoint-based collapse.
- **Pencil edit icon overlapped the persona button** because the character-info section's `flex-1` squeezed the pencil under its right neighbor.
- Wrapped Guides/Help/Settings/My-Keys/Profile/Logout in `hidden sm:contents` so they only render inline at `sm+`, and added a `MoreVertical` kebab that's `sm:hidden` and opens a viewport-fixed menu (same positioning approach as the PersonaSelector mobile dropdown). Added `flex-shrink-0` to the pencil and the right-side group.

## Test plan
- [x] Local `npm run build` passes
- [x] Mobile (375×812): persona dropdown opens fully within viewport; header row no longer overflows; kebab opens with all 5 secondary actions
- [x] Desktop: persona dropdown still anchors to button right edge; all icons inline (no kebab)
- [x] Persona avatar verified on multiple user messages, both bubbles layout
- [ ] Reviewer test: long persona names, real phone, all role tiers (admin sees Settings; end_user with personal-keys perm sees the Key icon)

🤖 Draft opened by the build-next-issue skill. Human review required before merge.