### PR TITLE
feat: add character preview modal before entering chat

### DIFF
--- a/src/components/character/CharacterPreviewModal.tsx
+++ b/src/components/character/CharacterPreviewModal.tsx
@@ -1,0 +1,160 @@
+import { MessageCircle, Tag } from 'lucide-react';
+import { Modal, Button } from '../ui';
+import type { CharacterInfo } from '../../api/client';
+
+interface CharacterPreviewModalProps {
+  isOpen: boolean;
+  character: CharacterInfo | null;
+  onClose: () => void;
+  onStartChat: (avatar: string) => void;
+}
+
+/**
+ * Read-only preview of a character's details — surfaced before the user
+ * commits to opening a chat. Lets users browse the description, scenario,
+ * personality, first message and tags without entering the chat view first.
+ *
+ * Triggered from the character list (sidebar) by the per-row info button;
+ * not used from any flow that already has the character loaded.
+ */
+export function CharacterPreviewModal({
+  isOpen,
+  character,
+  onClose,
+  onStartChat,
+}: CharacterPreviewModalProps) {
+  if (!character) return null;
+
+  // Prefer the canonical CharacterInfo fields, falling back to nested
+  // `data.*` for V2 cards that only populated the spec-shape copy.
+  const description =
+    character.description?.trim() || character.data?.description?.trim() || '';
+  const personality =
+    character.personality?.trim() || character.data?.personality?.trim() || '';
+  const scenario =
+    character.scenario?.trim() || character.data?.scenario?.trim() || '';
+  const firstMessage =
+    character.first_mes?.trim() || character.data?.first_mes?.trim() || '';
+  const creator =
+    character.creator?.trim() || character.data?.creator?.trim() || '';
+  const creatorNotes =
+    character.creator_notes?.trim() || character.data?.creator_notes?.trim() || '';
+  const tags = character.tags ?? character.data?.tags ?? [];
+
+  const fullAvatarUrl = `/characters/${encodeURIComponent(character.avatar)}`;
+
+  const handleStartChat = () => {
+    onStartChat(character.avatar);
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title={character.name} size="lg">
+      <div className="space-y-4">
+        {/* Avatar — full size so creator art reads properly */}
+        <div className="flex justify-center">
+          <img
+            src={fullAvatarUrl}
+            alt={character.name}
+            className="max-h-72 w-auto rounded-lg border border-[var(--color-border)] object-cover"
+          />
+        </div>
+
+        {/* Creator line */}
+        {creator && (
+          <p className="text-xs text-[var(--color-text-secondary)] text-center">
+            by {creator}
+            {character.character_version && ` · v${character.character_version}`}
+          </p>
+        )}
+
+        {/* Tags */}
+        {tags.length > 0 && (
+          <div className="flex flex-wrap gap-1.5">
+            <Tag size={14} className="text-[var(--color-text-secondary)] mt-0.5" />
+            {tags.map((tag) => (
+              <span
+                key={tag}
+                className="text-[11px] px-2 py-0.5 leading-5 bg-[var(--color-bg-tertiary)] text-[var(--color-text-secondary)] rounded-full border border-[var(--color-border)]"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        )}
+
+        {/* Description */}
+        {description && (
+          <PreviewSection label="Description" body={description} />
+        )}
+
+        {/* Personality */}
+        {personality && (
+          <PreviewSection label="Personality" body={personality} />
+        )}
+
+        {/* Scenario */}
+        {scenario && <PreviewSection label="Scenario" body={scenario} />}
+
+        {/* First message */}
+        {firstMessage && (
+          <PreviewSection label="First message" body={firstMessage} />
+        )}
+
+        {/* Creator notes */}
+        {creatorNotes && (
+          <PreviewSection label="Creator notes" body={creatorNotes} />
+        )}
+
+        {/* Empty-state — nothing meaningful to show */}
+        {!description &&
+          !personality &&
+          !scenario &&
+          !firstMessage &&
+          !creatorNotes && (
+            <p className="text-sm text-[var(--color-text-secondary)] italic text-center py-6">
+              This character doesn&apos;t have a description yet.
+            </p>
+          )}
+
+        {/* Actions */}
+        <div className="flex gap-3 pt-4 border-t border-[var(--color-border)]">
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={onClose}
+            className="flex-1"
+          >
+            Close
+          </Button>
+          <Button
+            type="button"
+            variant="primary"
+            onClick={handleStartChat}
+            className="flex-1"
+          >
+            <MessageCircle size={16} />
+            Chat with {character.name}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+interface PreviewSectionProps {
+  label: string;
+  body: string;
+}
+
+function PreviewSection({ label, body }: PreviewSectionProps) {
+  return (
+    <section className="space-y-1">
+      <h3 className="text-xs font-medium uppercase tracking-wide text-[var(--color-text-secondary)]">
+        {label}
+      </h3>
+      <p className="text-sm text-[var(--color-text-primary)] whitespace-pre-wrap break-words">
+        {body}
+      </p>
+    </section>
+  );
+}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -15,6 +15,7 @@ import {
   Filter,
   ArrowUpDown,
   Loader2,
+  Info,
 } from 'lucide-react';
 import { useCharacterStore } from '../../stores/characterStore';
 import { useChatStore, type GroupChatInfo } from '../../stores/chatStore';
@@ -24,6 +25,8 @@ import { haptic } from '../../utils/haptics';
 import { Avatar, Button, Input } from '../ui';
 import { CharacterCreation } from '../character/CharacterCreation';
 import { CharacterImport } from '../character/CharacterImport';
+import { CharacterPreviewModal } from '../character/CharacterPreviewModal';
+import type { CharacterInfo } from '../../api/client';
 import { useCharacterSprites } from '../../hooks/useCharacterSprites';
 import { getDefaultAvatarUrl, type Emotion } from '../../utils/emotions';
 import { LivePortraitVideo } from '../chat/LivePortraitVideo';
@@ -46,6 +49,7 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
   const [failedExpressions, setFailedExpressions] = useState<Set<string>>(new Set());
   const [isGroupSelectMode, setIsGroupSelectMode] = useState(false);
   const [showFilters, setShowFilters] = useState(false);
+  const [previewCharacter, setPreviewCharacter] = useState<CharacterInfo | null>(null);
   const {
     selectedCharacter,
     isLoading,
@@ -579,20 +583,34 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
                             </div>
                           </button>
                           {!isGroupSelectMode && (
-                            <button
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                toggleFavorite(character.avatar);
-                              }}
-                              className={`p-2 mr-2 rounded-lg transition-opacity ${
-                                isFav
-                                  ? 'text-yellow-400 opacity-100'
-                                  : 'text-[var(--color-text-secondary)] opacity-0 group-hover:opacity-100 hover:text-yellow-400'
-                              }`}
-                              title={isFav ? 'Unfavorite' : 'Favorite'}
-                            >
-                              <Star size={16} fill={isFav ? 'currentColor' : 'none'} />
-                            </button>
+                            <>
+                              <button
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  haptic();
+                                  setPreviewCharacter(character);
+                                }}
+                                className="p-2 rounded-lg text-[var(--color-text-secondary)] opacity-0 group-hover:opacity-100 hover:text-[var(--color-primary)] transition-opacity"
+                                title={`Preview ${character.name}`}
+                                aria-label={`Preview ${character.name}`}
+                              >
+                                <Info size={16} />
+                              </button>
+                              <button
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  toggleFavorite(character.avatar);
+                                }}
+                                className={`p-2 mr-2 rounded-lg transition-opacity ${
+                                  isFav
+                                    ? 'text-yellow-400 opacity-100'
+                                    : 'text-[var(--color-text-secondary)] opacity-0 group-hover:opacity-100 hover:text-yellow-400'
+                                }`}
+                                title={isFav ? 'Unfavorite' : 'Favorite'}
+                              >
+                                <Star size={16} fill={isFav ? 'currentColor' : 'none'} />
+                              </button>
+                            </>
                           )}
                         </div>
                       </li>
@@ -708,6 +726,18 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
         isOpen={showImportModal}
         onClose={() => setShowImportModal(false)}
         onImported={handleCharacterImported}
+      />
+
+      {/* Character Preview Modal — read-only details view shown before
+          committing to opening a chat. Triggered by the per-row info button. */}
+      <CharacterPreviewModal
+        isOpen={previewCharacter !== null}
+        character={previewCharacter}
+        onClose={() => setPreviewCharacter(null)}
+        onStartChat={(avatar) => {
+          setPreviewCharacter(null);
+          handleCharacterSelect(avatar);
+        }}
       />
     </>
   );


### PR DESCRIPTION
## Summary
Implements #207.

- New `CharacterPreviewModal` component renders a read-only details view: full-size avatar, tags, description, personality, scenario, first message, creator notes, plus a "Chat with [name]" CTA that forwards to the existing select-character path.
- Sidebar character rows pick up an info button (eye icon, opacity-0 → 1 on hover, mirroring the favorite-star behavior) that opens the modal. Group-select mode hides the button to keep that flow uncluttered.
- No changes to data flow — the modal reuses `selectCharacter` and the existing `handleCharacterSelect` handler when the user commits.

## Test plan
- [x] Local `npm run build` passes (already verified)
- [ ] Reviewer hovers a character row, clicks the info icon, confirms the preview modal renders all fields the card has (description, personality, scenario, first message, tags, creator notes)
- [ ] "Chat with [name]" closes the preview AND opens the chat (single tap path, no double-modal)
- [ ] Cards with very long descriptions render scrollable content inside the modal (Modal already handles its own scroll)
- [ ] Group-select mode does not show the info button (so it doesn't hijack the multi-select flow)
- [ ] Empty / sparse cards (no description) show the friendly empty-state line

🤖 Draft opened by the build-next-issue skill. Human review required before merge.