### PR TITLE
feat: support HTML/CSS in character info blurbs

### DIFF
--- a/src/components/character/CharacterPreviewModal.tsx
+++ b/src/components/character/CharacterPreviewModal.tsx
@@ -1,5 +1,6 @@
 import { MessageCircle, Tag } from 'lucide-react';
 import { Modal, Button } from '../ui';
+import { CharacterRichText } from './CharacterRichText';
 import type { CharacterInfo } from '../../api/client';
 
 interface CharacterPreviewModalProps {
@@ -152,9 +153,7 @@ function PreviewSection({ label, body }: PreviewSectionProps) {
       <h3 className="text-xs font-medium uppercase tracking-wide text-[var(--color-text-secondary)]">
         {label}
       </h3>
-      <p className="text-sm text-[var(--color-text-primary)] whitespace-pre-wrap break-words">
-        {body}
-      </p>
+      <CharacterRichText content={body} />
     </section>
   );
 }

--- a/src/components/character/CharacterRichText.tsx
+++ b/src/components/character/CharacterRichText.tsx
@@ -1,0 +1,99 @@
+import { useMemo } from 'react';
+import DOMPurify from 'dompurify';
+
+interface CharacterRichTextProps {
+  /** The raw character field content. May contain HTML/CSS markup. */
+  content: string;
+  /** Tailwind classes for the wrapper. Defaults match the regular preview text. */
+  className?: string;
+}
+
+// Tags that creators reasonably reach for when styling a character blurb:
+// inline formatting, headings, lists, quotes, simple typography, plus img
+// for illustrations. Deliberately omits script/iframe/embed/object/link/meta
+// (XSS surface) and form/input/button (interactive controls that don't
+// belong inside a read-only preview).
+const ALLOWED_TAGS = [
+  'p', 'br', 'strong', 'b', 'em', 'i', 'u', 'del', 's', 'small', 'mark',
+  'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+  'ul', 'ol', 'li',
+  'blockquote', 'pre', 'code',
+  'a', 'div', 'span', 'section', 'article',
+  'table', 'thead', 'tbody', 'tr', 'th', 'td', 'caption',
+  'hr', 'sub', 'sup',
+  'img', 'figure', 'figcaption',
+];
+
+// `style` lets creators colour text and pull off the visual flair the issue
+// is asking for; DOMPurify sanitises the CSS inside it (strips expression(),
+// behavior:, javascript:/data: URLs, @import, etc.). `class` is mostly inert
+// in our app (Tailwind classes need source compilation) but we keep it so
+// creators porting blurbs from other sites don't end up with naked text.
+const ALLOWED_ATTR = [
+  'href', 'title', 'target', 'rel',
+  'class', 'style',
+  'src', 'alt', 'width', 'height', 'loading',
+  'colspan', 'rowspan',
+];
+
+// Add a hook so any anchor that survives the sanitiser opens safely. Safe to
+// register at module scope — DOMPurify deduplicates identical hooks and our
+// chat MarkdownContent already registers the same one with the same body.
+DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+  if (node.tagName === 'A') {
+    node.setAttribute('target', '_blank');
+    node.setAttribute('rel', 'noopener noreferrer');
+  }
+});
+
+const SANITIZE_CONFIG = {
+  ALLOWED_TAGS,
+  ALLOWED_ATTR,
+  // Keep relative URLs intact; block the obvious dangerous schemes.
+  ALLOWED_URI_REGEXP: /^(?:(?:https?|mailto|tel|data:image\/(?:png|jpe?g|gif|webp|svg\+xml));|[^a-z]|[a-z+.-]+(?:[^a-z+.\-:]|$))/i,
+};
+
+/** Heuristic: does `content` contain any HTML-looking markup? Anything that
+ *  starts with `<letter` or `</letter` counts. We use this to keep plain-text
+ *  blurbs rendering identically to before — only blurbs that opted into HTML
+ *  go through the sanitiser. */
+function looksLikeHtml(content: string): boolean {
+  return /<\/?[a-zA-Z]/.test(content);
+}
+
+/**
+ * Render a character-info field that may contain HTML/CSS markup. Plain text
+ * falls through to a `whitespace-pre-wrap` paragraph so existing characters
+ * look identical. HTML content is sanitised via DOMPurify (no scripts, no
+ * iframes, no event handlers) and rendered inside an isolated container that
+ * prevents the character's CSS from leaking into the rest of the app.
+ *
+ * Surface area is intentionally limited to the read-only preview so that a
+ * malicious card can't intercept clicks on chat controls or persona forms —
+ * the worst it can do is style itself badly inside its own preview pane.
+ */
+export function CharacterRichText({ content, className }: CharacterRichTextProps) {
+  const sanitized = useMemo(() => {
+    if (!content) return '';
+    if (!looksLikeHtml(content)) return null;
+    return DOMPurify.sanitize(content, SANITIZE_CONFIG) as string;
+  }, [content]);
+
+  const baseClass =
+    'text-sm text-[var(--color-text-primary)] whitespace-pre-wrap break-words';
+  const cls = className ? `${baseClass} ${className}` : baseClass;
+
+  if (sanitized === null) {
+    // Plain text — keep existing rendering exactly as it was.
+    return <p className={cls}>{content}</p>;
+  }
+
+  // HTML content. `character-rich` provides the isolation/containment that
+  // keeps creator CSS scoped to its own pane (see index.css).
+  return (
+    <div
+      className={`${cls} character-rich`}
+      dangerouslySetInnerHTML={{ __html: sanitized }}
+    />
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -519,3 +519,77 @@ body {
     animation: none;
   }
 }
+
+/*
+ * Character-info rich content (#208) — creators may use HTML/CSS in
+ * description / personality / scenario fields to style their blurbs. The
+ * content is sanitised via DOMPurify (no scripts/iframes/handlers) but the
+ * CSS they ship can still try to escape into the rest of the page. Three
+ * defences live here:
+ *   - `contain: layout paint` and `isolation` keep their layout / stacking
+ *     context locked to this box.
+ *   - `overflow: hidden` clips anything that tries to render outside the
+ *     pane (banner overlays, position:fixed elements promoted via the
+ *     containment block, etc.).
+ *   - `max-width: 100%` and `overflow-wrap` stop wide content from
+ *     blowing out the modal column on small screens.
+ * The nested rules give plain HTML reasonable defaults so unstyled tags
+ * still look intentional inside the preview.
+ */
+.character-rich {
+  contain: layout paint;
+  isolation: isolate;
+  overflow: hidden;
+  max-width: 100%;
+  overflow-wrap: break-word;
+}
+.character-rich img {
+  max-width: 100%;
+  height: auto;
+}
+.character-rich a {
+  color: var(--color-primary);
+  text-decoration: underline;
+}
+.character-rich h1,
+.character-rich h2,
+.character-rich h3,
+.character-rich h4,
+.character-rich h5,
+.character-rich h6 {
+  margin: 0.4em 0 0.2em;
+  font-weight: 600;
+  line-height: 1.25;
+}
+.character-rich h1 { font-size: 1.3em; }
+.character-rich h2 { font-size: 1.2em; }
+.character-rich h3 { font-size: 1.1em; }
+.character-rich p {
+  margin: 0 0 0.6em;
+}
+.character-rich p:last-child {
+  margin-bottom: 0;
+}
+.character-rich ul,
+.character-rich ol {
+  margin: 0.4em 0;
+  padding-left: 1.4em;
+}
+.character-rich blockquote {
+  margin: 0.6em 0;
+  padding: 0.4em 0.8em;
+  border-left: 3px solid var(--color-border);
+  color: var(--color-text-secondary);
+}
+.character-rich code {
+  padding: 0.1em 0.3em;
+  border-radius: 4px;
+  background: var(--color-bg-tertiary);
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 0.9em;
+}
+.character-rich hr {
+  margin: 0.8em 0;
+  border: none;
+  border-top: 1px solid var(--color-border);
+}


### PR DESCRIPTION
## Summary
Implements #208. Replaces #211 (auto-closed when its base branch was deleted on merge of #210).

- New `CharacterRichText` component renders character info fields with HTML/CSS support, sanitised via DOMPurify. Plain-text descriptions render identically to before — only blurbs that opt into HTML go through the sanitiser.
- Wired into `CharacterPreviewModal`'s `PreviewSection` (the preview from #207) for description, personality, scenario, first message and creator notes.
- Added `.character-rich` styles in `index.css` with `contain: layout paint`, `isolation: isolate`, `overflow: hidden` so creator CSS can only style its own preview pane — it can't overlay chat controls, sidebars, or modals.

## Security notes
- **Disallowed tags:** script, iframe, object, embed, link, meta, form, input, button, video, audio.
- **Allowed tags:** common formatting + img/figure + tables + headings/lists/blockquote.
- **Allowed attributes:** href/title/target/rel, class, style, src/alt/width/height/loading, colspan/rowspan.
- **`style` attribute:** allowed. DOMPurify sanitises CSS inside it (strips `expression()`, `behavior:`, `javascript:` URLs, `@import`, etc.).
- **URI scheme allowlist:** https, mailto, tel, data:image (png/jpeg/gif/webp/svg+xml). javascript:/vbscript:/file: blocked.
- **Event handlers:** all `on*` attributes blocked (DOMPurify default).

## Test plan
- [x] Rebased onto current main (post #210), local `npm run build` passes
- [ ] Reviewer imports a card whose description contains `<strong style="color:red">test</strong>` and confirms it renders red+bold inside the preview
- [ ] Reviewer imports a card with `<script>alert('xss')</script>` in the description and confirms NO alert fires
- [ ] Plain-text descriptions render unchanged
- [ ] `<style>` tag is stripped (not in allowlist)
- [ ] `style="position:fixed; inset:0; background:red"` only colours the inside of the preview pane, not the page

🤖 Re-opened as part of the deploy sequence after #211 was auto-closed by the base-branch deletion.