### PR TITLE
feat: server-sync display and speech preferences across devices

### DIFF
--- a/docs/v2/ROADMAP.md
+++ b/docs/v2/ROADMAP.md
@@ -147,6 +147,118 @@ subscriptions
 
 **Why `character_instances` is the load-bearing table:** per-user memory, affinity score (gates "character sends you a friend request"), and privacy all live here. `characters` is the published/imported asset; `character_instances` is what *you* experience. This split is what lets a future public feed and present-day private chat coexist without a schema rewrite.
 
+### Deferred local-storage items — schema additions for Phase 1
+
+These are currently stored in browser `localStorage` and synced via the v1 settings blob as a stopgap. Full server-side storage requires the tables below; all are Phase 1 deliverables unless marked otherwise.
+
+```sql
+-- World Info / Lore books (replaces sillytavern_worldinfo_* localStorage keys)
+lorebooks
+  id, user_id, name, description,
+  auto_extracted (bool),           -- auto-built from character card
+  owner_character_avatar,          -- which character owns it, if any
+  created_at, updated_at
+
+lorebook_entries
+  id, lorebook_id,
+  keys (text[]),                   -- trigger keywords
+  content (text),
+  enabled (bool),
+  case_sensitive (bool), whole_word (bool),
+  priority (int),
+  position ('before_char' | 'after_char' | 'depth'), depth (int),
+  role ('system' | 'user' | 'assistant'),
+  -- cooldown / sticky / delay state (v1: sillytavern_wi_timers_v1)
+  cooldown_turns (int), sticky_turns (int), delay_turns (int),
+  created_at
+
+lorebook_chat_links           -- chat-scoped active book overrides
+  id, user_id, chat_id, lorebook_id
+  UNIQUE(user_id, chat_id, lorebook_id)
+
+-- Personas (replaces sillytavern_personas_v2 localStorage key)
+-- `personas` table is already in the schema sketch above with avatar_url.
+-- Add to existing `personas` table:
+--   description_position ('before_char' | 'after_char' | 'depth')
+--   description_depth (int)
+--   description_role ('system' | 'user' | 'assistant')
+--   linked_lorebook_ids (int[])   -- FK to lorebooks
+
+persona_locks                 -- per-character / per-chat persona overrides
+  id, user_id,
+  lock_type ('character' | 'chat'),
+  target_key (text),               -- avatar filename or chat_id
+  persona_id (int, FK personas)
+
+-- Chat history RAG embeddings (replaces stm:chat-history-rag localStorage key)
+-- pgvector extension required; included in Phase 1 stack decision.
+message_embeddings
+  id, message_id (FK messages), embedding (vector(1536))
+  INDEX USING ivfflat (embedding vector_cosine_ops)
+-- Note: ~6 KB per message in localStorage → <200 bytes stored in pgvector.
+-- Significant localStorage relief for power users.
+
+-- Data Bank documents (replaces stm:data-bank localStorage key)
+data_bank_documents
+  id, user_id,
+  name (text),
+  scope ('global' | 'character'),
+  character_avatar (text),         -- null when scope = global
+  content (text),
+  is_embedded (bool),
+  created_at
+
+data_bank_chunks
+  id, document_id (FK data_bank_documents),
+  chunk_text (text),
+  embedding (vector(1536))
+  INDEX USING ivfflat (embedding vector_cosine_ops)
+
+-- Image generation gallery (replaces sillytavern_imagegen_gallery localStorage key)
+-- Images move to R2; table holds metadata only.
+image_gen_gallery
+  id, user_id,
+  r2_key (text),                   -- Cloudflare R2 object key
+  prompt (text),
+  backend (text),
+  model (text),
+  width (int), height (int),
+  created_at
+-- Note: base64 data URLs currently bloat localStorage by MB; R2 fixes that.
+
+-- Regex scripts (replaces sillytavern_regex_scripts localStorage key)
+regex_scripts
+  id, user_id,
+  name (text),
+  find_pattern (text),
+  replace_with (text),
+  match_case (bool), is_regex (bool), is_enabled (bool),
+  sort_order (int),
+  created_at
+
+-- VN backgrounds per character (replaces stm:vn-bg-* localStorage keys)
+-- Images move to R2; reference stored on character_instances.
+-- Add to character_instances:
+--   vn_bg_r2_key (text)           -- per-user VN background for this character
+-- Global VN background: add to users table or a user_settings jsonb column.
+
+-- Author notes per chat (replaces sillytavern_author_notes localStorage key)
+-- Add to chats table:
+--   author_note_content (text)
+--   author_note_depth (int)
+--   author_note_role ('system' | 'user' | 'assistant')
+
+-- Chat variables (replaces stm:chat-vars localStorage key)
+-- Add to chats table:
+--   variables (jsonb)             -- {[varName]: value}
+```
+
+**Migration path from v1 localStorage:**
+- On first v2 login, the client reads each localStorage key and POSTs to a `/api/v2/migrate/local-storage` endpoint that populates the tables above in a single transaction.
+- Embeddings are re-computed server-side (client-side vectors from OpenAI JS SDK are discarded).
+- Base64 image galleries and VN backgrounds are uploaded to R2 during migration, then the localStorage keys are cleared.
+- The migration runs once and is idempotent (guarded by a `migrations` flag on the user record).
+
 ---
 
 ## Phasing

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -64,7 +64,6 @@ import {
   getChatFontSize,
   getChatMaxWidth,
   getVnMode,
-  setVnMode,
   getVnBgForCharacter,
   setVnBgForCharacter,
   clearVnBgForCharacter,
@@ -72,13 +71,15 @@ import {
   setVnBgGlobal,
   clearVnBgGlobal,
   getCostume,
-  setCostume,
-  clearCostume,
 } from '../../hooks/displayPreferences';
+import { useDisplayPreferencesStore } from '../../stores/displayPreferencesStore';
 import { fireSandboxLifecycleEvent } from '../../extensions/sandbox/sandboxEventBus';
 
 export function ChatView() {
   const routerNavigate = useNavigate();
+  const storeSetVnMode = useDisplayPreferencesStore(s => s.setVnMode);
+  const storeSetCostume = useDisplayPreferencesStore(s => s.setCostume);
+  const storeClearCostume = useDisplayPreferencesStore(s => s.clearCostume);
   const { selectedCharacter, isGroupChatMode, groupChatCharacters, exitGroupChat, characters: allCharacters } = useCharacterStore();
   const {
     messages,
@@ -747,7 +748,7 @@ export function ChatView() {
       // just chose. Without this, the upload would silently store the image
       // but render nothing because the bg <img> is gated on isVnMode.
       if (!getVnMode()) {
-        setVnMode(true);
+        storeSetVnMode(true);
         setIsVnModeState(true);
       }
     };
@@ -770,10 +771,10 @@ export function ChatView() {
   const handleSetCostume = useCallback((name: string) => {
     if (!selectedCharacter) return;
     if (name.trim()) {
-      setCostume(selectedCharacter.avatar, name.trim());
+      storeSetCostume(selectedCharacter.avatar, name.trim());
       setActiveCostumeState(name.trim());
     } else {
-      clearCostume(selectedCharacter.avatar);
+      storeClearCostume(selectedCharacter.avatar);
       setActiveCostumeState(null);
     }
   }, [selectedCharacter]);

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { ArrowLeft, BookOpen, ChevronRight, Database, Edit3, FileText, Image, Languages, Loader2, MessageSquare, Mic, Palette, Plus, Replace, Shield, Sliders, Sparkles, Trash2, UserPlus, Users, Volume2, Zap } from 'lucide-react';
 import { useSettingsPanelStore } from '../../stores/settingsPanelStore';
 import { useSettingsStore } from '../../stores/settingsStore';
@@ -7,38 +7,10 @@ import { useAuthStore } from '../../stores/authStore';
 import { hasPermission } from '../../utils/permissions';
 // PROVIDERS moved to AISettingsPage
 import { Button } from '../ui';
-import {
-  SPEECH_LANGUAGES,
-  getSpeechLanguage,
-  setSpeechLanguage,
-  getTtsVoiceUri,
-  setTtsVoiceUri,
-  getTtsRate,
-  setTtsRate,
-  getTtsPitch,
-  setTtsPitch,
-  getTtsAutoRead,
-  setTtsAutoRead,
-} from '../../hooks/speechLanguage';
-import {
-  getChatLayoutMode,
-  setChatLayoutMode,
-  getAvatarShape,
-  setAvatarShape,
-  getChatFontSize,
-  setChatFontSize,
-  getChatMaxWidth,
-  setChatMaxWidth,
-  getVnMode,
-  setVnMode,
-  getStandardizeMessageFormatting,
-  setStandardizeMessageFormatting,
-  getEnterToSendMode,
-  setEnterToSendMode,
-  type ChatLayoutMode,
-  type AvatarShape,
-  type EnterToSendMode,
-} from '../../hooks/displayPreferences';
+import { SPEECH_LANGUAGES } from '../../hooks/speechLanguage';
+import { type ChatLayoutMode, type AvatarShape, type EnterToSendMode } from '../../hooks/displayPreferences';
+import { useDisplayPreferencesStore } from '../../stores/displayPreferencesStore';
+import { useSpeechPreferencesStore } from '../../stores/speechPreferencesStore';
 import {
   THEME_PRESETS,
   PRESET_SWATCHES,
@@ -64,7 +36,6 @@ export function SettingsPage(_props?: { params?: Record<string, string> }) {
     clearMessages,
   } = useSettingsStore();
 
-  const [speechLang, setSpeechLangState] = useState<string>(() => getSpeechLanguage());
   const { isSupported: isSpeechSupported } = useSpeechRecognition();
 
   // Phase 7.4 + 6.1: Theme preferences (server-synced via themeStore)
@@ -77,22 +48,34 @@ export function SettingsPage(_props?: { params?: Record<string, string> }) {
   // Derived: built-in preset name for seeding the theme editor's base colors.
   const themePresetVal = (activePreset.startsWith('custom:') ? 'cyberpunk' : activePreset) as ThemePreset;
 
-  // Phase 7.3: Chat display preferences
-  const [layoutMode, setLayoutModeState] = useState<ChatLayoutMode>(() => getChatLayoutMode());
-  const [avatarShapePref, setAvatarShapeState] = useState<AvatarShape>(() => getAvatarShape());
-  const [fontSizePref, setFontSizeState] = useState<number>(() => getChatFontSize());
-  const [chatWidthPref, setChatWidthState] = useState<number>(() => getChatMaxWidth());
-  // Phase 6.4: VN mode
-  const [vnModeOn, setVnModeState] = useState<boolean>(() => getVnMode());
-  const [standardizeFmt, setStandardizeFmtState] = useState<boolean>(() => getStandardizeMessageFormatting());
-  const [enterToSendMode, setEnterToSendModeState] = useState<EnterToSendMode>(() => getEnterToSendMode());
+  // Display preferences (server-synced)
+  const layoutMode = useDisplayPreferencesStore(s => s.chatLayoutMode);
+  const avatarShapePref = useDisplayPreferencesStore(s => s.avatarShape);
+  const fontSizePref = useDisplayPreferencesStore(s => s.chatFontSize);
+  const chatWidthPref = useDisplayPreferencesStore(s => s.chatMaxWidth);
+  const vnModeOn = useDisplayPreferencesStore(s => s.vnMode);
+  const standardizeFmt = useDisplayPreferencesStore(s => s.standardizeMessageFormatting);
+  const enterToSendMode = useDisplayPreferencesStore(s => s.enterToSendMode);
+  const storeSetLayoutMode = useDisplayPreferencesStore(s => s.setChatLayoutMode);
+  const storeSetAvatarShape = useDisplayPreferencesStore(s => s.setAvatarShape);
+  const storeSetFontSize = useDisplayPreferencesStore(s => s.setChatFontSize);
+  const storeSetChatWidth = useDisplayPreferencesStore(s => s.setChatMaxWidth);
+  const storeSetVnMode = useDisplayPreferencesStore(s => s.setVnMode);
+  const storeSetStandardize = useDisplayPreferencesStore(s => s.setStandardizeMessageFormatting);
+  const storeSetEnterToSend = useDisplayPreferencesStore(s => s.setEnterToSendMode);
 
-  // Phase 6.3: TTS settings state
+  // Speech & TTS preferences (server-synced)
   const { isSupported: isTtsSupported, voices: ttsVoices } = useSpeechSynthesis();
-  const [ttsVoiceUri, setTtsVoiceUriState] = useState<string>(() => getTtsVoiceUri());
-  const [ttsRate, setTtsRateState] = useState<number>(() => getTtsRate());
-  const [ttsPitch, setTtsPitchState] = useState<number>(() => getTtsPitch());
-  const [ttsAutoReadOn, setTtsAutoReadState] = useState<boolean>(() => getTtsAutoRead());
+  const speechLang = useSpeechPreferencesStore(s => s.speechLang);
+  const ttsVoiceUri = useSpeechPreferencesStore(s => s.ttsVoiceUri);
+  const ttsRate = useSpeechPreferencesStore(s => s.ttsRate);
+  const ttsPitch = useSpeechPreferencesStore(s => s.ttsPitch);
+  const ttsAutoReadOn = useSpeechPreferencesStore(s => s.ttsAutoRead);
+  const storeSetSpeechLang = useSpeechPreferencesStore(s => s.setSpeechLang);
+  const storeSetTtsVoice = useSpeechPreferencesStore(s => s.setTtsVoiceUri);
+  const storeSetTtsRate = useSpeechPreferencesStore(s => s.setTtsRate);
+  const storeSetTtsPitch = useSpeechPreferencesStore(s => s.setTtsPitch);
+  const storeSetTtsAutoRead = useSpeechPreferencesStore(s => s.setTtsAutoRead);
 
   // Phase 7.2: Translation settings
   const translateProvider = useTranslateStore((s) => s.provider);
@@ -556,7 +539,7 @@ export function SettingsPage(_props?: { params?: Record<string, string> }) {
                 ] as const).map((opt) => (
                   <button
                     key={opt.value}
-                    onClick={() => { setLayoutModeState(opt.value); setChatLayoutMode(opt.value); }}
+                    onClick={() => storeSetLayoutMode(opt.value)}
                     className={`p-2.5 rounded-lg text-center transition-all ${
                       layoutMode === opt.value
                         ? 'bg-[var(--color-primary)] text-white'
@@ -585,7 +568,7 @@ export function SettingsPage(_props?: { params?: Record<string, string> }) {
                 ] as const).map((opt) => (
                   <button
                     key={opt.value}
-                    onClick={() => { setAvatarShapeState(opt.value); setAvatarShape(opt.value); }}
+                    onClick={() => storeSetAvatarShape(opt.value)}
                     className={`flex items-center justify-center gap-2 p-2.5 rounded-lg transition-all ${
                       avatarShapePref === opt.value
                         ? 'bg-[var(--color-primary)] text-white'
@@ -610,11 +593,7 @@ export function SettingsPage(_props?: { params?: Record<string, string> }) {
                 max={20}
                 step={1}
                 value={fontSizePref}
-                onChange={(e) => {
-                  const v = Number(e.target.value);
-                  setFontSizeState(v);
-                  setChatFontSize(v);
-                }}
+                onChange={(e) => storeSetFontSize(Number(e.target.value))}
                 className="w-full accent-[var(--color-primary)] mb-1"
               />
               <p className="text-[var(--color-text-secondary)] mb-4" style={{ fontSize: `${fontSizePref}px` }}>
@@ -634,11 +613,7 @@ export function SettingsPage(_props?: { params?: Record<string, string> }) {
                 max={100}
                 step={5}
                 value={chatWidthPref}
-                onChange={(e) => {
-                  const v = Number(e.target.value);
-                  setChatWidthState(v);
-                  setChatMaxWidth(v);
-                }}
+                onChange={(e) => storeSetChatWidth(Number(e.target.value))}
                 className="w-full accent-[var(--color-primary)]"
               />
 
@@ -653,11 +628,7 @@ export function SettingsPage(_props?: { params?: Record<string, string> }) {
                 <button
                   role="switch"
                   aria-checked={standardizeFmt}
-                  onClick={() => {
-                    const next = !standardizeFmt;
-                    setStandardizeFmtState(next);
-                    setStandardizeMessageFormatting(next);
-                  }}
+                  onClick={() => storeSetStandardize(!standardizeFmt)}
                   className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors flex-shrink-0 ${
                     standardizeFmt ? 'bg-[var(--color-primary)]' : 'bg-[var(--color-bg-tertiary)]'
                   }`}
@@ -678,11 +649,7 @@ export function SettingsPage(_props?: { params?: Record<string, string> }) {
                 </p>
                 <select
                   value={enterToSendMode}
-                  onChange={(e) => {
-                    const next = e.target.value as EnterToSendMode;
-                    setEnterToSendModeState(next);
-                    setEnterToSendMode(next);
-                  }}
+                  onChange={(e) => storeSetEnterToSend(e.target.value as EnterToSendMode)}
                   className="w-full bg-[var(--color-bg-tertiary)] text-[var(--color-text-primary)] text-xs rounded px-2 py-1.5 border border-[var(--color-border)]"
                 >
                   <option value="auto">Auto (device-aware)</option>
@@ -702,11 +669,7 @@ export function SettingsPage(_props?: { params?: Record<string, string> }) {
                 <button
                   role="switch"
                   aria-checked={vnModeOn}
-                  onClick={() => {
-                    const next = !vnModeOn;
-                    setVnModeState(next);
-                    setVnMode(next);
-                  }}
+                  onClick={() => storeSetVnMode(!vnModeOn)}
                   className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors flex-shrink-0 ${
                     vnModeOn ? 'bg-[var(--color-primary)]' : 'bg-[var(--color-bg-tertiary)]'
                   }`}
@@ -734,11 +697,7 @@ export function SettingsPage(_props?: { params?: Record<string, string> }) {
                 </p>
                 <select
                   value={speechLang}
-                  onChange={(e) => {
-                    const next = e.target.value;
-                    setSpeechLangState(next);
-                    setSpeechLanguage(next);
-                  }}
+                  onChange={(e) => storeSetSpeechLang(e.target.value)}
                   className="w-full bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] rounded-lg px-3 py-2 text-[var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]"
                 >
                   {SPEECH_LANGUAGES.some((l) => l.code === speechLang) ? null : (
@@ -772,11 +731,7 @@ export function SettingsPage(_props?: { params?: Record<string, string> }) {
                 </label>
                 <select
                   value={ttsVoiceUri}
-                  onChange={(e) => {
-                    const uri = e.target.value;
-                    setTtsVoiceUriState(uri);
-                    setTtsVoiceUri(uri);
-                  }}
+                  onChange={(e) => storeSetTtsVoice(e.target.value)}
                   className="w-full bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] rounded-lg px-3 py-2 text-[var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)] mb-4"
                 >
                   <option value="">System default</option>
@@ -797,11 +752,7 @@ export function SettingsPage(_props?: { params?: Record<string, string> }) {
                   max="2.0"
                   step="0.1"
                   value={ttsRate}
-                  onChange={(e) => {
-                    const val = parseFloat(e.target.value);
-                    setTtsRateState(val);
-                    setTtsRate(val);
-                  }}
+                  onChange={(e) => storeSetTtsRate(parseFloat(e.target.value))}
                   className="w-full mb-4 accent-[var(--color-primary)]"
                 />
 
@@ -815,11 +766,7 @@ export function SettingsPage(_props?: { params?: Record<string, string> }) {
                   max="2.0"
                   step="0.1"
                   value={ttsPitch}
-                  onChange={(e) => {
-                    const val = parseFloat(e.target.value);
-                    setTtsPitchState(val);
-                    setTtsPitch(val);
-                  }}
+                  onChange={(e) => storeSetTtsPitch(parseFloat(e.target.value))}
                   className="w-full mb-4 accent-[var(--color-primary)]"
                 />
 
@@ -835,11 +782,7 @@ export function SettingsPage(_props?: { params?: Record<string, string> }) {
                     type="button"
                     role="switch"
                     aria-checked={ttsAutoReadOn}
-                    onClick={() => {
-                      const next = !ttsAutoReadOn;
-                      setTtsAutoReadState(next);
-                      setTtsAutoRead(next);
-                    }}
+                    onClick={() => storeSetTtsAutoRead(!ttsAutoReadOn)}
                     className={`relative inline-flex h-6 w-11 shrink-0 rounded-full border-2 border-transparent transition-colors ${
                       ttsAutoReadOn ? 'bg-[var(--color-primary)]' : 'bg-zinc-600'
                     }`}

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -8,7 +8,7 @@ import { hasPermission } from '../../utils/permissions';
 // PROVIDERS moved to AISettingsPage
 import { Button } from '../ui';
 import { SPEECH_LANGUAGES } from '../../hooks/speechLanguage';
-import { type ChatLayoutMode, type AvatarShape, type EnterToSendMode } from '../../hooks/displayPreferences';
+import { type EnterToSendMode } from '../../hooks/displayPreferences';
 import { useDisplayPreferencesStore } from '../../stores/displayPreferencesStore';
 import { useSpeechPreferencesStore } from '../../stores/speechPreferencesStore';
 import {

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -5,6 +5,8 @@ import { useChatStore } from './chatStore';
 import { useSettingsStore } from './settingsStore';
 import { useWorldInfoStore } from './worldInfoStore';
 import { useThemeStore } from './themeStore';
+import { useDisplayPreferencesStore } from './displayPreferencesStore';
+import { useSpeechPreferencesStore } from './speechPreferencesStore';
 import { useExtensionStore } from './extensionStore';
 import { useSummarizeStore } from './summarizeStore';
 import { useAutoMemoryStore } from './autoMemoryStore';
@@ -75,6 +77,8 @@ export const useAuthStore = create<AuthState>((set) => ({
           isLoading: false,
         });
         useThemeStore.getState().fetchTheme();
+        useDisplayPreferencesStore.getState().fetchPrefs();
+        useSpeechPreferencesStore.getState().fetchPrefs();
       } else {
         set({ isAuthenticated: false, currentUser: null, isLoading: false });
       }
@@ -158,6 +162,8 @@ export const useAuthStore = create<AuthState>((set) => ({
         isLoading: false,
       });
       useThemeStore.getState().fetchTheme();
+      useDisplayPreferencesStore.getState().fetchPrefs();
+      useSpeechPreferencesStore.getState().fetchPrefs();
       return true;
     } catch (error) {
       set({

--- a/src/stores/displayPreferencesStore.ts
+++ b/src/stores/displayPreferencesStore.ts
@@ -1,0 +1,213 @@
+/**
+ * Server-synced display preferences store.
+ *
+ * Initialises from localStorage (instant first render), then hydrates from
+ * the user's server-side settings blob after login so preferences follow the
+ * user across devices.  Every mutation writes to localStorage immediately and
+ * patches the server in the background.
+ *
+ * Server settings blob key: `stm_display`
+ *
+ * Not synced (device-specific or needs R2):
+ *   - mobilePortraitHeight — physical screen constraint, per-device makes sense
+ *   - vnBgForCharacter / vnBgGlobal — base64 image blobs; deferred to R2 in v2
+ */
+
+import { create } from 'zustand';
+import { settingsApi } from '../api/client';
+import {
+  type ChatLayoutMode,
+  type AvatarShape,
+  type EnterToSendMode,
+  getChatLayoutMode,
+  setChatLayoutMode as lsSetLayoutMode,
+  getAvatarShape,
+  setAvatarShape as lsSetAvatarShape,
+  getChatFontSize,
+  setChatFontSize as lsSetFontSize,
+  getChatMaxWidth,
+  setChatMaxWidth as lsSetMaxWidth,
+  getVnMode,
+  setVnMode as lsSetVnMode,
+  getStandardizeMessageFormatting,
+  setStandardizeMessageFormatting as lsSetStandardize,
+  getEnterToSendMode,
+  setEnterToSendMode as lsSetEnterToSend,
+  setCostume as lsSetCostume,
+  clearCostume as lsClearCostume,
+} from '../hooks/displayPreferences';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface DisplayPrefsState {
+  chatLayoutMode: ChatLayoutMode;
+  avatarShape: AvatarShape;
+  chatFontSize: number;
+  chatMaxWidth: number;
+  vnMode: boolean;
+  standardizeMessageFormatting: boolean;
+  enterToSendMode: EnterToSendMode;
+  /** Per-character costume folder name, keyed by avatar filename. */
+  costumes: Record<string, string>;
+
+  /** Fetch from server after login and apply. No-op if no server data yet. */
+  fetchPrefs: () => Promise<void>;
+  setChatLayoutMode: (mode: ChatLayoutMode) => void;
+  setAvatarShape: (shape: AvatarShape) => void;
+  setChatFontSize: (px: number) => void;
+  setChatMaxWidth: (pct: number) => void;
+  setVnMode: (on: boolean) => void;
+  setStandardizeMessageFormatting: (on: boolean) => void;
+  setEnterToSendMode: (mode: EnterToSendMode) => void;
+  setCostume: (avatar: string, name: string) => void;
+  clearCostume: (avatar: string) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getInitialCostumes(): Record<string, string> {
+  const costumes: Record<string, string> = {};
+  try {
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (key?.startsWith('stm:costume-')) {
+        const avatar = key.slice('stm:costume-'.length);
+        const val = localStorage.getItem(key);
+        if (val) costumes[avatar] = val;
+      }
+    }
+  } catch { /* ignore */ }
+  return costumes;
+}
+
+async function getSettingsBlob(): Promise<Record<string, unknown>> {
+  const response = await settingsApi.getSettings();
+  if (typeof response.settings === 'string') {
+    try { return JSON.parse(response.settings); } catch { return {}; }
+  }
+  return (response.settings as Record<string, unknown>) || {};
+}
+
+async function patchServer(patch: Record<string, unknown>): Promise<void> {
+  const settings = await getSettingsBlob();
+  const display = (settings.stm_display as Record<string, unknown>) || {};
+  Object.assign(display, patch);
+  settings.stm_display = display;
+  await settingsApi.saveSettings(settings);
+}
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+export const useDisplayPreferencesStore = create<DisplayPrefsState>((set, get) => ({
+  chatLayoutMode: getChatLayoutMode(),
+  avatarShape: getAvatarShape(),
+  chatFontSize: getChatFontSize(),
+  chatMaxWidth: getChatMaxWidth(),
+  vnMode: getVnMode(),
+  standardizeMessageFormatting: getStandardizeMessageFormatting(),
+  enterToSendMode: getEnterToSendMode(),
+  costumes: getInitialCostumes(),
+
+  fetchPrefs: async () => {
+    try {
+      const settings = await getSettingsBlob();
+      const display = settings.stm_display as Record<string, unknown> | undefined;
+      if (!display) return;
+
+      const chatLayoutMode = (display.chatLayoutMode as ChatLayoutMode) ?? get().chatLayoutMode;
+      const avatarShape = (display.avatarShape as AvatarShape) ?? get().avatarShape;
+      const chatFontSize = typeof display.chatFontSize === 'number' ? display.chatFontSize : get().chatFontSize;
+      const chatMaxWidth = typeof display.chatMaxWidth === 'number' ? display.chatMaxWidth : get().chatMaxWidth;
+      const vnMode = typeof display.vnMode === 'boolean' ? display.vnMode : get().vnMode;
+      const standardizeMessageFormatting = typeof display.standardizeMessageFormatting === 'boolean'
+        ? display.standardizeMessageFormatting
+        : get().standardizeMessageFormatting;
+      const enterToSendMode = (display.enterToSendMode as EnterToSendMode) ?? get().enterToSendMode;
+      const costumes = (display.costumes as Record<string, string>) ?? get().costumes;
+
+      // Write back to localStorage so the next cold load is still instant.
+      lsSetLayoutMode(chatLayoutMode);
+      lsSetAvatarShape(avatarShape);
+      lsSetFontSize(chatFontSize);
+      lsSetMaxWidth(chatMaxWidth);
+      lsSetVnMode(vnMode);
+      lsSetStandardize(standardizeMessageFormatting);
+      lsSetEnterToSend(enterToSendMode);
+
+      // Restore per-character costumes: remove stale, write new.
+      try {
+        for (const avatar of Object.keys(get().costumes)) {
+          if (!costumes[avatar]) localStorage.removeItem(`stm:costume-${avatar}`);
+        }
+        for (const [avatar, name] of Object.entries(costumes)) {
+          localStorage.setItem(`stm:costume-${avatar}`, name);
+        }
+      } catch { /* ignore */ }
+
+      set({ chatLayoutMode, avatarShape, chatFontSize, chatMaxWidth, vnMode, standardizeMessageFormatting, enterToSendMode, costumes });
+    } catch { /* non-fatal — localStorage values remain active */ }
+  },
+
+  setChatLayoutMode: (mode) => {
+    lsSetLayoutMode(mode);
+    set({ chatLayoutMode: mode });
+    patchServer({ chatLayoutMode: mode }).catch(() => {});
+  },
+
+  setAvatarShape: (shape) => {
+    lsSetAvatarShape(shape);
+    set({ avatarShape: shape });
+    patchServer({ avatarShape: shape }).catch(() => {});
+  },
+
+  setChatFontSize: (px) => {
+    lsSetFontSize(px);
+    set({ chatFontSize: px });
+    patchServer({ chatFontSize: px }).catch(() => {});
+  },
+
+  setChatMaxWidth: (pct) => {
+    lsSetMaxWidth(pct);
+    set({ chatMaxWidth: pct });
+    patchServer({ chatMaxWidth: pct }).catch(() => {});
+  },
+
+  setVnMode: (on) => {
+    lsSetVnMode(on);
+    set({ vnMode: on });
+    patchServer({ vnMode: on }).catch(() => {});
+  },
+
+  setStandardizeMessageFormatting: (on) => {
+    lsSetStandardize(on);
+    set({ standardizeMessageFormatting: on });
+    patchServer({ standardizeMessageFormatting: on }).catch(() => {});
+  },
+
+  setEnterToSendMode: (mode) => {
+    lsSetEnterToSend(mode);
+    set({ enterToSendMode: mode });
+    patchServer({ enterToSendMode: mode }).catch(() => {});
+  },
+
+  setCostume: (avatar, name) => {
+    lsSetCostume(avatar, name);
+    const costumes = { ...get().costumes, [avatar]: name };
+    set({ costumes });
+    patchServer({ costumes }).catch(() => {});
+  },
+
+  clearCostume: (avatar) => {
+    lsClearCostume(avatar);
+    const costumes = { ...get().costumes };
+    delete costumes[avatar];
+    set({ costumes });
+    patchServer({ costumes }).catch(() => {});
+  },
+}));

--- a/src/stores/displayPreferencesStore.ts
+++ b/src/stores/displayPreferencesStore.ts
@@ -8,6 +8,13 @@
  *
  * Server settings blob key: `stm_display`
  *
+ * Sync strategy — gap 1 fix (failed patch recovery):
+ *   LOCAL_TS_KEY is stamped with Date.now() on every mutation.
+ *   patchServer embeds the same timestamp as _ts in the blob and, only on
+ *   success, updates LOCAL_TS_KEY to match.  A failed patch therefore leaves
+ *   LOCAL_TS_KEY > server._ts.  fetchPrefs detects this and re-uploads the
+ *   full local state rather than overwriting it with the stale server copy.
+ *
  * Not synced (device-specific or needs R2):
  *   - mobilePortraitHeight — physical screen constraint, per-device makes sense
  *   - vnBgForCharacter / vnBgGlobal — base64 image blobs; deferred to R2 in v2
@@ -69,6 +76,13 @@ interface DisplayPrefsState {
 // Helpers
 // ---------------------------------------------------------------------------
 
+/** localStorage key tracking the timestamp of the last local mutation. */
+const LOCAL_TS_KEY = 'stm:display-local-ts';
+
+function markLocalDirty(): void {
+  try { localStorage.setItem(LOCAL_TS_KEY, String(Date.now())); } catch { /* ignore */ }
+}
+
 function getInitialCostumes(): Record<string, string> {
   const costumes: Record<string, string> = {};
   try {
@@ -92,12 +106,19 @@ async function getSettingsBlob(): Promise<Record<string, unknown>> {
   return (response.settings as Record<string, unknown>) || {};
 }
 
+/**
+ * Read-modify-write the stm_display section of the settings blob.
+ * Embeds _ts in the patch and, only on success, advances LOCAL_TS_KEY
+ * to match — so a network failure leaves LOCAL_TS_KEY > server._ts.
+ */
 async function patchServer(patch: Record<string, unknown>): Promise<void> {
+  const ts = Date.now();
   const settings = await getSettingsBlob();
   const display = (settings.stm_display as Record<string, unknown>) || {};
-  Object.assign(display, patch);
+  Object.assign(display, patch, { _ts: ts });
   settings.stm_display = display;
-  await settingsApi.saveSettings(settings);
+  await settingsApi.saveSettings(settings); // throws on failure — LOCAL_TS_KEY not updated
+  try { localStorage.setItem(LOCAL_TS_KEY, String(ts)); } catch { /* ignore */ }
 }
 
 // ---------------------------------------------------------------------------
@@ -118,8 +139,28 @@ export const useDisplayPreferencesStore = create<DisplayPrefsState>((set, get) =
     try {
       const settings = await getSettingsBlob();
       const display = settings.stm_display as Record<string, unknown> | undefined;
-      if (!display) return;
+      const localTs = Number(localStorage.getItem(LOCAL_TS_KEY) || 0);
+      const serverTs = Number(display?._ts || 0);
 
+      if (localTs > serverTs) {
+        // Local has mutations that never confirmed to the server — re-upload them.
+        const s = get();
+        patchServer({
+          chatLayoutMode: s.chatLayoutMode,
+          avatarShape: s.avatarShape,
+          chatFontSize: s.chatFontSize,
+          chatMaxWidth: s.chatMaxWidth,
+          vnMode: s.vnMode,
+          standardizeMessageFormatting: s.standardizeMessageFormatting,
+          enterToSendMode: s.enterToSendMode,
+          costumes: s.costumes,
+        }).catch(() => {});
+        return; // keep local values — they are newer
+      }
+
+      if (!display) return; // No server prefs and no local changes — keep defaults.
+
+      // Server is current or newer — apply server values and write back to localStorage.
       const chatLayoutMode = (display.chatLayoutMode as ChatLayoutMode) ?? get().chatLayoutMode;
       const avatarShape = (display.avatarShape as AvatarShape) ?? get().avatarShape;
       const chatFontSize = typeof display.chatFontSize === 'number' ? display.chatFontSize : get().chatFontSize;
@@ -131,7 +172,6 @@ export const useDisplayPreferencesStore = create<DisplayPrefsState>((set, get) =
       const enterToSendMode = (display.enterToSendMode as EnterToSendMode) ?? get().enterToSendMode;
       const costumes = (display.costumes as Record<string, string>) ?? get().costumes;
 
-      // Write back to localStorage so the next cold load is still instant.
       lsSetLayoutMode(chatLayoutMode);
       lsSetAvatarShape(avatarShape);
       lsSetFontSize(chatFontSize);
@@ -150,6 +190,9 @@ export const useDisplayPreferencesStore = create<DisplayPrefsState>((set, get) =
         }
       } catch { /* ignore */ }
 
+      // Advance LOCAL_TS_KEY so a future fetchPrefs doesn't re-upload stale local state.
+      try { localStorage.setItem(LOCAL_TS_KEY, String(serverTs)); } catch { /* ignore */ }
+
       set({ chatLayoutMode, avatarShape, chatFontSize, chatMaxWidth, vnMode, standardizeMessageFormatting, enterToSendMode, costumes });
     } catch { /* non-fatal — localStorage values remain active */ }
   },
@@ -157,42 +200,49 @@ export const useDisplayPreferencesStore = create<DisplayPrefsState>((set, get) =
   setChatLayoutMode: (mode) => {
     lsSetLayoutMode(mode);
     set({ chatLayoutMode: mode });
+    markLocalDirty();
     patchServer({ chatLayoutMode: mode }).catch(() => {});
   },
 
   setAvatarShape: (shape) => {
     lsSetAvatarShape(shape);
     set({ avatarShape: shape });
+    markLocalDirty();
     patchServer({ avatarShape: shape }).catch(() => {});
   },
 
   setChatFontSize: (px) => {
     lsSetFontSize(px);
     set({ chatFontSize: px });
+    markLocalDirty();
     patchServer({ chatFontSize: px }).catch(() => {});
   },
 
   setChatMaxWidth: (pct) => {
     lsSetMaxWidth(pct);
     set({ chatMaxWidth: pct });
+    markLocalDirty();
     patchServer({ chatMaxWidth: pct }).catch(() => {});
   },
 
   setVnMode: (on) => {
     lsSetVnMode(on);
     set({ vnMode: on });
+    markLocalDirty();
     patchServer({ vnMode: on }).catch(() => {});
   },
 
   setStandardizeMessageFormatting: (on) => {
     lsSetStandardize(on);
     set({ standardizeMessageFormatting: on });
+    markLocalDirty();
     patchServer({ standardizeMessageFormatting: on }).catch(() => {});
   },
 
   setEnterToSendMode: (mode) => {
     lsSetEnterToSend(mode);
     set({ enterToSendMode: mode });
+    markLocalDirty();
     patchServer({ enterToSendMode: mode }).catch(() => {});
   },
 
@@ -200,6 +250,7 @@ export const useDisplayPreferencesStore = create<DisplayPrefsState>((set, get) =
     lsSetCostume(avatar, name);
     const costumes = { ...get().costumes, [avatar]: name };
     set({ costumes });
+    markLocalDirty();
     patchServer({ costumes }).catch(() => {});
   },
 
@@ -208,6 +259,7 @@ export const useDisplayPreferencesStore = create<DisplayPrefsState>((set, get) =
     const costumes = { ...get().costumes };
     delete costumes[avatar];
     set({ costumes });
+    markLocalDirty();
     patchServer({ costumes }).catch(() => {});
   },
 }));

--- a/src/stores/speechPreferencesStore.ts
+++ b/src/stores/speechPreferencesStore.ts
@@ -8,6 +8,13 @@
  *
  * Server settings blob key: `stm_speech`
  *
+ * Sync strategy — gap 1 fix (failed patch recovery):
+ *   LOCAL_TS_KEY is stamped with Date.now() on every mutation.
+ *   patchServer embeds the same timestamp as _ts in the blob and, only on
+ *   success, updates LOCAL_TS_KEY to match.  A failed patch therefore leaves
+ *   LOCAL_TS_KEY > server._ts.  fetchPrefs detects this and re-uploads the
+ *   full local state rather than overwriting it with the stale server copy.
+ *
  * Not synced:
  *   - speechPermission — browser-level mic grant state; device-specific
  */
@@ -52,6 +59,13 @@ interface SpeechPrefsState {
 // Helpers
 // ---------------------------------------------------------------------------
 
+/** localStorage key tracking the timestamp of the last local mutation. */
+const LOCAL_TS_KEY = 'stm:speech-local-ts';
+
+function markLocalDirty(): void {
+  try { localStorage.setItem(LOCAL_TS_KEY, String(Date.now())); } catch { /* ignore */ }
+}
+
 async function getSettingsBlob(): Promise<Record<string, unknown>> {
   const response = await settingsApi.getSettings();
   if (typeof response.settings === 'string') {
@@ -60,19 +74,26 @@ async function getSettingsBlob(): Promise<Record<string, unknown>> {
   return (response.settings as Record<string, unknown>) || {};
 }
 
+/**
+ * Read-modify-write the stm_speech section of the settings blob.
+ * Embeds _ts in the patch and, only on success, advances LOCAL_TS_KEY
+ * to match — so a network failure leaves LOCAL_TS_KEY > server._ts.
+ */
 async function patchServer(patch: Record<string, unknown>): Promise<void> {
+  const ts = Date.now();
   const settings = await getSettingsBlob();
   const speech = (settings.stm_speech as Record<string, unknown>) || {};
-  Object.assign(speech, patch);
+  Object.assign(speech, patch, { _ts: ts });
   settings.stm_speech = speech;
-  await settingsApi.saveSettings(settings);
+  await settingsApi.saveSettings(settings); // throws on failure — LOCAL_TS_KEY not updated
+  try { localStorage.setItem(LOCAL_TS_KEY, String(ts)); } catch { /* ignore */ }
 }
 
 // ---------------------------------------------------------------------------
 // Store
 // ---------------------------------------------------------------------------
 
-export const useSpeechPreferencesStore = create<SpeechPrefsState>((set) => ({
+export const useSpeechPreferencesStore = create<SpeechPrefsState>((set, get) => ({
   speechLang: getSpeechLanguage(),
   ttsVoiceUri: getTtsVoiceUri(),
   ttsRate: getTtsRate(),
@@ -83,20 +104,39 @@ export const useSpeechPreferencesStore = create<SpeechPrefsState>((set) => ({
     try {
       const settings = await getSettingsBlob();
       const speech = settings.stm_speech as Record<string, unknown> | undefined;
-      if (!speech) return;
+      const localTs = Number(localStorage.getItem(LOCAL_TS_KEY) || 0);
+      const serverTs = Number(speech?._ts || 0);
 
+      if (localTs > serverTs) {
+        // Local has mutations that never confirmed to the server — re-upload them.
+        const s = get();
+        patchServer({
+          speechLang: s.speechLang,
+          ttsVoiceUri: s.ttsVoiceUri,
+          ttsRate: s.ttsRate,
+          ttsPitch: s.ttsPitch,
+          ttsAutoRead: s.ttsAutoRead,
+        }).catch(() => {});
+        return; // keep local values — they are newer
+      }
+
+      if (!speech) return; // No server prefs and no local changes — keep defaults.
+
+      // Server is current or newer — apply server values and write back to localStorage.
       const speechLang = typeof speech.speechLang === 'string' ? speech.speechLang : getSpeechLanguage();
       const ttsVoiceUri = typeof speech.ttsVoiceUri === 'string' ? speech.ttsVoiceUri : getTtsVoiceUri();
       const ttsRate = typeof speech.ttsRate === 'number' ? speech.ttsRate : getTtsRate();
       const ttsPitch = typeof speech.ttsPitch === 'number' ? speech.ttsPitch : getTtsPitch();
       const ttsAutoRead = typeof speech.ttsAutoRead === 'boolean' ? speech.ttsAutoRead : getTtsAutoRead();
 
-      // Write back to localStorage so the next cold load is still instant.
       lsSetSpeechLang(speechLang);
       lsSetTtsVoice(ttsVoiceUri);
       lsSetTtsRate(ttsRate);
       lsSetTtsPitch(ttsPitch);
       lsSetTtsAutoRead(ttsAutoRead);
+
+      // Advance LOCAL_TS_KEY so a future fetchPrefs doesn't re-upload stale local state.
+      try { localStorage.setItem(LOCAL_TS_KEY, String(serverTs)); } catch { /* ignore */ }
 
       set({ speechLang, ttsVoiceUri, ttsRate, ttsPitch, ttsAutoRead });
     } catch { /* non-fatal — localStorage values remain active */ }
@@ -105,30 +145,35 @@ export const useSpeechPreferencesStore = create<SpeechPrefsState>((set) => ({
   setSpeechLang: (lang) => {
     lsSetSpeechLang(lang);
     set({ speechLang: lang });
+    markLocalDirty();
     patchServer({ speechLang: lang }).catch(() => {});
   },
 
   setTtsVoiceUri: (uri) => {
     lsSetTtsVoice(uri);
     set({ ttsVoiceUri: uri });
+    markLocalDirty();
     patchServer({ ttsVoiceUri: uri }).catch(() => {});
   },
 
   setTtsRate: (rate) => {
     lsSetTtsRate(rate);
     set({ ttsRate: rate });
+    markLocalDirty();
     patchServer({ ttsRate: rate }).catch(() => {});
   },
 
   setTtsPitch: (pitch) => {
     lsSetTtsPitch(pitch);
     set({ ttsPitch: pitch });
+    markLocalDirty();
     patchServer({ ttsPitch: pitch }).catch(() => {});
   },
 
   setTtsAutoRead: (on) => {
     lsSetTtsAutoRead(on);
     set({ ttsAutoRead: on });
+    markLocalDirty();
     patchServer({ ttsAutoRead: on }).catch(() => {});
   },
 }));

--- a/src/stores/speechPreferencesStore.ts
+++ b/src/stores/speechPreferencesStore.ts
@@ -1,0 +1,134 @@
+/**
+ * Server-synced speech & TTS preferences store.
+ *
+ * Initialises from localStorage (instant first render), then hydrates from
+ * the user's server-side settings blob after login so preferences follow the
+ * user across devices.  Every mutation writes to localStorage immediately and
+ * patches the server in the background.
+ *
+ * Server settings blob key: `stm_speech`
+ *
+ * Not synced:
+ *   - speechPermission — browser-level mic grant state; device-specific
+ */
+
+import { create } from 'zustand';
+import { settingsApi } from '../api/client';
+import {
+  getSpeechLanguage,
+  setSpeechLanguage as lsSetSpeechLang,
+  getTtsVoiceUri,
+  setTtsVoiceUri as lsSetTtsVoice,
+  getTtsRate,
+  setTtsRate as lsSetTtsRate,
+  getTtsPitch,
+  setTtsPitch as lsSetTtsPitch,
+  getTtsAutoRead,
+  setTtsAutoRead as lsSetTtsAutoRead,
+} from '../hooks/speechLanguage';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface SpeechPrefsState {
+  speechLang: string;
+  /** Voice URI from the Web Speech API — empty string means system default. */
+  ttsVoiceUri: string;
+  ttsRate: number;
+  ttsPitch: number;
+  ttsAutoRead: boolean;
+
+  /** Fetch from server after login and apply. No-op if no server data yet. */
+  fetchPrefs: () => Promise<void>;
+  setSpeechLang: (lang: string) => void;
+  setTtsVoiceUri: (uri: string) => void;
+  setTtsRate: (rate: number) => void;
+  setTtsPitch: (pitch: number) => void;
+  setTtsAutoRead: (on: boolean) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function getSettingsBlob(): Promise<Record<string, unknown>> {
+  const response = await settingsApi.getSettings();
+  if (typeof response.settings === 'string') {
+    try { return JSON.parse(response.settings); } catch { return {}; }
+  }
+  return (response.settings as Record<string, unknown>) || {};
+}
+
+async function patchServer(patch: Record<string, unknown>): Promise<void> {
+  const settings = await getSettingsBlob();
+  const speech = (settings.stm_speech as Record<string, unknown>) || {};
+  Object.assign(speech, patch);
+  settings.stm_speech = speech;
+  await settingsApi.saveSettings(settings);
+}
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+export const useSpeechPreferencesStore = create<SpeechPrefsState>((set) => ({
+  speechLang: getSpeechLanguage(),
+  ttsVoiceUri: getTtsVoiceUri(),
+  ttsRate: getTtsRate(),
+  ttsPitch: getTtsPitch(),
+  ttsAutoRead: getTtsAutoRead(),
+
+  fetchPrefs: async () => {
+    try {
+      const settings = await getSettingsBlob();
+      const speech = settings.stm_speech as Record<string, unknown> | undefined;
+      if (!speech) return;
+
+      const speechLang = typeof speech.speechLang === 'string' ? speech.speechLang : getSpeechLanguage();
+      const ttsVoiceUri = typeof speech.ttsVoiceUri === 'string' ? speech.ttsVoiceUri : getTtsVoiceUri();
+      const ttsRate = typeof speech.ttsRate === 'number' ? speech.ttsRate : getTtsRate();
+      const ttsPitch = typeof speech.ttsPitch === 'number' ? speech.ttsPitch : getTtsPitch();
+      const ttsAutoRead = typeof speech.ttsAutoRead === 'boolean' ? speech.ttsAutoRead : getTtsAutoRead();
+
+      // Write back to localStorage so the next cold load is still instant.
+      lsSetSpeechLang(speechLang);
+      lsSetTtsVoice(ttsVoiceUri);
+      lsSetTtsRate(ttsRate);
+      lsSetTtsPitch(ttsPitch);
+      lsSetTtsAutoRead(ttsAutoRead);
+
+      set({ speechLang, ttsVoiceUri, ttsRate, ttsPitch, ttsAutoRead });
+    } catch { /* non-fatal — localStorage values remain active */ }
+  },
+
+  setSpeechLang: (lang) => {
+    lsSetSpeechLang(lang);
+    set({ speechLang: lang });
+    patchServer({ speechLang: lang }).catch(() => {});
+  },
+
+  setTtsVoiceUri: (uri) => {
+    lsSetTtsVoice(uri);
+    set({ ttsVoiceUri: uri });
+    patchServer({ ttsVoiceUri: uri }).catch(() => {});
+  },
+
+  setTtsRate: (rate) => {
+    lsSetTtsRate(rate);
+    set({ ttsRate: rate });
+    patchServer({ ttsRate: rate }).catch(() => {});
+  },
+
+  setTtsPitch: (pitch) => {
+    lsSetTtsPitch(pitch);
+    set({ ttsPitch: pitch });
+    patchServer({ ttsPitch: pitch }).catch(() => {});
+  },
+
+  setTtsAutoRead: (on) => {
+    lsSetTtsAutoRead(on);
+    set({ ttsAutoRead: on });
+    patchServer({ ttsAutoRead: on }).catch(() => {});
+  },
+}));

--- a/src/utils/stscript/commands/display.ts
+++ b/src/utils/stscript/commands/display.ts
@@ -27,16 +27,17 @@ registerCommand({
       return '';
     }
 
-    const { setCostume, clearCostume, getCostume } = await import('../../../hooks/displayPreferences');
+    const { getCostume } = await import('../../../hooks/displayPreferences');
+    const { useDisplayPreferencesStore } = await import('../../../stores/displayPreferencesStore');
     const folderName = getUnnamedArgs(args).trim();
 
     if (folderName) {
-      setCostume(character.avatar, folderName);
+      useDisplayPreferencesStore.getState().setCostume(character.avatar, folderName);
       ctx.showToast(`Costume set to "${folderName}"`, 'success');
       return folderName;
     } else {
       const current = getCostume(character.avatar);
-      clearCostume(character.avatar);
+      useDisplayPreferencesStore.getState().clearCostume(character.avatar);
       if (current) ctx.showToast('Costume reset to default', 'success');
       return '';
     }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `displayPreferencesStore` and `speechPreferencesStore` following the existing `themeStore` pattern: init from `localStorage` for instant first render, hydrate from the server settings blob on login, write back to both localStorage and server on every mutation
- Wires both stores into `authStore` (`checkAuth` + `login`) so prefs sync on every session start
- Migrates `SettingsPage`, `ChatView`, and the `/costume` STscript command to use the stores instead of raw localStorage setters
- Adds a deferred-item schema design section to `docs/v2/ROADMAP.md` covering world info, personas, RAG embeddings, data bank, image gallery, regex scripts, VN backgrounds, author notes, and chat variables — with a migration path for the Phase 1 cutover

## What syncs now

| Store key | Contents |
|-----------|----------|
| `stm_display` | Layout mode, avatar shape, font size, chat width, VN mode, message formatting, enter-to-send, costumes |
| `stm_speech` | Speech language, TTS voice/rate/pitch, auto-read |

## What stays localStorage-only (and why)

- **VN background images** — base64 blobs; need Cloudflare R2 (v2 Phase 1)
- **Mobile portrait height** — physical screen constraint, per-device makes sense

## Test plan

- [ ] Log in on Device A, change theme, layout, font size, TTS rate
- [ ] Log in on Device B — verify all preferences appear correctly
- [ ] Change a pref on Device B, switch back to Device A (re-login) — verify it round-trips
- [ ] Verify VN bg image and mobile portrait height are unaffected between devices (expected: device-local)
- [ ] Run `/costume Alice_swimsuit` in STscript — verify costume persists to server

https://claude.ai/code/session_01J2vEpKbUuCvj2Qxphur6Ap
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J2vEpKbUuCvj2Qxphur6Ap)_