### PR TITLE
feat: fix character deletion requiring global storage push first

### DIFF
--- a/src/stores/characterOwnershipStore.ts
+++ b/src/stores/characterOwnershipStore.ts
@@ -134,7 +134,9 @@ export const useCharacterOwnershipStore = create<CharacterOwnershipState>((set, 
   canDeleteCharacter: (avatar, userHandle, userRole) => {
     if (userRole === 'owner') return true;
     const entry = get().ownershipMap[avatar];
-    if (!entry) return false;
+    // No metadata entry → personal character never pushed to global; the
+    // requesting user is its only possible owner, so allow deletion.
+    if (!entry) return true;
     return entry.ownerHandle === userHandle;
   },
 }));


### PR DESCRIPTION
## Summary
Closes #214.

- `canDeleteCharacter` in `characterOwnershipStore.ts` previously returned `false` for any character with no metadata entry, blocking deletion
- Characters with no metadata entry are personal/local (never pushed to global storage) — the requesting user is their sole owner
- Changed the `!entry` branch to return `true` so personal characters can be deleted directly

## Test plan
- [ ] Local `npm run build` passes (already verified)
- [ ] Upload a character, do NOT push to global storage, confirm delete works
- [ ] Upload a character, push to global storage, confirm delete still works (owned)
- [ ] Edge case: character owned by a different user → delete should still be blocked

🤖 Draft opened by the build-next-issue skill. Human review required before merge.