### PR TITLE
fix: restore dialogue color for italics inside quoted speech

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -275,6 +275,10 @@ body {
   color: var(--color-text-dialogue);
   font-weight: 500;
 }
+.markdown-content .md-segment .dialogue em,
+.markdown-content .md-segment .dialogue i {
+  color: inherit;
+}
 
 /* --- Roleplay action / thought — themeable color hooks (AI side) --- */
 .markdown-content .rp-action {


### PR DESCRIPTION
## Summary
Closes #215.

- `.markdown-content .md-segment em` has an explicit color rule (`--color-text-italic`) that cascades over its parent `.dialogue` span's color when `<em>` appears inside quoted text
- Added a higher-specificity rule: `.md-segment .dialogue em, .md-segment .dialogue i { color: inherit; }` so italics inside dialogue inherit the dialogue color instead
- No JS or template changes needed — pure CSS fix

## Test plan
- [ ] Local `npm run build` passes (already verified)
- [ ] Send a message with italics inside quotes: `"Hello *world*."` — dialogue color should apply to the whole quote including the italic word
- [ ] Send a message with italics outside quotes: `*action text*` — should still render in the italic color (unaffected)
- [ ] Edge case: nested `"dialogue *italic* more dialogue"` — all text in quote should be dialogue color

🤖 Draft opened by the build-next-issue skill. Human review required before merge.