### PR TITLE
fix: exempt constant lorebook entries from token budget pruning

### DIFF
--- a/src/stores/worldInfoStore.ts
+++ b/src/stores/worldInfoStore.ts
@@ -884,15 +884,23 @@ function applyTokenBudget(
   profile: TokenizerProfile
 ): MatchedEntry[] {
   if (budget <= 0) return matches;
+  // Constant entries are always injected — never pruned by the budget.
+  const constantMatches = matches.filter((m) => m.entry.constant);
+  const budgetable = matches.filter((m) => !m.entry.constant);
+  const constantCost = constantMatches.reduce(
+    (s, m) => s + estimateTokens(m.entry.content, profile),
+    0
+  );
+  const remaining = Math.max(0, budget - constantCost);
   // High priority first (lower `order`), drop lowest priority when over budget.
-  const sorted = [...matches].sort((a, b) => a.entry.order - b.entry.order);
+  const sorted = [...budgetable].sort((a, b) => a.entry.order - b.entry.order);
   const costs = sorted.map((m) => estimateTokens(m.entry.content, profile));
   let total = costs.reduce((s, c) => s + c, 0);
-  while (total > budget && sorted.length > 0) {
+  while (total > remaining && sorted.length > 0) {
     sorted.pop();
     total -= costs.pop() || 0;
   }
-  return sorted;
+  return [...constantMatches, ...sorted];
 }
 
 /**


### PR DESCRIPTION
## Summary
Closes #216.

- `applyTokenBudget` in `worldInfoStore.ts` sorted all matched entries together and dropped lowest-priority ones when total tokens exceeded the budget — this silently dropped constant entries, which are supposed to always inject regardless of keywords or budget
- Fixed by separating constant entries from the budgetable pool: constant cost is deducted from the budget first, then only non-constant entries are pruned against the remainder
- Constant entries are now always returned, matching their documented "unconditional" contract

## Test plan
- [ ] Local `npm run build` passes (already verified)
- [ ] Character with embedded lorebook (all entries `constant`) + total lorebook content > 1024 tokens: all entries consistently appear in generation context
- [ ] Character with mixed constant + keyword entries: constant entries always present; keyword entries still pruned by budget if total is large
- [ ] Character with small lorebook (under budget): no change in behavior

🤖 Draft opened by the build-next-issue skill. Human review required before merge.