### PR TITLE
feat(dev): one-command local stack via docker-compose.dev.yml

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# Local development env. Copy to .env (gitignored) and adjust.
+# Production uses /opt/goodgirlsbotclub/.env on the droplet — not this file.
+
+# ggbc-backend & ST owner — seeded on first boot if no users exist.
+# In dev, "dev" + "devpassword" is fine; pick anything for the password.
+OWNER_HANDLE=dev
+OWNER_PASSWORD=devpassword
+OWNER_NAME=Dev User
+
+# Postgres password (ggbc-backend connects as user 'ggbc'). Any value works
+# for local dev; production sets this to a real secret.
+POSTGRES_PASSWORD=ggbc
+
+# Whether registrations require an invite token. Set true in dev to make it
+# easier to spin up test users; production keeps this false.
+ALLOW_SELF_REGISTRATION=true

--- a/README.md
+++ b/README.md
@@ -33,12 +33,33 @@ After a fresh installation, no real users exist yet. The app uses a temporary bo
 
 ---
 
-## Development
+## Local development (full stack)
+
+Runs the production-style backend in Docker plus Vite dev for the frontend with HMR. Requires Docker Desktop.
 
 ```bash
-npm install
+cp .env.example .env       # one-time
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d
+npm install                # one-time
 npm run dev
 ```
+
+- Frontend with HMR: http://localhost:3000
+- ggbc-backend API: http://localhost:8001 (Vite proxies /auth /sync /invitations /health /api etc. to this)
+- Postgres: localhost:5432 (`psql -h 127.0.0.1 -U ggbc`)
+- SillyTavern: http://localhost:8000 (internal — Vite never hits it directly)
+
+The dev overlay (`docker-compose.dev.yml`) flips `COOKIE_SECURE` off so cookies work over HTTP localhost and enables self-registration so you can create test users without an invite. First-boot bootstrap creates the owner from `OWNER_HANDLE`/`OWNER_PASSWORD` in `.env`.
+
+### Backend changes
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build ggbc-backend
+```
+
+### Frontend-only
+
+If you don't need the backend stack (e.g. styling tweaks), `npm run dev` alone works — fetches will 404 but the UI renders. `GGBC_BACKEND=http://...` overrides the proxy target if you want to point at a remote backend.
 
 ## Build
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,70 @@
+# Local development overlay.
+#
+#   docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d
+#
+# Pairs with `npm run dev` (vite at http://localhost:3000 proxying to the
+# backend stack on :8001 via vite.config.ts).
+#
+# What this overlay does:
+#   - Publishes ggbc-backend, postgres, and sillytavern to host loopback
+#     (they share frontend's network namespace, so we add the host port
+#     mappings to the frontend service).
+#   - Switches cookies to non-Secure so they work on HTTP localhost.
+#   - Allows self-registration so you can spin up users without an invite.
+#   - Binds uvicorn on 0.0.0.0 inside the namespace so the published port
+#     reaches it.
+#
+# Production unchanged — that's just `docker compose up -d` against
+# docker-compose.yml alone.
+
+services:
+  frontend:
+    # Both frontend and sillytavern images are currently amd64-only on GHCR.
+    # Docker Desktop on Apple Silicon emulates amd64 via Rosetta — slower
+    # but functional. Multi-arch builds for those repos are a follow-up.
+    platform: linux/amd64
+    # Replace (not merge) the ports list — port 80 is skipped in dev because
+    # vite serves the frontend on :3000 and port 80 is often in use on
+    # developer machines (nginx, etc.). Publishing the backing service
+    # ports here works because they share the frontend's network namespace.
+    ports: !override
+      - "127.0.0.1:8001:8001"
+      - "127.0.0.1:5432:5432"
+      - "127.0.0.1:8000:8000"
+
+  sillytavern:
+    platform: linux/amd64
+
+  ggbc-backend:
+    # Build locally instead of pulling the GHCR image — the prod image is
+    # currently amd64-only and won't run on Apple Silicon. Assumes the
+    # ggbc-backend repo is checked out at ../ggbc-backend relative to this
+    # repo's root. Override via GGBC_BACKEND_PATH if it lives elsewhere.
+    build:
+      context: ${GGBC_BACKEND_PATH:-../ggbc-backend}
+    environment:
+      - COOKIE_SECURE=false
+      - COOKIE_SAMESITE=lax
+      - ALLOW_SELF_REGISTRATION=true
+      - ENVIRONMENT=development
+      # In dev we don't run seed-owner (busybox wget can't preserve the ST
+      # session cookie that script requires). Instead, ggbc-backend uses
+      # ST's auto-created `default-user` (unprotected admin) as its service
+      # identity. Users self-register through the UI.
+      - ST_SERVICE_HANDLE=default-user
+      - ST_SERVICE_PASSWORD=
+      # Disable the ggbc owner bootstrap too — same reason. Sign up your
+      # first user via /register; ggbc-backend will provision the matching
+      # ST account through default-user.
+      - OWNER_HANDLE=
+      - OWNER_PASSWORD=
+    command:
+      - "sh"
+      - "-c"
+      - "alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 8001"
+
+  seed-owner:
+    # Disabled in dev — busybox wget in alpine can't preserve the ST session
+    # cookie that seed-owner.sh depends on. ggbc-backend uses ST's auto-
+    # created default-user as its service identity instead.
+    profiles: ["disabled-in-dev"]

--- a/docker/seed-owner.sh
+++ b/docker/seed-owner.sh
@@ -11,7 +11,11 @@
 set -e
 
 SENTINEL="/config/.owner-seeded"
-ST="http://localhost:${ST_PORT:-8000}"
+# Use 127.0.0.1 (not localhost) — busybox wget resolves `localhost` to
+# IPv6 ::1 first, and ST listens on IPv4 only, so the localhost form
+# fails with "connection refused" on environments whose /etc/hosts
+# resolves localhost to both ::1 and 127.0.0.1 (Docker Desktop on Mac).
+ST="http://127.0.0.1:${ST_PORT:-8000}"
 
 # Skip if already seeded or env vars not set
 if [ -f "$SENTINEL" ]; then

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,9 +2,21 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 
-// Backend URL can be overridden via ST_BACKEND for local dev when the
-// default port is already in use (e.g. running two worktrees in parallel).
-const BACKEND = process.env.ST_BACKEND || 'http://localhost:8000'
+// Vite dev proxies everything that isn't a static asset to ggbc-backend,
+// which serves /auth/* /sync/* /invitations/* /health itself and forwards
+// /api/* /thumbnail /characters /scripts /csrf-token to SillyTavern with
+// the per-user ST session it manages. Override the target via the
+// GGBC_BACKEND env var if you're running two worktrees in parallel.
+//
+// Use 127.0.0.1 (not localhost) — node 18+ resolves localhost to IPv6 ::1
+// first, and Docker publishes 127.0.0.1:8001 IPv4-only, so the localhost
+// form silently fails before the proxy gets a chance to send anything.
+const BACKEND = process.env.GGBC_BACKEND || 'http://127.0.0.1:8001'
+
+const proxyTarget = {
+  target: BACKEND,
+  changeOrigin: true,
+}
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -12,40 +24,16 @@ export default defineConfig({
   server: {
     port: 3000,
     proxy: {
-      '/api': {
-        target: BACKEND,
-        changeOrigin: true,
-        headers: process.env.ST_BASIC_AUTH
-          ? { Authorization: `Basic ${Buffer.from(process.env.ST_BASIC_AUTH).toString('base64')}` }
-          : {},
-      },
-      '/csrf-token': {
-        target: BACKEND,
-        changeOrigin: true,
-        headers: process.env.ST_BASIC_AUTH
-          ? { Authorization: `Basic ${Buffer.from(process.env.ST_BASIC_AUTH).toString('base64')}` }
-          : {},
-      },
-      '/thumbnail': {
-        target: BACKEND,
-        changeOrigin: true,
-        headers: process.env.ST_BASIC_AUTH
-          ? { Authorization: `Basic ${Buffer.from(process.env.ST_BASIC_AUTH).toString('base64')}` }
-          : {},
-      },
-      '/characters': {
-        target: BACKEND,
-        changeOrigin: true,
-        headers: process.env.ST_BASIC_AUTH
-          ? { Authorization: `Basic ${Buffer.from(process.env.ST_BASIC_AUTH).toString('base64')}` }
-          : {},
-      },
+      '/auth': proxyTarget,
+      '/sync': proxyTarget,
+      '/invitations': proxyTarget,
+      '/health': proxyTarget,
+      '/api': proxyTarget,
+      '/csrf-token': proxyTarget,
+      '/thumbnail': proxyTarget,
+      '/characters': proxyTarget,
       '/scripts': {
-        target: BACKEND,
-        changeOrigin: true,
-        headers: process.env.ST_BASIC_AUTH
-          ? { Authorization: `Basic ${Buffer.from(process.env.ST_BASIC_AUTH).toString('base64')}` }
-          : {},
+        ...proxyTarget,
         // Specific upstream-compat shim modules served from public/ must NOT
         // be proxied — they shadow upstream files of the same name so
         // ES-module-based extensions can `import { ... } from '../../../...'`


### PR DESCRIPTION
## Summary

Runs the production-style backend stack in Docker plus vite dev for the frontend with HMR — no need to deploy to production to test changes.

\`\`\`
cp .env.example .env
GGBC_BACKEND_PATH=/path/to/ggbc-backend \\
    docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d
npm run dev   # http://localhost:3000
\`\`\`

## What's in the overlay

- Publishes ggbc-backend (8001), postgres (5432), sillytavern (8000) to host loopback via frontend's port list (they share its network namespace).
- Switches \`COOKIE_SECURE\` off so cookies work on HTTP localhost.
- Enables self-registration so a test user can be created in seconds.
- Builds ggbc-backend from a sibling \`../ggbc-backend\` checkout (env-overridable) — pairs with the multi-arch CI fix in [ggbc-backend#9](https://github.com/sammygallo/ggbc-backend/pull/9).
- Platform-pins the frontend + sillytavern images to \`linux/amd64\` (those repos are still amd64-only on GHCR; Docker Desktop emulates via Rosetta).
- Disables \`seed-owner\` in dev — busybox wget can't preserve the ST session cookie it depends on. ggbc-backend uses ST's auto-created \`default-user\` (unprotected admin) as its service identity instead; sign up your first dev user through the UI.

## Frontend changes

- \`vite.config.ts\`: switches BACKEND default to \`http://127.0.0.1:8001\` (was ST direct), adds \`/auth /sync /invitations /health\` proxy routes. Uses \`127.0.0.1\` so node's IPv6-first DNS doesn't miss Docker's IPv4-only port publish.
- \`docker/seed-owner.sh\`: same 127.0.0.1 fix — production-safe and stops the script from blackholing on any /etc/hosts that resolves localhost to \`::1\`.
- \`README.md\`: local-dev section with the two-terminal workflow.

## Verified end-to-end

- \`docker compose up\` brings up all five services
- \`npm run dev\` serves at localhost:3000
- Login → \`/auth/login\` 200 + cookie
- \`/api/users/me\` round-trips through ggbc-backend → ST proxy
- \`/sync/sections\` round-trips through ggbc-backend → postgres
- Characters load (Seraphina), no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)