### PR TITLE
A3.1a: sync lorebooks across devices

### DIFF
--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -87,6 +87,7 @@ export const useAuthStore = create<AuthState>((set) => ({
         usePersonaStore.getState().fetchPrefs();
         useConnectionProfileStore.getState().fetchPrefs();
         useChatHistoryRagStore.getState().fetchPrefs();
+      useWorldInfoStore.getState().fetchPrefs();
       } else {
         set({ isAuthenticated: false, currentUser: null, isLoading: false });
       }
@@ -150,6 +151,7 @@ export const useAuthStore = create<AuthState>((set) => ({
       usePersonaStore.getState().fetchPrefs();
       useConnectionProfileStore.getState().fetchPrefs();
       useChatHistoryRagStore.getState().fetchPrefs();
+      useWorldInfoStore.getState().fetchPrefs();
       return true;
     } catch (error) {
       set({
@@ -195,6 +197,7 @@ export const useAuthStore = create<AuthState>((set) => ({
       usePersonaStore.getState().fetchPrefs();
       useConnectionProfileStore.getState().fetchPrefs();
       useChatHistoryRagStore.getState().fetchPrefs();
+      useWorldInfoStore.getState().fetchPrefs();
       return true;
     } catch (error) {
       set({

--- a/src/stores/worldInfoStore.ts
+++ b/src/stores/worldInfoStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { estimateTokens, type TokenizerProfile } from '../utils/tokenizer';
+import { getSettingsBlob, makeLocalTsKey, patchServerKey } from '../utils/serverSettings';
 import type {
   CharacterBookV2,
   CharacterBookEntryV2,
@@ -1114,6 +1115,32 @@ interface WorldInfoState {
   // to clear in-memory state so one user's books don't bleed into another's.
   initForUser: (handle: string) => void;
   resetUser: () => void;
+
+  /**
+   * Pull this user's lorebook state from ggbc-backend's /sync/section/{name}.
+   *
+   * Migration on first call: if the server has no record yet, push the
+   * current localStorage state up as the initial sync (so users who built
+   * up lorebooks pre-A3 don't lose them). After this returns, autosave is
+   * enabled — any subsequent mutation debounces a PUT back to the server.
+   */
+  fetchPrefs: () => Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Cross-device sync (A3.1a — lorebooks)
+// ---------------------------------------------------------------------------
+
+const SERVER_KEY = 'stm_worldinfo';
+const LOCAL_TS_KEY = makeLocalTsKey(SERVER_KEY);
+
+interface PersistedShape {
+  books: WorldInfoBook[];
+  activeBookIds: string[];
+  chatLinkedBookIds: Record<string, string[]>;
+  scanDepth: number;
+  maxRecursionSteps: number;
+  tokenBudget: number;
 }
 
 export const useWorldInfoStore = create<WorldInfoState>((set, get) => ({
@@ -1433,6 +1460,9 @@ export const useWorldInfoStore = create<WorldInfoState>((set, get) => ({
 
   initForUser: (handle) => {
     _currentHandle = handle;
+    // Hydrate from localStorage first so the UI has something to show before
+    // fetchPrefs returns. fetchPrefs will overlay the server state if newer.
+    _persistEnabled = false;
     set({
       books: loadBooks(handle),
       activeBookIds: loadActiveBooks(handle),
@@ -1445,6 +1475,7 @@ export const useWorldInfoStore = create<WorldInfoState>((set, get) => ({
   },
 
   resetUser: () => {
+    _persistEnabled = false;
     _currentHandle = null;
     set({
       books: [],
@@ -1456,4 +1487,115 @@ export const useWorldInfoStore = create<WorldInfoState>((set, get) => ({
       error: null,
     });
   },
+
+  fetchPrefs: async () => {
+    try {
+      const settings = await getSettingsBlob();
+      const stored = settings[SERVER_KEY] as
+        | (PersistedShape & { _ts?: number })
+        | undefined;
+      const localTs = Number(localStorage.getItem(LOCAL_TS_KEY) || 0);
+      const serverTs = Number(stored?._ts || 0);
+
+      if (!stored) {
+        // First-ever sync for this user — seed the server with the
+        // localStorage state we just loaded in initForUser.
+        _persistEnabled = true;
+        const s = get();
+        const hasAnything =
+          s.books.length > 0 ||
+          s.activeBookIds.length > 0 ||
+          Object.keys(s.chatLinkedBookIds).length > 0;
+        if (hasAnything) {
+          patchServerKey(
+            SERVER_KEY,
+            snapshotForServer(s) as unknown as Record<string, unknown>,
+            LOCAL_TS_KEY,
+          ).catch(() => {});
+        }
+        return;
+      }
+
+      if (localTs > serverTs) {
+        // Local has unconfirmed mutations — push them and keep local state.
+        _persistEnabled = true;
+        patchServerKey(
+          SERVER_KEY,
+          snapshotForServer(get()) as unknown as Record<string, unknown>,
+          LOCAL_TS_KEY,
+        ).catch(() => {});
+        return;
+      }
+
+      // Server has newer (or equal) state — apply it.
+      _persistEnabled = false;
+      const handle = _currentHandle;
+      const books = Array.isArray(stored.books) ? stored.books : [];
+      const activeBookIds = Array.isArray(stored.activeBookIds)
+        ? stored.activeBookIds
+        : [];
+      const chatLinkedBookIds =
+        stored.chatLinkedBookIds && typeof stored.chatLinkedBookIds === 'object'
+          ? stored.chatLinkedBookIds
+          : {};
+      set({
+        books,
+        activeBookIds,
+        chatLinkedBookIds,
+        scanDepth: stored.scanDepth ?? DEFAULT_SCAN_DEPTH,
+        maxRecursionSteps: stored.maxRecursionSteps ?? DEFAULT_MAX_RECURSION,
+        tokenBudget: stored.tokenBudget ?? DEFAULT_TOKEN_BUDGET,
+      });
+      // Cache to localStorage so the next cold load is instant.
+      if (handle) {
+        try {
+          localStorage.setItem(scopedKey(BOOKS_KEY, handle), JSON.stringify(books));
+          localStorage.setItem(scopedKey(ACTIVE_BOOKS_KEY, handle), JSON.stringify(activeBookIds));
+          localStorage.setItem(scopedKey(CHAT_LINKED_BOOKS_KEY, handle), JSON.stringify(chatLinkedBookIds));
+          localStorage.setItem(scopedKey(SCAN_DEPTH_KEY, handle), String(stored.scanDepth ?? DEFAULT_SCAN_DEPTH));
+          localStorage.setItem(scopedKey(MAX_RECURSION_KEY, handle), String(stored.maxRecursionSteps ?? DEFAULT_MAX_RECURSION));
+          localStorage.setItem(scopedKey(TOKEN_BUDGET_KEY, handle), String(stored.tokenBudget ?? DEFAULT_TOKEN_BUDGET));
+        } catch { /* ignore */ }
+      }
+      try { localStorage.setItem(LOCAL_TS_KEY, String(serverTs)); } catch { /* ignore */ }
+      _persistEnabled = true;
+    } catch {
+      // Network failure — keep local state. Next mutation marks LOCAL_TS_KEY
+      // dirty, so a future fetchPrefs will detect the local-newer case.
+      _persistEnabled = true;
+    }
+  },
 }));
+
+// ---------------------------------------------------------------------------
+// Subscribe-based autosave (debounced) — set up after the store exists so
+// useWorldInfoStore is in scope.
+// ---------------------------------------------------------------------------
+
+let _persistTimer: ReturnType<typeof setTimeout> | null = null;
+let _persistEnabled = false;
+
+function snapshotForServer(s: WorldInfoState): PersistedShape {
+  return {
+    books: s.books,
+    activeBookIds: s.activeBookIds,
+    chatLinkedBookIds: s.chatLinkedBookIds,
+    scanDepth: s.scanDepth,
+    maxRecursionSteps: s.maxRecursionSteps,
+    tokenBudget: s.tokenBudget,
+  };
+}
+
+useWorldInfoStore.subscribe((state) => {
+  if (!_persistEnabled) return;
+  try { localStorage.setItem(LOCAL_TS_KEY, String(Date.now())); } catch { /* ignore */ }
+  if (_persistTimer) clearTimeout(_persistTimer);
+  _persistTimer = setTimeout(() => {
+    _persistTimer = null;
+    patchServerKey(
+      SERVER_KEY,
+      snapshotForServer(state) as unknown as Record<string, unknown>,
+      LOCAL_TS_KEY,
+    ).catch(() => {});
+  }, 300);
+});


### PR DESCRIPTION
## Summary

First A3 chunk — wires \`worldInfoStore\` into the A2 \`/sync/section/{name}\` layer so lorebooks (books + active flags + chat-linked overrides + scan-depth / recursion / token-budget settings) follow users across devices instead of being trapped in per-device localStorage.

## How

- **fetchPrefs**: pulls \`/sync/section/stm_worldinfo\`. First call per user with no server record seeds the server with localStorage state — so pre-A3 lorebooks survive the cutover. Otherwise applies the server state and caches it back to localStorage.
- **Subscribe-based autosave**: 300ms debounced PUT on any store change, gated by a \`_persistEnabled\` flag so \`initForUser\` / \`resetUser\` / \`fetchPrefs\`'s own state apply don't echo back to the server.
- **authStore**: \`fetchPrefs\` wired into \`checkAuth\` / \`register\` / \`login\` alongside the existing seven synced stores.

## Verified locally

Against the docker-compose.dev.yml stack:

- PUT a stm_worldinfo blob → reload → \`worldInfoStore.getState()\` correctly hydrated with the book, entries, and settings.
- \`createBook('Live-mutation Test')\` via the store → server_ts increments (1 → 2) + new book visible on \`GET /sync/section/stm_worldinfo\` within ~300ms.
- Zero console errors.

## Why this is the pattern, not a one-off

Same shape will repeat in A3.1b through A3.1d:

- group chats, branches, author notes → \`stm_chat_state\` (or split — TBD)
- regex scripts → \`stm_regex_scripts\`
- prompt templates → \`stm_prompt_templates\`
- image gallery → \`stm_image_gallery\`
- Data Bank documents → \`stm_data_bank\`
- persona avatars + VN backgrounds → \`user_blobs\` (separate API)

Each store gets the same: SERVER_KEY constant, fetchPrefs with first-time seed, subscribe-based debounced push, wire into authStore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)