### PR TITLE
A3.1b1: sync chat branches across devices

### DIFF
--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -4,6 +4,7 @@ import { useCharacterStore } from './characterStore';
 import { useChatStore } from './chatStore';
 import { useSettingsStore } from './settingsStore';
 import { useWorldInfoStore } from './worldInfoStore';
+import { useBranchStore } from './branchStore';
 import { useThemeStore } from './themeStore';
 import { useDisplayPreferencesStore } from './displayPreferencesStore';
 import { useSpeechPreferencesStore } from './speechPreferencesStore';
@@ -88,6 +89,7 @@ export const useAuthStore = create<AuthState>((set) => ({
         useConnectionProfileStore.getState().fetchPrefs();
         useChatHistoryRagStore.getState().fetchPrefs();
       useWorldInfoStore.getState().fetchPrefs();
+      useBranchStore.getState().fetchPrefs();
       } else {
         set({ isAuthenticated: false, currentUser: null, isLoading: false });
       }
@@ -152,6 +154,7 @@ export const useAuthStore = create<AuthState>((set) => ({
       useConnectionProfileStore.getState().fetchPrefs();
       useChatHistoryRagStore.getState().fetchPrefs();
       useWorldInfoStore.getState().fetchPrefs();
+      useBranchStore.getState().fetchPrefs();
       return true;
     } catch (error) {
       set({
@@ -198,6 +201,7 @@ export const useAuthStore = create<AuthState>((set) => ({
       useConnectionProfileStore.getState().fetchPrefs();
       useChatHistoryRagStore.getState().fetchPrefs();
       useWorldInfoStore.getState().fetchPrefs();
+      useBranchStore.getState().fetchPrefs();
       return true;
     } catch (error) {
       set({

--- a/src/stores/branchStore.ts
+++ b/src/stores/branchStore.ts
@@ -3,9 +3,14 @@
  * A "branch" (checkpoint) is a named snapshot of the conversation up to a
  * specific message. Branches are stored in localStorage keyed by chat file.
  * Loading a branch replaces the in-memory message array without touching disk.
+ *
+ * A3.1b: branches now sync across devices via /sync/section/stm_branches.
+ * localStorage stays as a synchronous cache for instant cold loads; the
+ * server is the source of truth once fetchPrefs runs.
  */
 import { create } from 'zustand';
 import type { ChatMessage } from './chatStore';
+import { getSettingsBlob, makeLocalTsKey, patchServerKey } from '../utils/serverSettings';
 
 export interface Branch {
   id: string;
@@ -21,6 +26,8 @@ export interface Branch {
 }
 
 const BRANCHES_KEY = 'sillytavern_branches';
+const SERVER_KEY = 'stm_branches';
+const LOCAL_TS_KEY = makeLocalTsKey(SERVER_KEY);
 
 function loadAllFromStorage(): Record<string, Branch[]> {
   try {
@@ -34,8 +41,38 @@ function loadAllFromStorage(): Record<string, Branch[]> {
   }
 }
 
-function saveAllToStorage(data: Record<string, Branch[]>) {
-  localStorage.setItem(BRANCHES_KEY, JSON.stringify(data));
+function writeLocalStorageOnly(data: Record<string, Branch[]>): void {
+  try {
+    localStorage.setItem(BRANCHES_KEY, JSON.stringify(data));
+  } catch {
+    // ignore quota
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Cross-device sync (debounced, post-fetchPrefs only)
+// ---------------------------------------------------------------------------
+
+let _persistEnabled = false;
+let _persistTimer: ReturnType<typeof setTimeout> | null = null;
+
+function schedulePersist(data: Record<string, Branch[]>): void {
+  if (!_persistEnabled) return;
+  try { localStorage.setItem(LOCAL_TS_KEY, String(Date.now())); } catch { /* ignore */ }
+  if (_persistTimer) clearTimeout(_persistTimer);
+  _persistTimer = setTimeout(() => {
+    _persistTimer = null;
+    patchServerKey(
+      SERVER_KEY,
+      { all: data } as unknown as Record<string, unknown>,
+      LOCAL_TS_KEY,
+    ).catch(() => {});
+  }, 300);
+}
+
+function saveAllToStorage(data: Record<string, Branch[]>): void {
+  writeLocalStorageOnly(data);
+  schedulePersist(data);
 }
 
 interface BranchState {
@@ -56,6 +93,13 @@ interface BranchState {
   deleteBranch(id: string, chatFile: string): void;
   renameBranch(id: string, chatFile: string, name: string): void;
   setActiveBranch(id: string | null): void;
+
+  /**
+   * Pull /sync/section/stm_branches and reconcile with localStorage.
+   * First call per user with no server record seeds the server with whatever
+   * is currently in localStorage so pre-A3 checkpoints survive the cutover.
+   */
+  fetchPrefs(): Promise<void>;
 }
 
 export const useBranchStore = create<BranchState>((set, get) => ({
@@ -108,5 +152,55 @@ export const useBranchStore = create<BranchState>((set, get) => ({
 
   setActiveBranch(id) {
     set({ activeBranchId: id });
+  },
+
+  fetchPrefs: async () => {
+    try {
+      const settings = await getSettingsBlob();
+      const stored = settings[SERVER_KEY] as
+        | { all?: Record<string, Branch[]>; _ts?: number }
+        | undefined;
+      const localTs = Number(localStorage.getItem(LOCAL_TS_KEY) || 0);
+      const serverTs = Number(stored?._ts || 0);
+
+      if (!stored || !stored.all) {
+        // First-ever sync for this user — seed the server with localStorage.
+        _persistEnabled = true;
+        const local = loadAllFromStorage();
+        if (Object.keys(local).length > 0) {
+          patchServerKey(
+            SERVER_KEY,
+            { all: local } as unknown as Record<string, unknown>,
+            LOCAL_TS_KEY,
+          ).catch(() => {});
+        }
+        return;
+      }
+
+      if (localTs > serverTs) {
+        // Local has unconfirmed mutations — push them.
+        _persistEnabled = true;
+        patchServerKey(
+          SERVER_KEY,
+          { all: loadAllFromStorage() } as unknown as Record<string, unknown>,
+          LOCAL_TS_KEY,
+        ).catch(() => {});
+        return;
+      }
+
+      // Server has newer (or equal) state — apply and cache.
+      _persistEnabled = false;
+      writeLocalStorageOnly(stored.all);
+      // We don't know which chat is currently open, so any visible branches
+      // will refresh next time loadBranchesForChat is called by the chat view.
+      // Clear the in-memory list so stale entries aren't shown.
+      set({ branches: [], activeBranchId: null });
+      try { localStorage.setItem(LOCAL_TS_KEY, String(serverTs)); } catch { /* ignore */ }
+      _persistEnabled = true;
+    } catch {
+      // Network failure — keep local state. Future mutations will mark
+      // LOCAL_TS_KEY dirty, so a later fetchPrefs detects the local-newer case.
+      _persistEnabled = true;
+    }
   },
 }));


### PR DESCRIPTION
## Summary

Second A3 chunk — wires \`branchStore\` into \`/sync/section/stm_branches\`. Chat branches (named checkpoints) now follow users across devices.

Same pattern as #233 (lorebooks), simpler since \`branchStore\` already funnels every mutation through a single \`saveAllToStorage()\` — adding the patch hook there gives sync to all four actions (\`createBranch\` / \`deleteBranch\` / \`renameBranch\` / load-after-replace) for free.

## How

- \`SERVER_KEY = 'stm_branches'\`, payload shape \`{ all: Record<chatFile, Branch[]> }\` (one row in user_documents holds the full record).
- \`fetchPrefs()\`: first call per user with no server record seeds the server with localStorage so pre-A3 checkpoints survive the cutover. Otherwise applies the server's snapshot to localStorage and clears the in-memory list — the chat view re-populates via the existing \`loadBranchesForChat\` path.
- 300ms-debounced PUT, gated by \`_persistEnabled\` so the apply-from-server step doesn't echo back.
- \`authStore\`: \`useBranchStore.fetchPrefs()\` wired into \`checkAuth\` / \`register\` / \`login\` alongside the existing synced stores.

## Verified locally

Against the docker-compose.dev.yml stack:

- \`createBranch\` via store → \`PUT /sync/section/stm_branches\` populated within ~300ms (server_ts = 1).
- Page reload → \`fetchPrefs\` hydrates localStorage → \`loadBranchesForChat\` returns the branch in store state.
- Zero app-level console errors.

## Next

A3.1b2 — \`chatStore\` (group chats + author notes + per-chat variables) is the bigger chat-state cousin and will land separately because chatStore is ~3000 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)