### PR TITLE
A3.1c: sync regex scripts + prompt templates

### DIFF
--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -5,6 +5,8 @@ import { useChatStore } from './chatStore';
 import { useSettingsStore } from './settingsStore';
 import { useWorldInfoStore } from './worldInfoStore';
 import { useBranchStore } from './branchStore';
+import { useRegexScriptStore } from './regexScriptStore';
+import { usePromptTemplateStore } from './promptTemplateStore';
 import { useThemeStore } from './themeStore';
 import { useDisplayPreferencesStore } from './displayPreferencesStore';
 import { useSpeechPreferencesStore } from './speechPreferencesStore';
@@ -91,6 +93,8 @@ export const useAuthStore = create<AuthState>((set) => ({
       useWorldInfoStore.getState().fetchPrefs();
       useBranchStore.getState().fetchPrefs();
       useChatStore.getState().fetchPrefs();
+      useRegexScriptStore.getState().fetchPrefs();
+      usePromptTemplateStore.getState().fetchPrefs();
       } else {
         set({ isAuthenticated: false, currentUser: null, isLoading: false });
       }
@@ -157,6 +161,8 @@ export const useAuthStore = create<AuthState>((set) => ({
       useWorldInfoStore.getState().fetchPrefs();
       useBranchStore.getState().fetchPrefs();
       useChatStore.getState().fetchPrefs();
+      useRegexScriptStore.getState().fetchPrefs();
+      usePromptTemplateStore.getState().fetchPrefs();
       return true;
     } catch (error) {
       set({
@@ -205,6 +211,8 @@ export const useAuthStore = create<AuthState>((set) => ({
       useWorldInfoStore.getState().fetchPrefs();
       useBranchStore.getState().fetchPrefs();
       useChatStore.getState().fetchPrefs();
+      useRegexScriptStore.getState().fetchPrefs();
+      usePromptTemplateStore.getState().fetchPrefs();
       return true;
     } catch (error) {
       set({

--- a/src/stores/promptTemplateStore.ts
+++ b/src/stores/promptTemplateStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { getSettingsBlob, makeLocalTsKey, patchServerKey } from '../utils/serverSettings';
 import {
   useGenerationStore,
   DEFAULT_PROMPT_CONFIG,
@@ -69,9 +70,31 @@ interface PromptTemplateState {
   importTemplates: (json: string) => { imported: number; errors: number };
   exportTemplates: () => string;
   exportTemplate: (id: string) => string | null;
+
+  /** A3.1c — pull /sync/section/stm_prompt_templates and reconcile. */
+  fetchPrefs: () => Promise<void>;
 }
 
 const STORAGE_KEY = 'stm:prompt-templates';
+const SERVER_KEY = 'stm_prompt_templates';
+const LOCAL_TS_KEY = makeLocalTsKey(SERVER_KEY);
+
+let _persistEnabled = false;
+let _persistTimer: ReturnType<typeof setTimeout> | null = null;
+
+function schedulePersist(state: PersistedShape): void {
+  if (!_persistEnabled) return;
+  try { localStorage.setItem(LOCAL_TS_KEY, String(Date.now())); } catch { /* ignore */ }
+  if (_persistTimer) clearTimeout(_persistTimer);
+  _persistTimer = setTimeout(() => {
+    _persistTimer = null;
+    patchServerKey(
+      SERVER_KEY,
+      state as unknown as Record<string, unknown>,
+      LOCAL_TS_KEY,
+    ).catch(() => {});
+  }, 300);
+}
 
 interface PersistedShape {
   templates: PromptTemplate[];
@@ -113,14 +136,16 @@ function loadFromStorage(): PersistedShape {
  * drop fields they didn't pass.
  */
 function saveToStorage(state: PersistedShape) {
+  let merged: PersistedShape = state;
   try {
     const existingRaw = localStorage.getItem(STORAGE_KEY);
     const existing: Partial<PersistedShape> = existingRaw ? JSON.parse(existingRaw) : {};
-    const merged: PersistedShape = { ...existing, ...state };
+    merged = { ...existing, ...state };
     localStorage.setItem(STORAGE_KEY, JSON.stringify(merged));
   } catch {
     // ignore quota / parse errors
   }
+  schedulePersist(merged);
 }
 
 function generateId(): string {
@@ -379,5 +404,74 @@ export const usePromptTemplateStore = create<PromptTemplateState>((set, get) => 
     const t = templates.find((x) => x.id === id);
     if (!t) return null;
     return JSON.stringify({ version: 1, templates: [t] }, null, 2);
+  },
+
+  fetchPrefs: async () => {
+    try {
+      const settings = await getSettingsBlob();
+      const stored = settings[SERVER_KEY] as
+        | (PersistedShape & { _ts?: number })
+        | undefined;
+      const localTs = Number(localStorage.getItem(LOCAL_TS_KEY) || 0);
+      const serverTs = Number(stored?._ts || 0);
+
+      if (!stored) {
+        _persistEnabled = true;
+        const s = get();
+        const snapshot: PersistedShape = {
+          templates: s.templates,
+          activeTemplateId: s.activeTemplateId,
+          linkedTemplateByAvatar: s.linkedTemplateByAvatar,
+          mainPromptSnapshot: s.mainPromptSnapshot,
+        };
+        if (s.templates.length > 0 || Object.keys(s.linkedTemplateByAvatar).length > 0) {
+          patchServerKey(
+            SERVER_KEY,
+            snapshot as unknown as Record<string, unknown>,
+            LOCAL_TS_KEY,
+          ).catch(() => {});
+        }
+        return;
+      }
+
+      if (localTs > serverTs) {
+        _persistEnabled = true;
+        const s = get();
+        const snapshot: PersistedShape = {
+          templates: s.templates,
+          activeTemplateId: s.activeTemplateId,
+          linkedTemplateByAvatar: s.linkedTemplateByAvatar,
+          mainPromptSnapshot: s.mainPromptSnapshot,
+        };
+        patchServerKey(
+          SERVER_KEY,
+          snapshot as unknown as Record<string, unknown>,
+          LOCAL_TS_KEY,
+        ).catch(() => {});
+        return;
+      }
+
+      _persistEnabled = false;
+      const templates = Array.isArray(stored.templates) ? stored.templates : [];
+      const activeTemplateId =
+        typeof stored.activeTemplateId === 'string' ? stored.activeTemplateId : null;
+      const linkedTemplateByAvatar =
+        stored.linkedTemplateByAvatar && typeof stored.linkedTemplateByAvatar === 'object'
+          ? stored.linkedTemplateByAvatar
+          : {};
+      const mainPromptSnapshot =
+        typeof stored.mainPromptSnapshot === 'string' ? stored.mainPromptSnapshot : null;
+      try {
+        localStorage.setItem(
+          STORAGE_KEY,
+          JSON.stringify({ templates, activeTemplateId, linkedTemplateByAvatar, mainPromptSnapshot }),
+        );
+        localStorage.setItem(LOCAL_TS_KEY, String(serverTs));
+      } catch { /* ignore */ }
+      set({ templates, activeTemplateId, linkedTemplateByAvatar, mainPromptSnapshot });
+      _persistEnabled = true;
+    } catch {
+      _persistEnabled = true;
+    }
   },
 }));

--- a/src/stores/regexScriptStore.ts
+++ b/src/stores/regexScriptStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { getSettingsBlob, makeLocalTsKey, patchServerKey } from '../utils/serverSettings';
 
 /** Phase 8.2: Regex Scripts — find/replace patterns applied to AI output,
  *  user input, or both. Scripts can be display-only (render transform only)
@@ -27,6 +28,25 @@ export interface RegexScript {
 export type RegexScope = 'ai_output' | 'user_input' | 'both';
 
 const STORAGE_KEY = 'sillytavern_regex_scripts';
+const SERVER_KEY = 'stm_regex_scripts';
+const LOCAL_TS_KEY = makeLocalTsKey(SERVER_KEY);
+
+let _persistEnabled = false;
+let _persistTimer: ReturnType<typeof setTimeout> | null = null;
+
+function schedulePersist(scripts: RegexScript[]): void {
+  if (!_persistEnabled) return;
+  try { localStorage.setItem(LOCAL_TS_KEY, String(Date.now())); } catch { /* ignore */ }
+  if (_persistTimer) clearTimeout(_persistTimer);
+  _persistTimer = setTimeout(() => {
+    _persistTimer = null;
+    patchServerKey(
+      SERVER_KEY,
+      { scripts } as unknown as Record<string, unknown>,
+      LOCAL_TS_KEY,
+    ).catch(() => {});
+  }, 300);
+}
 
 function generateId(): string {
   return `rs_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
@@ -50,6 +70,7 @@ function saveToStorage(scripts: RegexScript[]) {
   } catch {
     console.error('[RegexScripts] Failed to save to localStorage');
   }
+  schedulePersist(scripts);
 }
 
 interface RegexScriptState {
@@ -63,6 +84,9 @@ interface RegexScriptState {
 
   importScripts: (json: string) => number;
   exportScripts: () => string;
+
+  /** A3.1c — pull /sync/section/stm_regex_scripts and reconcile. */
+  fetchPrefs: () => Promise<void>;
 }
 
 export const useRegexScriptStore = create<RegexScriptState>((set, get) => ({
@@ -190,5 +214,50 @@ export const useRegexScriptStore = create<RegexScriptState>((set, get) => ({
   exportScripts: () => {
     const { scripts } = get();
     return JSON.stringify({ scripts }, null, 2);
+  },
+
+  fetchPrefs: async () => {
+    try {
+      const settings = await getSettingsBlob();
+      const stored = settings[SERVER_KEY] as
+        | { scripts?: RegexScript[]; _ts?: number }
+        | undefined;
+      const localTs = Number(localStorage.getItem(LOCAL_TS_KEY) || 0);
+      const serverTs = Number(stored?._ts || 0);
+
+      if (!stored) {
+        _persistEnabled = true;
+        const scripts = get().scripts;
+        if (scripts.length > 0) {
+          patchServerKey(
+            SERVER_KEY,
+            { scripts } as unknown as Record<string, unknown>,
+            LOCAL_TS_KEY,
+          ).catch(() => {});
+        }
+        return;
+      }
+
+      if (localTs > serverTs) {
+        _persistEnabled = true;
+        patchServerKey(
+          SERVER_KEY,
+          { scripts: get().scripts } as unknown as Record<string, unknown>,
+          LOCAL_TS_KEY,
+        ).catch(() => {});
+        return;
+      }
+
+      _persistEnabled = false;
+      const scripts = Array.isArray(stored.scripts) ? stored.scripts : [];
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(scripts));
+        localStorage.setItem(LOCAL_TS_KEY, String(serverTs));
+      } catch { /* ignore */ }
+      set({ scripts });
+      _persistEnabled = true;
+    } catch {
+      _persistEnabled = true;
+    }
   },
 }));


### PR DESCRIPTION
## Summary

Fourth A3 chunk. Same pattern as #233/#234/#235 — both stores already funnel mutations through a single \`saveToStorage\` helper, so wiring \`schedulePersist\` in there gives sync to every mutation site for free.

- \`regexScriptStore\` → \`/sync/section/stm_regex_scripts\` (payload \`{scripts}\`)
- \`promptTemplateStore\` → \`/sync/section/stm_prompt_templates\` (payload \`{templates, activeTemplateId, linkedTemplateByAvatar, mainPromptSnapshot}\`)
- Both stores get the same \`fetchPrefs\` with first-call-seed / local-newer / server-newer reconciliation.
- \`authStore\`: fetchPrefs wired into checkAuth / register / login.

## Verified locally

- \`createScript('Test Regex', …)\` → \`GET /sync/section/stm_regex_scripts\` returns the script within ~300ms (server_ts = 1).
- Build clean, zero app-level console errors.

## Remaining

- **A3.1d** — \`imageGenStore\` (gallery) + \`dataBankStore\` (RAG docs)
- **A3.2** — persona avatars + VN backgrounds (needs the new \`user_blobs\` backend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)