### PR TITLE
A3.1d: sync Data Bank documents + image-gen config

### DIFF
--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -7,6 +7,8 @@ import { useWorldInfoStore } from './worldInfoStore';
 import { useBranchStore } from './branchStore';
 import { useRegexScriptStore } from './regexScriptStore';
 import { usePromptTemplateStore } from './promptTemplateStore';
+import { useImageGenStore } from './imageGenStore';
+import { useDataBankStore } from './dataBankStore';
 import { useThemeStore } from './themeStore';
 import { useDisplayPreferencesStore } from './displayPreferencesStore';
 import { useSpeechPreferencesStore } from './speechPreferencesStore';
@@ -95,6 +97,8 @@ export const useAuthStore = create<AuthState>((set) => ({
       useChatStore.getState().fetchPrefs();
       useRegexScriptStore.getState().fetchPrefs();
       usePromptTemplateStore.getState().fetchPrefs();
+      useImageGenStore.getState().fetchPrefs();
+      useDataBankStore.getState().fetchPrefs();
       } else {
         set({ isAuthenticated: false, currentUser: null, isLoading: false });
       }
@@ -163,6 +167,8 @@ export const useAuthStore = create<AuthState>((set) => ({
       useChatStore.getState().fetchPrefs();
       useRegexScriptStore.getState().fetchPrefs();
       usePromptTemplateStore.getState().fetchPrefs();
+      useImageGenStore.getState().fetchPrefs();
+      useDataBankStore.getState().fetchPrefs();
       return true;
     } catch (error) {
       set({
@@ -213,6 +219,8 @@ export const useAuthStore = create<AuthState>((set) => ({
       useChatStore.getState().fetchPrefs();
       useRegexScriptStore.getState().fetchPrefs();
       usePromptTemplateStore.getState().fetchPrefs();
+      useImageGenStore.getState().fetchPrefs();
+      useDataBankStore.getState().fetchPrefs();
       return true;
     } catch (error) {
       set({

--- a/src/stores/dataBankStore.ts
+++ b/src/stores/dataBankStore.ts
@@ -18,6 +18,7 @@
 import { create } from 'zustand';
 import { chunkText } from '../utils/chunker';
 import { getEmbedding, findTopK } from '../utils/embeddings';
+import { getSettingsBlob, makeLocalTsKey, patchServerKey } from '../utils/serverSettings';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -88,6 +89,9 @@ interface DataBankState {
     characterAvatar?: string,
     topK?: number
   ) => Promise<Array<{ text: string; docName: string }>>;
+
+  /** A3.1d — pull /sync/section/stm_data_bank and reconcile. */
+  fetchPrefs: () => Promise<void>;
 }
 
 // ---------------------------------------------------------------------------
@@ -95,11 +99,30 @@ interface DataBankState {
 // ---------------------------------------------------------------------------
 
 const STORAGE_KEY = 'stm:data-bank';
+const SERVER_KEY = 'stm_data_bank';
+const LOCAL_TS_KEY = makeLocalTsKey(SERVER_KEY);
 
 const EMBED_KEY_STORAGE = 'stm:data-bank-embed-key';
 
 interface PersistedShape {
   documents: DataBankDocument[];
+}
+
+let _persistEnabled = false;
+let _persistTimer: ReturnType<typeof setTimeout> | null = null;
+
+function schedulePersist(documents: DataBankDocument[]): void {
+  if (!_persistEnabled) return;
+  try { localStorage.setItem(LOCAL_TS_KEY, String(Date.now())); } catch { /* ignore */ }
+  if (_persistTimer) clearTimeout(_persistTimer);
+  _persistTimer = setTimeout(() => {
+    _persistTimer = null;
+    patchServerKey(
+      SERVER_KEY,
+      { documents } as unknown as Record<string, unknown>,
+      LOCAL_TS_KEY,
+    ).catch(() => {});
+  }, 500);
 }
 
 function loadFromStorage(): DataBankDocument[] {
@@ -117,6 +140,7 @@ function saveToStorage(documents: DataBankDocument[]) {
   try {
     localStorage.setItem(STORAGE_KEY, JSON.stringify({ documents } satisfies PersistedShape));
   } catch { /* ignore */ }
+  schedulePersist(documents);
 }
 
 function loadEmbedKey(): string {
@@ -235,6 +259,53 @@ export const useDataBankStore = create<DataBankState>((set, get) => ({
     } catch {
       // Fail silently so generation still proceeds without RAG
       return [];
+    }
+  },
+
+  fetchPrefs: async () => {
+    try {
+      const settings = await getSettingsBlob();
+      const stored = settings[SERVER_KEY] as
+        | { documents?: DataBankDocument[]; _ts?: number }
+        | undefined;
+      const localTs = Number(localStorage.getItem(LOCAL_TS_KEY) || 0);
+      const serverTs = Number(stored?._ts || 0);
+
+      if (!stored) {
+        _persistEnabled = true;
+        const documents = get().documents;
+        if (documents.length > 0) {
+          patchServerKey(
+            SERVER_KEY,
+            { documents } as unknown as Record<string, unknown>,
+            LOCAL_TS_KEY,
+          ).catch(() => {});
+        }
+        return;
+      }
+
+      if (localTs > serverTs) {
+        _persistEnabled = true;
+        patchServerKey(
+          SERVER_KEY,
+          { documents: get().documents } as unknown as Record<string, unknown>,
+          LOCAL_TS_KEY,
+        ).catch(() => {});
+        return;
+      }
+
+      _persistEnabled = false;
+      const documents = Array.isArray(stored.documents) ? stored.documents : [];
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify({ documents }));
+        localStorage.setItem(LOCAL_TS_KEY, String(serverTs));
+      } catch { /* ignore */ }
+      // Imported documents have no embeddings yet — caller will re-embed when
+      // RAG is next used. Same as the in-memory shape after a fresh load.
+      set({ documents, embeddingIds: new Set() });
+      _persistEnabled = true;
+    } catch {
+      _persistEnabled = true;
     }
   },
 }));

--- a/src/stores/imageGenStore.ts
+++ b/src/stores/imageGenStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { imageGenApi, type ImageGenBackend } from '../api/imageGenApi';
+import { getSettingsBlob, makeLocalTsKey, patchServerKey } from '../utils/serverSettings';
 
 // ---------------------------------------------------------------------------
 // Gallery entry — persisted alongside config
@@ -19,6 +20,25 @@ export interface GalleryEntry {
 
 const STORAGE_KEY = 'sillytavern_imagegen_config';
 const GALLERY_KEY = 'sillytavern_imagegen_gallery';
+const SERVER_KEY = 'stm_imagegen_config';
+const LOCAL_TS_KEY = makeLocalTsKey(SERVER_KEY);
+
+let _persistEnabled = false;
+let _persistTimer: ReturnType<typeof setTimeout> | null = null;
+
+function schedulePersist(config: ImageGenConfig): void {
+  if (!_persistEnabled) return;
+  try { localStorage.setItem(LOCAL_TS_KEY, String(Date.now())); } catch { /* ignore */ }
+  if (_persistTimer) clearTimeout(_persistTimer);
+  _persistTimer = setTimeout(() => {
+    _persistTimer = null;
+    patchServerKey(
+      SERVER_KEY,
+      config as unknown as Record<string, unknown>,
+      LOCAL_TS_KEY,
+    ).catch(() => {});
+  }, 300);
+}
 
 interface ImageGenConfig {
   backend: ImageGenBackend;
@@ -64,6 +84,7 @@ function loadConfig(): ImageGenConfig {
 
 function saveConfig(config: ImageGenConfig) {
   localStorage.setItem(STORAGE_KEY, JSON.stringify(config));
+  schedulePersist(config);
 }
 
 function loadGallery(): GalleryEntry[] {
@@ -122,6 +143,13 @@ interface ImageGenState extends ImageGenConfig {
   addToGallery: (entry: GalleryEntry) => void;
   removeFromGallery: (id: string) => void;
   clearGallery: () => void;
+
+  /**
+   * A3.1d — sync the image-gen config (backend choice, model, dims, etc.).
+   * The gallery's base64 data URLs are too large for JSONB rows and defer
+   * to A3.2's blob storage.
+   */
+  fetchPrefs: () => Promise<void>;
 }
 
 export const useImageGenStore = create<ImageGenState>((set, get) => ({
@@ -241,5 +269,65 @@ export const useImageGenStore = create<ImageGenState>((set, get) => ({
   clearGallery: () => {
     saveGallery([]);
     set({ gallery: [] });
+  },
+
+  fetchPrefs: async () => {
+    try {
+      const settings = await getSettingsBlob();
+      const stored = settings[SERVER_KEY] as
+        | (ImageGenConfig & { _ts?: number })
+        | undefined;
+      const localTs = Number(localStorage.getItem(LOCAL_TS_KEY) || 0);
+      const serverTs = Number(stored?._ts || 0);
+
+      const currentConfig = (): ImageGenConfig => {
+        const s = get();
+        return {
+          backend: s.backend,
+          sdUrl: s.sdUrl,
+          sdAuth: s.sdAuth,
+          pollinationsModel: s.pollinationsModel,
+          hordeModel: s.hordeModel,
+          hordeApiKey: s.hordeApiKey,
+          dalleModel: s.dalleModel,
+          dalleQuality: s.dalleQuality,
+          width: s.width,
+          height: s.height,
+          steps: s.steps,
+          cfgScale: s.cfgScale,
+        };
+      };
+
+      if (!stored) {
+        _persistEnabled = true;
+        patchServerKey(
+          SERVER_KEY,
+          currentConfig() as unknown as Record<string, unknown>,
+          LOCAL_TS_KEY,
+        ).catch(() => {});
+        return;
+      }
+
+      if (localTs > serverTs) {
+        _persistEnabled = true;
+        patchServerKey(
+          SERVER_KEY,
+          currentConfig() as unknown as Record<string, unknown>,
+          LOCAL_TS_KEY,
+        ).catch(() => {});
+        return;
+      }
+
+      _persistEnabled = false;
+      const merged: ImageGenConfig = { ...DEFAULT_CONFIG, ...stored };
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(merged));
+        localStorage.setItem(LOCAL_TS_KEY, String(serverTs));
+      } catch { /* ignore */ }
+      set(merged);
+      _persistEnabled = true;
+    } catch {
+      _persistEnabled = true;
+    }
   },
 }));


### PR DESCRIPTION
## Summary

Fifth A3 chunk. Wires the last two JSON-shaped stores into \`/sync/section/*\`. Image gallery dataUrls and persona avatar blobs are the last unsynced pieces — both defer to **A3.2** (which adds a \`user_blobs\` backend endpoint).

- \`dataBankStore\` → \`/sync/section/stm_data_bank\` (\`{documents}\`). 500ms debounce instead of the usual 300ms since document text can be large. Embeddings API key stays device-local (secret); embedding IDs stay client-side (transient runtime state, not persistent).
- \`imageGenStore\` → \`/sync/section/stm_imagegen_config\` (the full ImageGenConfig: backend choice, model, dims, etc.). Gallery base64 dataUrls deferred to A3.2.
- Same fetchPrefs reconciliation pattern as #233/#234/#235/#236.
- \`authStore\`: both fetchPrefs wired into checkAuth / register / login.

## Verified locally

Build clean, no console errors. End-to-end test pattern (createBook → server_ts increments, reload → fetchPrefs hydrates) already proved out across the prior four A3 PRs; this PR follows the same shape and reuses the same plumbing.

## After this lands

Only **A3.2** remains — persona avatars + VN backgrounds → new \`user_blobs\` backend + endpoint, frontend cutover for binary attachments. That's a different shape (binary blob storage, not JSONB) and worth its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)