### PR TITLE
feat(b3a): point generation + secrets at ggbc-backend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,18 @@ services:
       - COOKIE_SAMESITE=lax
       - ALLOW_SELF_REGISTRATION=${ALLOW_SELF_REGISTRATION:-false}
       - ENVIRONMENT=production
+      # B3a — Fernet master key for at-rest encryption of API secrets.
+      # MUST be set in .env on the droplet (generate with `python -c
+      # "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"`).
+      # If unset, ggbc-backend falls back to a public dev key — anyone
+      # with the source can decrypt the DB.
+      - SECRET_ENCRYPTION_KEY=${SECRET_ENCRYPTION_KEY:-}
+    volumes:
+      # Read-only access to ST's data directory so the one-shot
+      # migrate_st_secrets script can scoop up existing per-user
+      # secrets.json files. Safe to keep mounted long-term — the
+      # backend never writes here.
+      - st-data:/st-data:ro
     # Run pending migrations, then start uvicorn. Migrations are idempotent
     # so this is safe on every container start.
     command: ["sh", "-c", "alembic upgrade head && uvicorn app.main:app --host 127.0.0.1 --port 8001"]

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -725,6 +725,21 @@ export const api = {
       body.chat_completion_source = provider || 'openai';
       endpoint = '/api/backends/chat-completions/generate';
     }
+    // B3a — ggbc-backend's generation proxy is stateless wrt. settings
+    // (unlike ST, which looked up custom_url server-side). For
+    // chat_completion_source=custom we have to thread the URL through
+    // the request body so the proxy knows where to forward.
+    if ((body.chat_completion_source || provider) === 'custom') {
+      try {
+        // Lazy import keeps a circular dependency from forming between
+        // api/client.ts and stores/settingsStore.ts at module load.
+        const { useSettingsStore } = await import('../stores/settingsStore');
+        const customUrl = useSettingsStore.getState().customUrl;
+        if (customUrl) body.custom_url = customUrl;
+      } catch {
+        // Best effort; the backend will surface a clear 400 if missing.
+      }
+    }
 
     if (generationOptions) {
       if (generationOptions.topP !== undefined) body.top_p = generationOptions.topP;


### PR DESCRIPTION
## Summary

Frontend half of [B3a](https://github.com/sammygallo/ggbc-backend/pull/13). The ST proxy is no longer in the request path for chat completion or API key storage. Frontend keeps the existing wire shapes — same URLs, same body fields — so the only frontend-side change is threading \`custom_url\` into the generation request body when source=custom.

## What changed

- **api/client.ts**: when \`chat_completion_source === 'custom'\`, read \`customUrl\` from \`settingsStore\` and include it in the generation body. ggbc-backend can't read it from ST's \`oai_settings\` the way ST used to; that lookup moves into B3b.
- **docker-compose.yml**:
  - Mount the ST data volume read-only at \`/st-data\` on \`ggbc-backend\` so the one-shot \`migrate_st_secrets\` script can scoop up existing per-user \`secrets.json\` files.
  - Pipe \`SECRET_ENCRYPTION_KEY\` env var from \`.env\` into the container. Production MUST override the public dev default before relying on at-rest encryption.

No nginx or vite-proxy changes needed — the routes stay under \`/api\` which already proxies to ggbc-backend.

## Deploy steps (paired with backend PR)

1. Generate a Fernet key and set \`SECRET_ENCRYPTION_KEY\` in \`/opt/goodgirlsbotclub/.env\`.
2. \`git pull && docker compose pull && docker compose up -d\`.
3. \`docker compose exec ggbc-backend python -m app.scripts.migrate_st_secrets\` to bring existing API keys into the new store.

## Test plan

- [x] tsc -b clean.
- [x] Local docker stack end-to-end: secret write/read round-trips with no plaintext leak; real chat-completion request to api.openai.com with a fake key surfaces a clean 401-as-SSE inline.
- [ ] Post-deploy: each user verifies generation works (or re-enters their key if the migration script didn't catch it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)