### PR TITLE
feat(b3c-assets): point expression + live-portrait URLs at user_blobs

### DIFF
--- a/src/api/livePortraitGen.ts
+++ b/src/api/livePortraitGen.ts
@@ -27,14 +27,26 @@ const POLL_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes total — leaves headroom 
  * server-side). Lets clients auto-populate their local store on character
  * load so users see Live Portrait everywhere — not just on the device
  * that ran generation.
+ *
+ * B3c-assets — clips moved into user_blobs under
+ * `live-portrait/{avatar}/{emotion}.mp4`. We list the user's blobs and
+ * filter by the per-character prefix instead of hitting ST's
+ * `/api/live-portrait/list/{name}` route.
  */
-export async function fetchExistingClips(characterName: string): Promise<EmotionClips> {
-  const r = await fetch(`/api/live-portrait/list/${encodeURIComponent(characterName)}`, {
-    credentials: 'include',
-  });
+export async function fetchExistingClips(characterAvatar: string): Promise<EmotionClips> {
+  const r = await fetch('/blobs', { credentials: 'include' });
   if (!r.ok) throw new Error(`HTTP ${r.status}`);
-  const data = await r.json();
-  return data.clips ?? {};
+  const rows: Array<{ key: string }> = await r.json();
+  const prefix = `live-portrait/${characterAvatar}/`;
+  const clips: EmotionClips = {};
+  for (const row of rows) {
+    if (!row.key.startsWith(prefix)) continue;
+    const filename = row.key.slice(prefix.length);
+    const emotion = filename.replace(/\.[^/.]+$/, '');
+    if (!emotion) continue;
+    clips[emotion] = `/blobs/${encodeURI(row.key)}`;
+  }
+  return clips;
 }
 
 /**

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -295,9 +295,10 @@ export function ChatView() {
   useEffect(() => {
     if (!selectedCharacter || !livePortraitEnabled) return;
     if (livePortraitClips && Object.keys(livePortraitClips).length > 0) return;
-    const characterName = selectedCharacter.avatar.replace(/\.png$/i, '');
     let cancelled = false;
-    fetchExistingClips(characterName)
+    // B3c-assets — clips are now stored in user_blobs keyed by the
+    // character's avatar (filename incl. .png), not the name slug.
+    fetchExistingClips(selectedCharacter.avatar)
       .then((clips) => {
         if (cancelled) return;
         if (Object.keys(clips).length > 0) {

--- a/src/utils/emotions.ts
+++ b/src/utils/emotions.ts
@@ -170,10 +170,7 @@ export function stripEmotionTag(content: string): string {
  * Get the default avatar URL (used for neutral or fallback)
  */
 export function getDefaultAvatarUrl(characterAvatar: string): string {
-  // B1 — character art moved into ggbc-backend's user_blobs, served as
-  // raw PNG bytes at /blobs/character/{avatar}. Expression sub-images
-  // (/characters/Name/emotion.png) are still proxied to ST because
-  // expression packs remain on ST's filesystem until a later phase.
+  // B1 — character art lives in ggbc-backend's user_blobs.
   return `/blobs/character/${encodeURIComponent(characterAvatar)}`;
 }
 
@@ -188,15 +185,10 @@ export function getExpressionUrl(
   if (!emotion || emotion === 'neutral') {
     return getDefaultAvatarUrl(characterAvatar);
   }
-
-  // Expression images are stored in /characters/[name]/[emotion].png
-  // Extract character name from avatar filename (e.g., "Seraphina.png" -> "Seraphina")
-  const characterName = characterAvatar.replace(/\.[^/.]+$/, '');
-  const url = `/characters/${encodeURIComponent(characterName)}/${emotion}.png`;
-
-  console.log('[Expression] Avatar:', characterAvatar, '-> Name:', characterName, '-> URL:', url);
-
-  return url;
+  // B3c-assets — expression sprites moved into user_blobs under
+  // `expressions/{avatar}/{emotion}.png`. The previous URL
+  // (/characters/{name}/{emotion}.png, proxied to ST) is gone.
+  return `/blobs/expressions/${encodeURIComponent(characterAvatar)}/${emotion}.png`;
 }
 
 /**
@@ -207,12 +199,7 @@ export function getExpressionThumbnailUrl(
   emotion: Emotion | null
 ): string {
   if (!emotion || emotion === 'neutral') {
-    // ST's /thumbnail is gone — characters live in user_blobs now. The
-    // browser handles the down-scaling for chat-message thumbnails.
     return `/blobs/character/${encodeURIComponent(characterAvatar)}`;
   }
-
-  // For expressions, we use the full-size path since thumbnails may not exist
-  const characterName = characterAvatar.replace(/\.[^/.]+$/, '');
-  return `/characters/${encodeURIComponent(characterName)}/${emotion}.png`;
+  return `/blobs/expressions/${encodeURIComponent(characterAvatar)}/${emotion}.png`;
 }


### PR DESCRIPTION
## Summary

Frontend half of [B3c-assets](https://github.com/sammygallo/ggbc-backend/pulls). ST is out of the request path for character expression sprites and live-portrait MP4s; both come from user_blobs now.

## What changed

- **\`src/utils/emotions.ts\`** — \`getExpressionUrl\` + \`getExpressionThumbnailUrl\` return \`/blobs/expressions/{avatar}/{emotion}.png\` instead of the old \`/characters/{name}/{emotion}.png\` (proxied to ST). Keyed by avatar to line up with the existing \`/blobs/character/{avatar}\` scheme and the migration script's blob keys.
- **\`src/api/livePortraitGen.ts\`** — \`fetchExistingClips\` lists \`/blobs\` and filters for the \`live-portrait/{avatar}/\` prefix instead of hitting ST's \`/api/live-portrait/list/{name}\` endpoint. Returns blob URLs directly.
- **\`src/components/chat/ChatView.tsx\`** — passes \`avatar\` (not name slug) to \`fetchExistingClips\` since the new path is keyed by avatar.

## Out of scope

Generation of NEW live-portrait clips still proxies to ST through the existing \`/api/live-portrait/{generate,status,emotions}\` routes — that Replicate pipeline gets its own slice. Existing clips keep working post-deploy via the new blob URLs.

## Test plan

- [x] \`tsc -b\` clean.
- [x] Local docker stack: ran the matching backend migration (\`migrate_st_assets\`) → 28 expression PNGs copied for sammy's Seraphina; \`/blobs/expressions/default_Seraphina.png/joy.png\` returns 200 image/png; chat view renders cleanly with no broken images and zero console errors.
- [ ] Post-deploy: trigger an expression on a real chat with stri's Seraphina (who has the full pack); confirm the emotion image swaps in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)