### PR TITLE
fix: keep lorebook editor open after saving an entry

### DIFF
--- a/src/components/worldinfo/WorldInfoEntryForm.tsx
+++ b/src/components/worldinfo/WorldInfoEntryForm.tsx
@@ -134,6 +134,9 @@ export function WorldInfoEntryForm({ bookId, entry, onClose }: WorldInfoEntryFor
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    // Stop propagation so the submit event doesn't bubble through the React portal
+    // tree to CharacterEdit's outer form, which would save + close the character editor.
+    e.stopPropagation();
     if (!content.trim()) return;
     if (!constant && parsedKeys.length === 0) return;
 


### PR DESCRIPTION
## Summary

Closes #225.

- `WorldInfoEntryForm` submits inside a React portal (`Modal` → `createPortal`), but React 19 bubbles synthetic events through the **React component tree** — not the DOM tree. Without `stopPropagation()`, saving a lorebook entry triggered `CharacterEdit`'s outer `<form onSubmit>`, which saved and closed the entire character editor.
- Added `e.stopPropagation()` alongside the existing `e.preventDefault()` in `WorldInfoEntryForm.handleSubmit`. One line change.

## Test plan
- [x] Local `npm run build` passes (already verified)
- [x] Open a character editor → expand Lorebooks → open the embedded lorebook → edit an existing entry → click Save Changes → confirm the lorebook list view stays open (character editor does **not** close)
- [x] Create a new entry → confirm same behaviour
- [x] Cancel button still closes the form back to list view
- [x] Escape key still closes the lorebook modal
- [x] Saving a character from the character editor still works normally

🤖 Draft opened by the build-next-issue skill. Human review required before merge.