### PR TITLE
feat: use Creator Notes first sentence as character bio

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -39,6 +39,12 @@ interface SidebarProps {
   onClose: () => void;
 }
 
+function firstSentence(text?: string): string {
+  if (!text) return '';
+  const idx = text.search(/[.!?]/);
+  return (idx === -1 ? text : text.slice(0, idx + 1)).trim();
+}
+
 export function Sidebar({ isOpen, onClose }: SidebarProps) {
   const { currentUser } = useAuthStore();
   const userRole = currentUser?.role;
@@ -297,9 +303,9 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
                     {latestEmotion}
                   </span>
                 )}
-                {selectedCharacter.description && (
+                {firstSentence(selectedCharacter.creator_notes) && (
                   <p className="text-sm text-[var(--color-text-secondary)] mt-2 line-clamp-3">
-                    {selectedCharacter.description}
+                    {firstSentence(selectedCharacter.creator_notes)}
                   </p>
                 )}
               </div>
@@ -555,9 +561,9 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
                               <p className="text-sm font-medium text-[var(--color-text-primary)] truncate">
                                 {character.name}
                               </p>
-                              {character.description && (
+                              {firstSentence(character.creator_notes) && (
                                 <p className="text-xs text-[var(--color-text-secondary)] truncate">
-                                  {character.description}
+                                  {firstSentence(character.creator_notes)}
                                 </p>
                               )}
                               {(() => {


### PR DESCRIPTION
## Summary

Closes #227.

- Added a `firstSentence(text?)` helper at module scope in `Sidebar.tsx` that extracts text up to and including the first `.`, `!`, or `?` (returns the full string if no terminator is found).
- Changed both bio display sites — the portrait panel (below the avatar) and the character list rows — to show `firstSentence(creator_notes)` instead of the full `description`.
- Characters with no `creator_notes` will show no bio text (the conditional guard naturally hides it).

## Test plan
- [ ] Local `npm run build` passes (already verified)
- [ ] Open a character that has `Creator Notes` set → confirm the bio beneath the portrait shows the first sentence of Creator Notes, not Description
- [ ] Open a character with no Creator Notes → confirm no bio text is shown (not a blank line)
- [ ] Character with Creator Notes ending mid-sentence (no period) → confirm the full creator_notes text is shown
- [ ] Character list rows show the same first-sentence-of-creator_notes text

🤖 Draft opened by the build-next-issue skill. Human review required before merge.