### PR TITLE
feat: show more / show less toggle for character description

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -47,6 +47,7 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
   const [showImportModal, setShowImportModal] = useState(false);
   const [showCharacterList, setShowCharacterList] = useState(false);
   const [failedExpressions, setFailedExpressions] = useState<Set<string>>(new Set());
+  const [descExpanded, setDescExpanded] = useState(false);
   const [isGroupSelectMode, setIsGroupSelectMode] = useState(false);
   const [showFilters, setShowFilters] = useState(false);
   const [previewCharacter, setPreviewCharacter] = useState<CharacterInfo | null>(null);
@@ -123,8 +124,8 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
   useEffect(() => {
     if (selectedCharacter) {
       setShowCharacterList(false);
-      // Reset failed expressions for new character
       setFailedExpressions(new Set());
+      setDescExpanded(false);
     }
   }, [selectedCharacter]);
 
@@ -298,9 +299,19 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
                   </span>
                 )}
                 {selectedCharacter.description && (
-                  <p className="text-sm text-[var(--color-text-secondary)] mt-2 line-clamp-3">
-                    {selectedCharacter.description}
-                  </p>
+                  <div className="mt-2 text-left w-full">
+                    <p className={`text-sm text-[var(--color-text-secondary)] ${descExpanded ? '' : 'line-clamp-3'}`}>
+                      {selectedCharacter.description}
+                    </p>
+                    {selectedCharacter.description.length > 150 && (
+                      <button
+                        onClick={() => setDescExpanded(!descExpanded)}
+                        className="text-xs text-[var(--color-primary)] hover:underline mt-1"
+                      >
+                        {descExpanded ? 'Show less' : 'Show more'}
+                      </button>
+                    )}
+                  </div>
                 )}
               </div>
             </div>


### PR DESCRIPTION
## Summary

Closes #228.

- The description text beneath the character portrait was hard-clamped to 3 lines with no way to read the rest.
- Added a "Show more" / "Show less" toggle button that appears when the description exceeds 150 characters.
- `descExpanded` state resets to collapsed whenever a new character is selected, so the panel is always tidy on switch.

## Test plan
- [ ] Local `npm run build` passes (already verified)
- [ ] Select a character with a long description (> 3 lines) → "Show more" link appears below the clamped text → clicking expands to full description → "Show less" collapses it back
- [ ] Select a character with a short description (< 150 chars) → no toggle shown, full text displayed naturally
- [ ] Switch to a different character while expanded → description collapses back to 3-line preview
- [ ] Edge case: description with no text → nothing rendered (unchanged)

**Note:** PR #249 also touches `Sidebar.tsx` (changes bio source from `description` to `creator_notes`). These will need to be merged in sequence to avoid a conflict.

🤖 Draft opened by the build-next-issue skill. Human review required before merge.