### PR TITLE
fix: keep character/persona selectors visible when Android keyboard opens

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover, interactive-widget=resizes-content" />
     <meta name="theme-color" content="#0f0f0f" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />

--- a/src/index.css
+++ b/src/index.css
@@ -23,9 +23,17 @@
 }
 
 /* Base styles */
+html {
+  height: 100%;
+  overflow: hidden;
+}
+
 body {
   @apply bg-[var(--color-bg-primary)] text-[var(--color-text-primary)] antialiased;
   font-family: system-ui, -apple-system, sans-serif;
+  height: 100%;
+  overflow: hidden;
+  overscroll-behavior: none;
 }
 
 /* Scrollbar styling */


### PR DESCRIPTION
## Summary

Closes #229.

- **Root cause:** On Android Chrome, focusing the chat input triggers the browser to scroll the visual viewport upward to center the input field. This pushed the sticky `<Header>` (with character info + PersonaSelector) off the top of the screen. Touching the messages area then captured the scroll, so users couldn't recover the header.
- **`interactive-widget=resizes-content`** added to the viewport meta: Chrome 108+ treats keyboard open as a viewport resize rather than a visual-viewport scroll. `100dvh` adjusts automatically, the header stays pinned at the top. No JS changes needed.
- **`html/body { overflow:hidden; overscroll-behavior:none }`**: Belt-and-suspenders for Android browsers that don't support `interactive-widget`. Locks the document scroll so nothing can push the header off screen.

## Test plan
- [ ] Local `npm run build` passes (already verified)
- [ ] On Android Chrome (108+): open a chat → focus the input → keyboard opens → **confirm the header with character name, persona selector stays visible at the top**
- [ ] On Android: dismiss keyboard → header still in place, no layout jank
- [ ] On iOS: keyboard behavior unchanged (Safari ignores `interactive-widget`)
- [ ] Desktop: no visible difference — `overflow:hidden` on html/body has no effect when content fits
- [ ] Pull-to-refresh in sidebar character list still works (it's on the inner element, not document)

🤖 Draft opened by the build-next-issue skill. Human review required before merge.