### PR TITLE
feat(providers): add claude-opus-4-7 to model lists

### DIFF
--- a/src/api/providerCatalog.ts
+++ b/src/api/providerCatalog.ts
@@ -83,6 +83,7 @@ export const NATIVE_PROVIDERS: readonly CatalogProvider[] = [
     nativeRouted: true,
     secretKey: 'api_key_claude',
     defaultModels: [
+      'claude-opus-4-7',
       'claude-opus-4-6',
       'claude-sonnet-4-6',
       'claude-opus-4-5',
@@ -184,6 +185,7 @@ export const NATIVE_PROVIDERS: readonly CatalogProvider[] = [
       'openai/gpt-4.1',
       'openai/o3',
       'openai/gpt-4o',
+      'anthropic/claude-opus-4-7',
       'anthropic/claude-opus-4-6',
       'anthropic/claude-sonnet-4-6',
       'google/gemini-2.5-pro',
@@ -314,6 +316,7 @@ export const NATIVE_PROVIDERS: readonly CatalogProvider[] = [
     defaultModels: [
       'gpt-4o',
       'chatgpt-4o-latest',
+      'claude-opus-4-7',
       'claude-opus-4-6',
       'claude-sonnet-4-6',
       'gemini-2.5-pro',


### PR DESCRIPTION
## Summary
- Adds `claude-opus-4-7` above `claude-opus-4-6` in the Anthropic direct API default model list
- Adds `anthropic/claude-opus-4-7` to the OpenRouter default model list
- Adds `claude-opus-4-7` to the NanoGPT default model list

Closes #246 is NOT this — this is a hotfix from user report that the Claude model picker topped out at Opus 4-6.

## Test plan
- [ ] Open Settings → Providers → Claude — verify `claude-opus-4-7` appears at the top of the model dropdown
- [ ] Open Settings → Providers → OpenRouter — verify `anthropic/claude-opus-4-7` appears in the list
- [ ] Open Settings → Providers → NanoGPT — verify `claude-opus-4-7` appears in the list