### PR TITLE
fix(nginx): drop trailing slash on /blobs location so GET /blobs doesn't redirect

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -60,7 +60,11 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
-    location /blobs/ {
+    # No trailing slash on the location so GET /blobs (the list endpoint)
+    # matches without nginx auto-redirecting to /blobs/. The outer TLS
+    # terminator is upstream of this nginx, so the auto-add-slash redirect
+    # came out as http:// and got blocked as mixed-content by the browser.
+    location /blobs {
         proxy_pass http://127.0.0.1:8001;
         proxy_http_version 1.1;
         proxy_set_header Host $host;


### PR DESCRIPTION
## Summary

Live portraits were silently missing for every character after the latest deploy.

**Cause traced**: `fetch('/blobs')` was returning a `301` to `http://goodgirlsbotclub.com/blobs/`. The browser blocked the mixed-content downgrade, `fetchExistingClips()` returned `Failed to fetch`, and `clipsByAvatar` stayed empty (the v2→v3 localStorage migration had correctly cleared the stale URLs and was relying on `/blobs` to repopulate).

The 301 came from this nginx (the one that serves the SPA bundle and proxies dynamic routes to ggbc-backend). It sits behind the outer TLS terminator and only speaks HTTP internally. The `location /blobs/` had a trailing slash, so `GET /blobs` fell out of the proxy block, hit nginx's default behavior, and auto-appended the slash via a 301 — building the Location URL from the inner scheme (`http://`) instead of `X-Forwarded-Proto`.

Drop the trailing slash so both `/blobs` and `/blobs/{key}` match the proxy block directly.

Closes the third of three deploy regressions (settings provider fixed in ggbc-backend#21, character sharing fixed in #254, this one is live portraits).

## Test plan

- [ ] After deploy: `curl -sI https://goodgirlsbotclub.com/blobs --cookie '...'` returns `401` (or `200`), not `301`
- [ ] Browser console: `fetch('/blobs', {credentials:'include'}).then(r=>r.json()).then(rows => console.log(rows.filter(r=>r.key.startsWith('live-portrait/'))))` returns the expected MP4 blob keys instead of a mixed-content error
- [ ] Open a chat with a character that has portraits — the animated clip plays in the avatar slot

🤖 Generated with [Claude Code](https://claude.com/claude-code)