### PR TITLE
fix(chat): send continue/impersonate instruction as user, not system

### DIFF
--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -2380,10 +2380,15 @@ export const useChatStore = create<ChatState>((set, get) => ({
       // Build context including the current AI message
       const ragCtx = await resolveRagContext(messages, character.avatar || '', get().currentChatFile || undefined);
       const context = buildConversationContext(messages, character, availableEmotions, undefined, ragCtx ?? undefined);
-      // Add a system instruction to continue
+      // Append the continue instruction as a user turn, not a system one.
+      // Gemini extracts system messages into its separate systemInstruction
+      // field, which would leave contents[] ending with an assistant ('model')
+      // role and trip its "conversation must end with a user message" 400.
+      // User-role works on every provider — Anthropic coerces non-user/assistant
+      // roles to user anyway, OpenAI is permissive.
       context.push({
-        role: 'system',
-        content: 'Continue your previous response naturally. Do not repeat what you already said. Pick up exactly where you left off.',
+        role: 'user',
+        content: '(Continue your previous response naturally. Do not repeat what you already said. Pick up exactly where you left off.)',
       });
 
       const { provider, model } = getProviderAndModel();
@@ -2454,10 +2459,13 @@ export const useChatStore = create<ChatState>((set, get) => ({
     try {
       const ragCtx = await resolveRagContext(messages, character.avatar || '', get().currentChatFile || undefined);
       const context = buildConversationContext(messages, character, availableEmotions, undefined, ragCtx ?? undefined);
-      // Replace the system prompt's last line to instruct impersonation
+      // User-role instruction so Gemini (which extracts system into a
+      // separate systemInstruction field) doesn't leave contents[] ending
+      // with an assistant turn and trip its 400. See continueMessage above
+      // for the full rationale.
       context.push({
-        role: 'system',
-        content: `Now write the next message as the user (You). Write from a first-person perspective as the user would. Do NOT include an emotion tag. Do NOT write as ${character.name}.`,
+        role: 'user',
+        content: `(Now write the next message as the user (You). Write from a first-person perspective as the user would. Do NOT include an emotion tag. Do NOT write as ${character.name}.)`,
       });
 
       const { provider, model } = getProviderAndModel();


### PR DESCRIPTION
## Summary

Continue and Impersonate were broken for Gemini users. The SSE stream returned:

> `This model does not support assistant message prefill. The conversation must end with a user message.`

**Cause**: both [`continueMessage`](src/stores/chatStore.ts) and `impersonate` append their final instruction as a `system` role. Gemini's adapter pulls system messages out into a separate `systemInstruction` field, so the `contents[]` array ends with the assistant message that's being continued — and Gemini 400s on a trailing assistant turn.

**Fix**: change the role from `system` to `user`. The conversation now ends with a user turn on every provider:
- Gemini: stays in `contents[]`, ends with `user` ✓
- Anthropic: already coerces non-user/assistant roles to user ([anthropic.py:94](https://github.com/sammygallo/ggbc-backend/blob/main/app/providers/anthropic.py#L94)) ✓
- OpenAI: permissive either way ✓

**Why now?** Latent bug surfaced after the settings-blob fix shipped earlier today (ggbc-backend#21). That fix made `/api/settings/get` actually return the user's stored provider instead of falling back to a hardcoded GPT-4.1 default. Users who'd configured Gemini as their provider hit this on the first Continue click after reload.

## Test plan

- [x] `npx tsc -b` clean
- [ ] After deploy: open a Gemini-backed chat, click Continue — response extends the last AI message instead of erroring
- [ ] Same chat, click Impersonate — generates a user-as-you message
- [ ] Verify on Claude/OpenAI that Continue/Impersonate still work (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)