### PR TITLE
fix(generation): loadPresetTransient + restoreDefault no longer overwrite saved sampler

### DIFF
--- a/src/stores/generationStore.ts
+++ b/src/stores/generationStore.ts
@@ -424,47 +424,31 @@ export const useGenerationStore = create<GenerationState>((set, get) => ({
     });
   },
 
+  // In-memory only. Both callers (ChatView's character-link auto-loader and
+  // restoreDefault below) run on every chat-open / unmount, so persisting
+  // here would silently overwrite the user's hand-tuned sampler with the
+  // linked preset's stored values on every session — the user's edits would
+  // never survive a logout/login.
   loadPresetTransient: (id) => {
     const { presets } = get();
     const preset = presets.find((p) => p.id === id);
     if (!preset) return;
-    set((state) => {
-      const next = {
-        ...state,
-        sampler: { ...preset.sampler },
-        activePresetId: preset.id,
-      };
-      persist(next);
-      return { sampler: next.sampler, activePresetId: preset.id };
-    });
+    set({ sampler: { ...preset.sampler }, activePresetId: preset.id });
   },
 
+  // Also in-memory only — see loadPresetTransient. ChatView calls this on
+  // unmount and on switch to an unlinked character; persisting would clobber
+  // server-stored edits with the default preset's snapshot.
   restoreDefault: () => {
     const { defaultPresetId, presets, activePresetId } = get();
     if (!defaultPresetId) {
-      // No default — just clear the transient marker if it points at a different
-      // preset than what the user last chose. Leave the sampler alone.
-      if (activePresetId !== null) {
-        set((state) => {
-          const next = { ...state, activePresetId: null };
-          persist(next);
-          return { activePresetId: null };
-        });
-      }
+      if (activePresetId !== null) set({ activePresetId: null });
       return;
     }
     if (activePresetId === defaultPresetId) return;
     const preset = presets.find((p) => p.id === defaultPresetId);
     if (!preset) return;
-    set((state) => {
-      const next = {
-        ...state,
-        sampler: { ...preset.sampler },
-        activePresetId: preset.id,
-      };
-      persist(next);
-      return { sampler: next.sampler, activePresetId: preset.id };
-    });
+    set({ sampler: { ...preset.sampler }, activePresetId: preset.id });
   },
 
   deletePreset: (id) => {


### PR DESCRIPTION
## Summary

User reported: changing Max Response Tokens to 4096, then logging out and back in, reverts the value to whatever the character-linked preset has stored (1500 in their case).

**Cause**: `loadPresetTransient` in [generationStore.ts](src/stores/generationStore.ts) was calling `persist()`, which writes through to localStorage AND syncs to ggbc-backend via `patchServerKey`. The function is called by [ChatView.tsx:575](src/components/chat/ChatView.tsx) on every character open. So every chat-open silently overwrote the user's server-stored sampler with the linked preset's stored values, defeating any in-place edits.

Same bug pattern in `restoreDefault` — its only callers are ChatView's transient lifecycle hooks (on character switch and on chat unmount).

**Fix**: make both functions match their names — update in-memory state only, no localStorage, no server sync. User-explicit `loadPreset` (the "Load" button on the settings page) still persists, which is the intentional save path.

Confirmed by inspecting prod DB:
```
sammy | stm_generation | maxTokens=1500 | server_ts=78  ← chat-open overwrites every session
preset "Roleplay — Immersive" sampler.maxTokens = 1500
linkedPresetByAvatar { "default_Seraphina.png": "preset_…kinah9" }
```

## Test plan

- [x] `npx tsc -b` clean
- [ ] After deploy: change Max Response Tokens to 4096 in AI Settings → open Seraphina chat → leave → reopen Settings → value still 4096
- [ ] Logout → login → open Settings → value still 4096
- [ ] Open Seraphina chat → Settings shows 1500 in the active session (preset applied transiently) — but the persisted value is still 4096
- [ ] Click "Load" on a different preset → that one DOES persist (intentional user action)

🤖 Generated with [Claude Code](https://claude.com/claude-code)