### PR TITLE
fix(generation): setSampler mirrors edits into the active preset

### DIFF
--- a/src/stores/generationStore.ts
+++ b/src/stores/generationStore.ts
@@ -363,17 +363,39 @@ export const useGenerationStore = create<GenerationState>((set, get) => ({
 
   setSampler: (patch) => {
     set((state) => {
-      const next = { ...state, sampler: { ...state.sampler, ...patch } };
+      const nextSampler = { ...state.sampler, ...patch };
+      // If a preset is currently active (loaded via loadPreset or
+      // loadPresetTransient), mirror the edit into that preset's stored
+      // sampler too. Without this, the next character-switch fires
+      // loadPresetTransient again and snaps the in-memory sampler back to
+      // the preset's stale snapshot — silently undoing the user's edit.
+      const nextPresets = state.activePresetId
+        ? state.presets.map((p) =>
+            p.id === state.activePresetId
+              ? { ...p, sampler: { ...p.sampler, ...patch } }
+              : p,
+          )
+        : state.presets;
+      const next = { ...state, sampler: nextSampler, presets: nextPresets };
       persist(next);
-      return { sampler: next.sampler };
+      return { sampler: nextSampler, presets: nextPresets };
     });
   },
 
   resetSampler: () => {
     set((state) => {
-      const next = { ...state, sampler: { ...DEFAULT_SAMPLER } };
+      // Same active-preset mirroring rule — a reset is also an edit, so the
+      // preset definition should track it.
+      const nextPresets = state.activePresetId
+        ? state.presets.map((p) =>
+            p.id === state.activePresetId
+              ? { ...p, sampler: { ...DEFAULT_SAMPLER } }
+              : p,
+          )
+        : state.presets;
+      const next = { ...state, sampler: { ...DEFAULT_SAMPLER }, presets: nextPresets };
       persist(next);
-      return { sampler: next.sampler };
+      return { sampler: next.sampler, presets: nextPresets };
     });
   },
 


### PR DESCRIPTION
## Summary

User-reported follow-up to [PR #257](https://github.com/sammygallo/goodgirlsbotclub/pull/257). After that fix, changing Max Response Tokens to 4096, switching characters, and switching back still reverted the displayed value to 1500.

**Cause**: PR #257 made `loadPresetTransient` and `restoreDefault` transient (no server write), but the **preset's stored sampler snapshot was unchanged**. So on character-switch, `loadPresetTransient` reloaded the preset's stale 1500 snapshot into the in-memory sampler, and the UI displayed 1500 again — even though the user's explicit edit was correctly persisted to the server's top-level `sampler` field.

**Fix**: when a preset is active, `setSampler` and `resetSampler` also patch that preset's stored sampler. Edits now persist into the preset definition, so the next character-switch reloads a preset whose snapshot already reflects the edit.

**Edge case**: power-users sharing one preset across multiple characters will see edits propagate. Deliberate trade-off — the alternative (silent edit loss) was already reported as confusing.

## Test plan

- [x] `npx tsc -b` clean
- [ ] After deploy: open Seraphina chat → Generation Settings shows linked preset's value → click Extended (4096) → switch character → switch back → value still 4096
- [ ] Open Settings, edit other slider (temperature) → confirm preset definition updated by examining preset list highlight + reload behavior
- [ ] Manual loadPreset (click "Load" on a different preset) still works and overwrites the live sampler with that preset's values

🤖 Generated with [Claude Code](https://claude.com/claude-code)