### PR TITLE
feat(character-mgmt): render 'also owned by' hint for admin view

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -244,6 +244,10 @@ export interface CharacterMetadataEntry {
   ownerHandle: string;
   visibility: CharacterVisibility;
   claimedAt: number;
+  // Populated only when the caller is an admin/owner viewing a card that
+  // multiple users have a copy of. Lists the other users' handles so the
+  // UI can render an "also owned by X" hint without an extra request.
+  otherOwners?: string[];
 }
 
 export type CharacterMetadataMap = Record<string, CharacterMetadataEntry>;
@@ -271,6 +275,9 @@ export interface CharacterInfo {
   // backends, in which case callers treat as 'personal' / null).
   visibility?: CharacterVisibility;
   owner_handle?: string | null;
+  // Admin-only: handles of other users with a copy of this same-named card.
+  // Server only populates this for admin/owner callers; omitted otherwise.
+  other_owners?: string[];
   // Advanced Character Card V2 fields
   alternate_greetings?: string[];
   system_prompt?: string;

--- a/src/components/settings/CharacterManagementPage.tsx
+++ b/src/components/settings/CharacterManagementPage.tsx
@@ -336,6 +336,10 @@ function CharacterRow({
   const visibility = ownershipStore.getVisibility(avatar);
   const isOwned = ownershipStore.isOwnedBy(avatar, userHandle);
   const ownerHandle = ownershipStore.getOwner(avatar);
+  // Admin/owner only — server populates this for callers who can see
+  // every user's cards, so the row can surface that linz/vulpixxy also
+  // have their own copies of the same-named character.
+  const otherOwners = ownershipStore.getOtherOwners(avatar);
 
   const canEdit =
     hasPermission(currentUser, 'character:edit') ||
@@ -388,6 +392,9 @@ function CharacterRow({
           </div>
           <p className="text-xs text-[var(--color-text-secondary)] truncate mt-0.5">
             {creator ? `by ${creator}` : ownerHandle ? `owned by ${ownerHandle}` : 'No owner'}
+            {otherOwners.length > 0 && (
+              <span className="ml-1">· also owned by {otherOwners.join(', ')}</span>
+            )}
           </p>
         </div>
 

--- a/src/stores/characterOwnershipStore.ts
+++ b/src/stores/characterOwnershipStore.ts
@@ -24,6 +24,10 @@ import type { UserRole } from '../types';
 export interface OwnershipEntry {
   ownerHandle: string;
   visibility: 'global' | 'personal';
+  // Only populated when the caller is an admin/owner. Lists other users
+  // who have a copy of this same-named card; used to render an "also
+  // owned by X" hint in Character Management.
+  otherOwners?: string[];
 }
 
 export interface CharacterOwnershipState {
@@ -44,6 +48,7 @@ export interface CharacterOwnershipState {
   getOwner: (avatar: string) => string | null;
   getVisibility: (avatar: string) => 'global' | 'personal';
   isOwnedBy: (avatar: string, handle: string) => boolean;
+  getOtherOwners: (avatar: string) => string[];
 
   // Permission helpers
   canEditCharacter: (avatar: string, userHandle: string, userRole: UserRole | undefined) => boolean;
@@ -54,10 +59,14 @@ function toOwnershipMap(serverMap: CharacterMetadataMap): Record<string, Ownersh
   const result: Record<string, OwnershipEntry> = {};
   for (const [avatar, entry] of Object.entries(serverMap)) {
     if (!entry || typeof entry !== 'object') continue;
-    result[avatar] = {
+    const out: OwnershipEntry = {
       ownerHandle: entry.ownerHandle,
       visibility: entry.visibility === 'global' ? 'global' : 'personal',
     };
+    if (Array.isArray(entry.otherOwners) && entry.otherOwners.length > 0) {
+      out.otherOwners = entry.otherOwners;
+    }
+    result[avatar] = out;
   }
   return result;
 }
@@ -118,6 +127,10 @@ export const useCharacterOwnershipStore = create<CharacterOwnershipState>((set, 
 
   isOwnedBy: (avatar, handle) => {
     return get().ownershipMap[avatar]?.ownerHandle === handle;
+  },
+
+  getOtherOwners: (avatar) => {
+    return get().ownershipMap[avatar]?.otherOwners ?? [];
   },
 
   canEditCharacter: (avatar, userHandle, userRole) => {


### PR DESCRIPTION
## Summary
- Wire the new backend `otherOwners` field through CharacterMetadataEntry / CharacterInfo and characterOwnershipStore.
- CharacterRow appends "· also owned by X, Y" after the existing owner line when present (admin-only; backend omits the field otherwise).

Depends on ggbc-backend#24.

## Test plan
- [ ] As owner, open Character Management — each row that other users also have shows "also owned by ..." below the name.
- [ ] As end_user, no hint appears (field is absent in the response).

🤖 Generated with [Claude Code](https://claude.com/claude-code)