### PR TITLE
feat(character): render HTML/CSS in creator notes everywhere they're shown

### DIFF
--- a/src/components/character/CharacterRichText.tsx
+++ b/src/components/character/CharacterRichText.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import DOMPurify from 'dompurify';
+import { looksLikeHtml } from '../../utils/characterRichText';
 
 interface CharacterRichTextProps {
   /** The raw character field content. May contain HTML/CSS markup. */
@@ -52,14 +53,6 @@ const SANITIZE_CONFIG = {
   // Keep relative URLs intact; block the obvious dangerous schemes.
   ALLOWED_URI_REGEXP: /^(?:(?:https?|mailto|tel|data:image\/(?:png|jpe?g|gif|webp|svg\+xml));|[^a-z]|[a-z+.-]+(?:[^a-z+.\-:]|$))/i,
 };
-
-/** Heuristic: does `content` contain any HTML-looking markup? Anything that
- *  starts with `<letter` or `</letter` counts. We use this to keep plain-text
- *  blurbs rendering identically to before — only blurbs that opted into HTML
- *  go through the sanitiser. */
-function looksLikeHtml(content: string): boolean {
-  return /<\/?[a-zA-Z]/.test(content);
-}
 
 /**
  * Render a character-info field that may contain HTML/CSS markup. Plain text

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -26,6 +26,8 @@ import { Avatar, Button, Input } from '../ui';
 import { CharacterCreation } from '../character/CharacterCreation';
 import { CharacterImport } from '../character/CharacterImport';
 import { CharacterPreviewModal } from '../character/CharacterPreviewModal';
+import { CharacterRichText } from '../character/CharacterRichText';
+import { htmlToPlainText } from '../../utils/characterRichText';
 import type { CharacterInfo } from '../../api/client';
 import { useCharacterSprites } from '../../hooks/useCharacterSprites';
 import { getDefaultAvatarUrl, type Emotion } from '../../utils/emotions';
@@ -39,10 +41,14 @@ interface SidebarProps {
   onClose: () => void;
 }
 
+// Condensed teaser for list rows / the collapsed portrait blurb. Strips any
+// HTML markup first so notes that opted into rich formatting show clean text
+// here instead of a half-open tag, then clips to the first sentence.
 function firstSentence(text?: string): string {
-  if (!text) return '';
-  const idx = text.search(/[.!?]/);
-  return (idx === -1 ? text : text.slice(0, idx + 1)).trim();
+  const plain = htmlToPlainText(text);
+  if (!plain) return '';
+  const idx = plain.search(/[.!?]/);
+  return (idx === -1 ? plain : plain.slice(0, idx + 1)).trim();
 }
 
 export function Sidebar({ isOpen, onClose }: SidebarProps) {
@@ -306,12 +312,18 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
                 )}
                 {firstSentence(selectedCharacter.creator_notes) && (
                   <div className="mt-2 text-left w-full">
-                    <p className={`text-sm text-[var(--color-text-secondary)] ${descExpanded ? '' : 'line-clamp-3'}`}>
-                      {descExpanded
-                        ? selectedCharacter.creator_notes
-                        : firstSentence(selectedCharacter.creator_notes)}
-                    </p>
-                    {(selectedCharacter.creator_notes?.length ?? 0) > 150 && (
+                    {descExpanded ? (
+                      // Full notes: render any creator HTML/CSS (sanitised +
+                      // style-isolated inside .character-rich).
+                      <CharacterRichText
+                        content={selectedCharacter.creator_notes ?? ''}
+                      />
+                    ) : (
+                      <p className="text-sm text-[var(--color-text-secondary)] line-clamp-3">
+                        {firstSentence(selectedCharacter.creator_notes)}
+                      </p>
+                    )}
+                    {htmlToPlainText(selectedCharacter.creator_notes).length > 150 && (
                       <button
                         onClick={() => setDescExpanded(!descExpanded)}
                         className="text-xs text-[var(--color-primary)] hover:underline mt-1"

--- a/src/utils/characterRichText.ts
+++ b/src/utils/characterRichText.ts
@@ -1,0 +1,31 @@
+/**
+ * Helpers for handling character-info fields that may contain HTML/CSS markup
+ * (description, personality, creator notes, …). Kept out of the component file
+ * so the renderer can stay component-only for Fast Refresh.
+ */
+
+/** Heuristic: does `content` contain any HTML-looking markup? Anything that
+ *  starts with `<letter` or `</letter` counts. We use this to keep plain-text
+ *  blurbs rendering identically to before — only blurbs that opted into HTML
+ *  go through the sanitiser. */
+export function looksLikeHtml(content: string): boolean {
+  return /<\/?[a-zA-Z]/.test(content);
+}
+
+/**
+ * Flatten a possibly-HTML blurb to readable plain text. Used by condensed
+ * surfaces (sidebar list rows, the collapsed portrait teaser) where rendering
+ * full markup would break the layout — and where naively truncating raw HTML
+ * would leak half-open tags like `<div style="color:re…` into the preview.
+ *
+ * Parsing happens in a detached document via DOMParser: scripts never run and
+ * the nodes are never attached, so reading `textContent` is safe with no need
+ * to sanitise first. Input without any markup is returned untouched; HTML input
+ * has its tags dropped and entities decoded (e.g. `<b>A &amp; B</b>` → `A & B`).
+ */
+export function htmlToPlainText(content?: string): string {
+  if (!content) return '';
+  if (!looksLikeHtml(content) || typeof DOMParser === 'undefined') return content;
+  const doc = new DOMParser().parseFromString(content, 'text/html');
+  return doc.body.textContent ?? '';
+}


### PR DESCRIPTION
## Summary
Adds HTML/CSS rendering for character creator notes everywhere they're displayed.

Creator notes already supported rich HTML/CSS in the character **preview modal** (`CharacterRichText`, DOMPurify-sanitized + style-isolated in `.character-rich`). This extends the same support to the two **sidebar** surfaces that still rendered plain text:

- **Expanded portrait blurb** → full HTML/CSS via `CharacterRichText`.
- **Truncated previews** (character list row + collapsed portrait teaser) → HTML stripped to clean plain text via a new `htmlToPlainText` helper, so notes that opted into markup no longer leak half-open tags like `<div style="color:re…` through `firstSentence()`. The 'Show more' threshold now measures visible-text length.

`looksLikeHtml` + `htmlToPlainText` were moved into `src/utils/characterRichText.ts` (keeps the renderer component-only for Fast Refresh).

## Testing
- `npm run build` (tsc -b && vite build) green; eslint clean on touched files.
- Verified live against the ggbc-backend stack:
  - list row + collapsed teaser show clean stripped text (no raw tags);
  - expanded view renders bold / italic / inline-color CSS, lists, and blockquotes — computed styles confirmed (`#e91e63`, `#3f51b5`, blockquote 3px border, `contain: layout paint`);
  - no `<script>` survives sanitization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)