### PR TITLE
fix(live-portrait): make clip discovery work on desktop, not just mobile

### DIFF
--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -31,13 +31,12 @@ import { useSummarizeStore } from '../../stores/summarizeStore';
 import { useAutoMemoryStore } from '../../stores/autoMemoryStore';
 import { useCharacterSprites } from '../../hooks/useCharacterSprites';
 import { LivePortraitVideo } from './LivePortraitVideo';
-import { useLivePortraitStore } from '../../stores/livePortraitStore';
+import { useLivePortraitDiscovery } from '../../hooks/useLivePortraitDiscovery';
 import { useMotionModeStore, resolveMotionMode } from '../../stores/motionModeStore';
 import { MotionModePicker } from '../character/MotionModePicker';
 import { useGenerationStore } from '../../stores/generationStore';
 import { usePromptTemplateStore } from '../../stores/promptTemplateStore';
 import { usePortraitPositionStore } from '../../stores/portraitPositionStore';
-import { fetchExistingClips } from '../../api/livePortraitGen';
 import {
   getExpressionThumbnailUrl,
   getDefaultAvatarUrl,
@@ -270,12 +269,11 @@ export function ChatView() {
     [messages, failedExpressions, availableEmotions, getSpritePath, isGroupChatMode, selectedCharacter?.avatar]
   );
 
-  const livePortraitEnabled = useLivePortraitStore((s) => s.enabled);
-  const livePortraitClips = useLivePortraitStore((s) =>
-    selectedCharacter ? s.getClips(selectedCharacter.avatar) : null,
-  );
-  const hasLivePortraitClips =
-    livePortraitEnabled && !!livePortraitClips && 'idle' in livePortraitClips;
+  const {
+    clips: livePortraitClips,
+    hasClips: hasLivePortraitClips,
+    loading: livePortraitLoading,
+  } = useLivePortraitDiscovery(selectedCharacter?.avatar);
   const hasExpressionSprites = availableEmotions.length > 0;
   const motionMode = useMotionModeStore((s) =>
     selectedCharacter ? s.modesByAvatar[selectedCharacter.avatar] ?? 'auto' : 'auto',
@@ -288,30 +286,6 @@ export function ChatView() {
   const hasLivePortrait = resolvedMotionMode === 'liveportrait';
   const expressionsActive = resolvedMotionMode === 'expressions';
   const portraitEmotion = expressionsActive ? latestEmotion : null;
-
-  // Auto-discover server-side clips when a character is selected so users
-  // see Live Portrait on any device — not just the one that ran generation.
-  // Skips the fetch when the local store already has clips for this avatar.
-  useEffect(() => {
-    if (!selectedCharacter || !livePortraitEnabled) return;
-    if (livePortraitClips && Object.keys(livePortraitClips).length > 0) return;
-    let cancelled = false;
-    // B3c-assets — clips are now stored in user_blobs keyed by the
-    // character's avatar (filename incl. .png), not the name slug.
-    fetchExistingClips(selectedCharacter.avatar)
-      .then((clips) => {
-        if (cancelled) return;
-        if (Object.keys(clips).length > 0) {
-          useLivePortraitStore.getState().setClips(selectedCharacter.avatar, clips);
-        }
-      })
-      .catch(() => {
-        // No clips, no route, or auth issue — fall back to static avatar silently.
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [selectedCharacter?.avatar, livePortraitEnabled, livePortraitClips]);
 
   // Per-character draggable framing for the mobile portrait panel.
   // Stored as {x%, y%} object-position values, persisted via Zustand.
@@ -1156,6 +1130,11 @@ export function ChatView() {
                       }
                     }}
                   />
+                )}
+                {livePortraitLoading && !hasLivePortrait && (
+                  <div className="absolute top-2 right-2 rounded-full bg-black/40 p-1.5 backdrop-blur-sm">
+                    <div className="h-3 w-3 animate-spin rounded-full border-2 border-white/40 border-t-white" />
+                  </div>
                 )}
                 <div className="absolute inset-x-0 bottom-0 h-24 bg-gradient-to-t from-[var(--color-bg-primary)] to-transparent" />
                 <div className="absolute bottom-2 left-4 right-4 flex flex-col gap-2">

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -32,7 +32,7 @@ import type { CharacterInfo } from '../../api/client';
 import { useCharacterSprites } from '../../hooks/useCharacterSprites';
 import { getDefaultAvatarUrl, type Emotion } from '../../utils/emotions';
 import { LivePortraitVideo } from '../chat/LivePortraitVideo';
-import { useLivePortraitStore } from '../../stores/livePortraitStore';
+import { useLivePortraitDiscovery } from '../../hooks/useLivePortraitDiscovery';
 import { MotionModePicker } from '../character/MotionModePicker';
 import { useMotionModeStore, resolveMotionMode } from '../../stores/motionModeStore';
 
@@ -106,12 +106,11 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
     return (characterMessages[characterMessages.length - 1] as { emotion?: Emotion | null }).emotion ?? null;
   }, [messages]);
 
-  const livePortraitEnabled = useLivePortraitStore((s) => s.enabled);
-  const livePortraitClips = useLivePortraitStore((s) =>
-    selectedCharacter ? s.getClips(selectedCharacter.avatar) : null,
-  );
-  const hasLivePortraitClips =
-    livePortraitEnabled && !!livePortraitClips && 'idle' in livePortraitClips;
+  const {
+    clips: livePortraitClips,
+    hasClips: hasLivePortraitClips,
+    loading: livePortraitLoading,
+  } = useLivePortraitDiscovery(selectedCharacter?.avatar);
   const hasExpressionSprites = availableEmotions.length > 0;
   const motionMode = useMotionModeStore((s) =>
     selectedCharacter ? s.modesByAvatar[selectedCharacter.avatar] ?? 'auto' : 'auto',
@@ -263,7 +262,7 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
 
             {/* Full Character Portrait */}
             <div className="flex-1 flex flex-col items-center justify-center p-4 overflow-hidden">
-              <div className="w-full max-w-[240px] aspect-[2/3] rounded-xl overflow-hidden shadow-lg border border-[var(--color-border)]">
+              <div className="relative w-full max-w-[240px] aspect-[2/3] rounded-xl overflow-hidden shadow-lg border border-[var(--color-border)]">
                 {hasLivePortrait ? (
                   <LivePortraitVideo
                     clips={livePortraitClips!}
@@ -288,6 +287,11 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
                       }
                     }}
                   />
+                )}
+                {livePortraitLoading && !hasLivePortrait && (
+                  <div className="absolute bottom-2 right-2 rounded-full bg-black/40 p-1.5 backdrop-blur-sm">
+                    <div className="h-3 w-3 animate-spin rounded-full border-2 border-white/40 border-t-white" />
+                  </div>
                 )}
               </div>
 

--- a/src/hooks/useLivePortraitDiscovery.ts
+++ b/src/hooks/useLivePortraitDiscovery.ts
@@ -1,0 +1,97 @@
+import { useEffect, useState } from 'react';
+import { fetchExistingClips } from '../api/livePortraitGen';
+import { useLivePortraitStore, type EmotionClips } from '../stores/livePortraitStore';
+
+/**
+ * Auto-discovers server-side Live Portrait clips for a character and populates
+ * the local store, so the portrait shows on any device — not just the one that
+ * ran generation.
+ *
+ * This used to live as an inline effect in ChatView only. That meant the
+ * desktop layout (where the portrait renders in the Sidebar, not ChatView's
+ * `lg:hidden` panel) had no way to recover an empty cache on its own, and a
+ * single transient `/blobs` failure was swallowed silently with no retry —
+ * leaving the static avatar showing until some unrelated re-render happened to
+ * re-fire the fetch. Both ChatView and Sidebar now call this hook, so whichever
+ * layout is active drives discovery.
+ *
+ * - De-duped across consumers: ChatView and Sidebar are both always mounted, so
+ *   a module-level in-flight set ensures only one `/blobs` fetch per avatar runs
+ *   at a time.
+ * - Retries once on failure (transient auth/session/network), then logs instead
+ *   of failing silently.
+ * - Exposes `loading` so callers can avoid committing to the static fallback
+ *   before discovery has had a chance to resolve.
+ */
+
+const MAX_ATTEMPTS = 2;
+const RETRY_BASE_DELAY_MS = 1500;
+
+// Shared across all hook consumers so simultaneously-mounted layouts don't each
+// fire their own /blobs request for the same character.
+const inFlight = new Set<string>();
+
+export interface LivePortraitDiscovery {
+  /** Clip URL map for this character, or null if none cached yet. */
+  clips: EmotionClips | null;
+  /** True when the feature is enabled and a playable (idle-bearing) clip set is cached. */
+  hasClips: boolean;
+  /** True while discovery is in progress and the cache is still empty. */
+  loading: boolean;
+}
+
+export function useLivePortraitDiscovery(
+  avatar: string | null | undefined,
+): LivePortraitDiscovery {
+  const enabled = useLivePortraitStore((s) => s.enabled);
+  const clips = useLivePortraitStore((s) => (avatar ? s.getClips(avatar) : null));
+  const [loading, setLoading] = useState(false);
+
+  const hasLocalClips = !!clips && Object.keys(clips).length > 0;
+
+  useEffect(() => {
+    if (!avatar || !enabled) return;
+    if (hasLocalClips) return; // cache already populated
+    if (inFlight.has(avatar)) return; // another consumer is already fetching
+
+    inFlight.add(avatar); // this invocation owns the in-flight marker
+    let cancelled = false;
+    setLoading(true);
+
+    (async () => {
+      for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+        try {
+          const fetched = await fetchExistingClips(avatar);
+          if (cancelled) return;
+          if (Object.keys(fetched).length > 0) {
+            useLivePortraitStore.getState().setClips(avatar, fetched);
+          }
+          return; // success — an empty result just means this character has no clips
+        } catch (err) {
+          if (cancelled) return;
+          if (attempt < MAX_ATTEMPTS) {
+            await new Promise((r) => setTimeout(r, RETRY_BASE_DELAY_MS * attempt));
+          } else {
+            // Final failure: surface it once rather than swallowing silently,
+            // so a recurring /blobs problem is diagnosable instead of invisible.
+            console.warn(
+              `[LivePortrait] clip discovery failed for "${avatar}" after ${MAX_ATTEMPTS} attempts; showing static avatar`,
+              err,
+            );
+          }
+        }
+      }
+    })().finally(() => {
+      inFlight.delete(avatar);
+      if (!cancelled) setLoading(false);
+    });
+
+    return () => {
+      cancelled = true;
+      inFlight.delete(avatar);
+    };
+  }, [avatar, enabled, hasLocalClips]);
+
+  const hasClips = enabled && !!clips && 'idle' in clips;
+  return { clips: clips ?? null, hasClips, loading: loading && !hasLocalClips };
+}


### PR DESCRIPTION
## Problem

Live Portraits showed on desktop, then disappeared while still rendering on mobile — and "came back" only when the desktop window was narrowed into the mobile breakpoint (e.g. opening DevTools).

## Root cause

The portrait renders in **two separate places** depending on viewport — both always mounted, switched by CSS only:
- **Mobile (<1024px):** a panel in `ChatView` (`lg:hidden`)
- **Desktop (≥1024px):** a card in the `Sidebar` (ChatView's panel is hidden)

But the only code that **re-discovers server-side clips** (`fetchExistingClips` → populate the store) lived **inline in ChatView**. The `Sidebar` was a passive store consumer with no way to repopulate an empty cache on its own. Worse, the fetch's failure path was a bare `.catch(() => {})` — no retry, no log, no loading state. So when a user's local cache was empty (`clipsByAvatar: {}`) and the initial `/blobs` fetch raced session setup or hiccuped, the failure was swallowed and desktop sat on the static avatar until some unrelated re-render happened to re-fire the effect.

## Fix

Extract discovery into a shared **`useLivePortraitDiscovery`** hook, used by both `ChatView` and `Sidebar`:

- **Both layouts drive discovery** — desktop recovers on its own instead of depending on ChatView's effect having run.
- **De-duped** — a module-level in-flight set ensures only one `/blobs` request per avatar across the two always-mounted consumers.
- **Retries once** with backoff on a transient failure, then **logs a warning** instead of failing silently — so a recurring `/blobs` problem is diagnosable.
- **Exposes `loading`** — both render sites show a small spinner over the static avatar while discovery is in flight, so a slow load looks like "loading" rather than "no live portrait."

No data change: clips live server-side in `user_blobs` and repopulate automatically on next load.

## Verification
- `tsc -p tsconfig.app.json --noEmit` → clean
- `eslint` on changed files → no new issues (pre-existing errors confirmed on baseline; net −1 warning)
- `npm run build` → ✓ built

🤖 Generated with [Claude Code](https://claude.com/claude-code)