### PR TITLE
feat(chat): render markdown inside *action* and {{thought}} segments

### DIFF
--- a/src/components/chat/MarkdownContent.tsx
+++ b/src/components/chat/MarkdownContent.tsx
@@ -78,9 +78,12 @@ function parseRPSegments(text: string): TextSegment[] {
     segments.push({ type: 'dialogue', content: safe });
   }
 
-  // --- Step 3: restore code placeholders in dialogue segments ---
+  // --- Step 3: restore code placeholders in ALL segment types ---
+  // Dialogue, action, and thought segments now all render through
+  // renderMarkdown, so sheltered code must be restored everywhere — otherwise
+  // inline/fenced code inside *actions* or {{thoughts}} leaks its internal
+  // \x00C{n}\x00 placeholder to the user.
   return segments.map((seg) => {
-    if (seg.type !== 'dialogue') return seg;
     let c = seg.content;
     for (const [k, v] of codePH) c = c.replaceAll(k, v);
     return { ...seg, content: c };

--- a/src/components/chat/MarkdownContent.tsx
+++ b/src/components/chat/MarkdownContent.tsx
@@ -276,25 +276,29 @@ export function MarkdownContent({ content, isUser, isStreaming }: MarkdownConten
               }
 
               if (segment.type === 'action') {
+                const { html: actionHtml } = renderMarkdown(segment.content, isStreaming && isLastSeg);
+                const actionCursorHtml = isStreaming && isLastSeg
+                  ? actionHtml + '<span class="streaming-cursor"></span>'
+                  : actionHtml;
                 return (
                   <span
                     key={segIdx}
                     className={`italic ${isUser ? 'text-white/70' : 'rp-action'}`}
-                  >
-                    {segment.content}
-                    {isStreaming && isLastSeg && <span className="streaming-cursor" />}
-                  </span>
+                    dangerouslySetInnerHTML={{ __html: actionCursorHtml }}
+                  />
                 );
               }
               if (segment.type === 'thought') {
+                const { html: thoughtHtml } = renderMarkdown(segment.content, isStreaming && isLastSeg);
+                const thoughtCursorHtml = isStreaming && isLastSeg
+                  ? thoughtHtml + '<span class="streaming-cursor"></span>'
+                  : thoughtHtml;
                 return (
                   <span
                     key={segIdx}
                     className={`italic ${isUser ? 'text-white/60' : 'rp-thought'}`}
-                  >
-                    {segment.content}
-                    {isStreaming && isLastSeg && <span className="streaming-cursor" />}
-                  </span>
+                    dangerouslySetInnerHTML={{ __html: thoughtCursorHtml }}
+                  />
                 );
               }
 


### PR DESCRIPTION
## Summary

Roleplay **action** (`*…*`) and **thought** (`{{…}}`) segments rendered their inner text as raw escaped strings, so markdown inside them never formatted — e.g. `*she said it was **really** important*` showed literal `**` asterisks. Dialogue segments already routed through `renderMarkdown` (marked → DOMPurify sanitize) + `dangerouslySetInnerHTML`; this brings action/thought in line with that same path, including the streaming-cursor append.

Two commits:
1. **Render markdown in action/thought segments** — route their content through `renderMarkdown`, matching the existing dialogue path.
2. **Restore code placeholders in all segment types** — a latent bug surfaced during verification: `parseRPSegments` shelters inline/fenced code behind `\x00C{n}\x00` placeholders but only restored them into *dialogue* segments. That was fine when action/thought were plain text, but now that they render through `renderMarkdown`, code inside them leaked the placeholder (rendered as e.g. `C0`). Now restored everywhere.

## Safety

No new XSS surface. `renderMarkdown` sanitizes via `DOMPurify.sanitize(raw, SANITIZE_CONFIG)` with a strict tag/attr allowlist, and the `afterSanitizeAttributes` hook forces `target="_blank" rel="noopener noreferrer"` on links. The appended `<span class="streaming-cursor">` is a static literal. This is the exact trust path dialogue segments already use.

## Verification

Rendered the real `MarkdownContent` component in a browser against representative RP samples and inspected the resulting DOM:

| Case | Result |
|------|--------|
| `*She said it was **really** important.*` | `<strong>really</strong>` renders (italic+bold) |
| `{{I wonder if _this_ and \`that\` render...}}` | `<em>this</em>` + `<code>that</code>` — **no more `C0` leak** |
| `*She glanced at [the note](https://example.com)...*` | `<a href=… target="_blank" rel="noopener noreferrer">` inside `.rp-action` |

`npm run build` (tsc -b && vite build, matches CI) green; eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)