### PR TITLE
fix(sidebar): always show character info/favorite icons on touch devices

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -626,7 +626,7 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
                                   haptic();
                                   setPreviewCharacter(character);
                                 }}
-                                className="p-2 rounded-lg text-[var(--color-text-secondary)] opacity-0 group-hover:opacity-100 hover:text-[var(--color-primary)] transition-opacity"
+                                className="p-2 rounded-lg text-[var(--color-text-secondary)] opacity-100 [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover:opacity-100 hover:text-[var(--color-primary)] transition-opacity"
                                 title={`Preview ${character.name}`}
                                 aria-label={`Preview ${character.name}`}
                               >
@@ -640,7 +640,7 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
                                 className={`p-2 mr-2 rounded-lg transition-opacity ${
                                   isFav
                                     ? 'text-yellow-400 opacity-100'
-                                    : 'text-[var(--color-text-secondary)] opacity-0 group-hover:opacity-100 hover:text-yellow-400'
+                                    : 'text-[var(--color-text-secondary)] opacity-100 [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover:opacity-100 hover:text-yellow-400'
                                 }`}
                                 title={isFav ? 'Unfavorite' : 'Favorite'}
                               >


### PR DESCRIPTION
## Problem

On the character list, each row's **info** (preview) and **favorite** (star) icons were gated behind `opacity-0 group-hover:opacity-100`. Touch devices can't hover, so on mobile these icons were **permanently invisible** — there was no way to preview a character or favorite/unfavorite one.

## Fix

Gate the hide-until-hover behavior behind `@media (hover: hover)` instead of having it always-on:

```
opacity-100 [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover:opacity-100
```

- **Touch devices** (`hover: none`): the `@media(hover:hover)` rules never match, so only the base `opacity-100` applies → icons **always visible**.
- **Mouse devices** (`hover: hover`): unchanged — icons hide and reveal on row hover as before.

Using the hover media query rather than a width breakpoint (`lg:`) correctly handles wide touch devices like tablets, which can't hover regardless of viewport width. The already-favorited star (which was always visible) is untouched.

## Verification

Rendered the real `Sidebar` in a browser and measured computed `opacity` on both icons:

| Device class | `opacity` | Behavior |
|---|---|---|
| Mouse, not hovering (live) | `0` | hidden — hover-reveal preserved |
| Touch (`hover: none`) | `1` | **always visible** — the fix |

(The preview browser is hover-capable and can't emulate touch, so the touch state was measured by reproducing exactly what a `hover:none` device computes — the `@media(hover:hover)` rules don't apply there.)

`npm run build` (matches CI) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)