### PR TITLE
fix(sidebar): always show delete icon on group chats on touch devices

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -693,7 +693,7 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
                           </div>
                           <button
                             onClick={(e) => handleDeleteGroupChat(e, groupChat.fileName)}
-                            className="p-1.5 text-[var(--color-text-secondary)] hover:text-red-400 opacity-0 group-hover:opacity-100 transition-opacity"
+                            className="p-1.5 text-[var(--color-text-secondary)] hover:text-red-400 opacity-100 [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover:opacity-100 transition-opacity"
                             title="Delete group chat"
                           >
                             <Trash2 size={14} />


### PR DESCRIPTION
## Problem

Follow-up to #267. The **Delete group chat** trash icon in the Sidebar's Group Chats section had the same hover-only bug — `opacity-0 group-hover:opacity-100` — so it was invisible (and untappable) on touch devices, which can't hover.

## Fix

Same one-line pattern as #267 — gate the hide-until-hover behind `@media (hover: hover)`:

```
opacity-100 [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover:opacity-100
```

Touch devices → always visible; mouse devices → unchanged (hide, reveal on row hover).

## Verification

Identical CSS mechanism to #267, which was runtime-verified this session (computed `opacity` measured: `0` on a hover-capable device, `1` on a `hover:none` touch device). `npm run build` (matches CI) green; no new lint errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)