### PR TITLE
feat(worldinfo): create lorebook from chat transcript

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -354,6 +354,26 @@ export interface GenerationOptions {
   stopStrings?: string[];
 }
 
+/**
+ * Some newer models reject the classic sampler params outright — the backend
+ * returns a 400 ("`temperature` is deprecated for this model") rather than
+ * ignoring them. For those we omit temperature/top_p/etc. and let the provider
+ * use its own defaults. Currently this covers Claude Opus/Sonnet/Haiku 4.7 and
+ * newer; extend the version check as other models surface the same constraint.
+ */
+export function modelRejectsSamplers(model?: string): boolean {
+  if (!model) return false;
+  const m = model.toLowerCase();
+  const claude = m.match(/claude-(?:opus|sonnet|haiku)-(\d+)-(\d+)/);
+  if (claude) {
+    const major = Number(claude[1]);
+    const minor = Number(claude[2]);
+    if (major > 4) return true;
+    if (major === 4 && minor >= 7) return true;
+  }
+  return false;
+}
+
 /** Phase 6.1 — image attachment sent with generateMessage. `base64` is
  *  the raw payload (NO `data:...;base64,` prefix); the API client folds
  *  these into OpenAI-style content parts before POST. */
@@ -713,13 +733,17 @@ export const api = {
     }
 
     // Build request body with optional sampler params.
-    // Unknown fields are ignored by most providers.
+    // Unknown fields are ignored by most providers — except newer models that
+    // 400 on samplers like `temperature`, which we omit entirely for them.
+    const omitSamplers = modelRejectsSamplers(model);
     const body: Record<string, unknown> = {
       stream: true,
       max_tokens: generationOptions?.maxTokens ?? 1024,
-      temperature: generationOptions?.temperature ?? 0.9,
       model: model || 'gpt-4o',
     };
+    if (!omitSamplers) {
+      body.temperature = generationOptions?.temperature ?? 0.9;
+    }
 
     // Phase 10.3: text completion mode sends a single prompt string
     // to a separate backend endpoint.
@@ -753,7 +777,8 @@ export const api = {
       }
     }
 
-    if (generationOptions) {
+    // Sampler params — skipped for models that reject them (see omitSamplers).
+    if (generationOptions && !omitSamplers) {
       if (generationOptions.topP !== undefined) body.top_p = generationOptions.topP;
       if (generationOptions.topK !== undefined && generationOptions.topK > 0) {
         body.top_k = generationOptions.topK;
@@ -770,9 +795,12 @@ export const api = {
       if (generationOptions.repetitionPenalty !== undefined && generationOptions.repetitionPenalty !== 1.0) {
         body.repetition_penalty = generationOptions.repetitionPenalty;
       }
-      if (generationOptions.stopStrings && generationOptions.stopStrings.length > 0) {
-        body.stop = generationOptions.stopStrings;
-      }
+    }
+
+    // Stop strings aren't samplers and are accepted even by models that reject
+    // temperature/top_p, so honor them regardless.
+    if (generationOptions?.stopStrings && generationOptions.stopStrings.length > 0) {
+      body.stop = generationOptions.stopStrings;
     }
 
     const response = await fetch(endpoint, {

--- a/src/components/chat/ChatOptionsMenu.tsx
+++ b/src/components/chat/ChatOptionsMenu.tsx
@@ -14,7 +14,7 @@ import { useEffect, useRef } from 'react';
 import { useIsMobile } from '../../hooks/useIsMobile';
 import {
   BookOpen, FileText, GitFork, Library, MessageSquare, FolderOpen,
-  Trash2, Flag, Users, RefreshCw, ArrowRight, User, Image, ImageOff,
+  Trash2, Flag, Users, RefreshCw, ArrowRight, User, Image, ImageOff, BookPlus,
 } from 'lucide-react';
 import { BottomSheet } from '../ui/BottomSheet';
 
@@ -44,6 +44,7 @@ interface ChatOptionsMenuProps {
   onSaveCheckpoint?: () => void;
   onDeleteMessages: () => void;
   onConvertToGroup?: () => void;
+  onGenerateLorebook?: () => void;
   onRegenerate?: () => void;
   onContinue?: () => void;
   onImpersonate?: () => void;
@@ -105,6 +106,7 @@ function MenuBody({
   onSaveCheckpoint,
   onDeleteMessages,
   onConvertToGroup,
+  onGenerateLorebook,
   onRegenerate,
   onContinue,
   onImpersonate,
@@ -127,6 +129,7 @@ function MenuBody({
   onSaveCheckpoint?: () => void;
   onDeleteMessages: () => void;
   onConvertToGroup?: () => void;
+  onGenerateLorebook?: () => void;
   onRegenerate?: () => void;
   onContinue?: () => void;
   onImpersonate?: () => void;
@@ -175,6 +178,9 @@ function MenuBody({
         )}
         {!isGroupChat && onConvertToGroup && (
           <ActionRow icon={Users} label="Convert to group" onClick={wrap(onConvertToGroup)} />
+        )}
+        {onGenerateLorebook && (
+          <ActionRow icon={BookPlus} label="Create lorebook from chat" onClick={wrap(onGenerateLorebook)} />
         )}
         {onSetBackground && (
           <ActionRow
@@ -290,6 +296,7 @@ export function ChatOptionsMenu({
   onSaveCheckpoint,
   onDeleteMessages,
   onConvertToGroup,
+  onGenerateLorebook,
   onRegenerate,
   onContinue,
   onImpersonate,
@@ -347,6 +354,7 @@ export function ChatOptionsMenu({
       onSaveCheckpoint={onSaveCheckpoint}
       onDeleteMessages={onDeleteMessages}
       onConvertToGroup={onConvertToGroup}
+      onGenerateLorebook={onGenerateLorebook}
       onRegenerate={onRegenerate}
       onContinue={onContinue}
       onImpersonate={onImpersonate}

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -13,6 +13,7 @@ import { ChatOptionsMenu } from './ChatOptionsMenu';
 import { BottomSheet } from '../ui/BottomSheet';
 import { ChatHistoryPanel } from './ChatHistoryPanel';
 import { ChatLorebookModal } from './ChatLorebookModal';
+import { GenerateLorebookModal } from '../worldinfo/GenerateLorebookModal';
 import { useWorldInfoStore } from '../../stores/worldInfoStore';
 import { GroupChatControls } from './GroupChatControls';
 import { AuthorNote } from './AuthorNote';
@@ -216,6 +217,7 @@ export function ChatView() {
   // Phase 9.1: in-chat message search
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const [isConvertToGroupOpen, setIsConvertToGroupOpen] = useState(false);
+  const [isGenLorebookOpen, setIsGenLorebookOpen] = useState(false);
   const [convertGroupSelected, setConvertGroupSelected] = useState<string[]>([]);
   const [searchQuery, setSearchQuery] = useState('');
   const [searchMatchIndex, setSearchMatchIndex] = useState(0);
@@ -367,6 +369,12 @@ export function ChatView() {
 
   const hasAiMessage = useMemo(
     () => messages.some((m) => !m.isUser && !m.isSystem),
+    [messages]
+  );
+
+  // Enough back-and-forth to make lorebook extraction worthwhile.
+  const nonSystemMessageCount = useMemo(
+    () => messages.filter((m) => !m.isSystem).length,
     [messages]
   );
 
@@ -1756,6 +1764,7 @@ export function ChatView() {
           onSaveCheckpoint={currentChatFile && lastAiMessageId ? () => handleCheckpoint(lastAiMessageId) : undefined}
           onDeleteMessages={() => startNewChat(selectedCharacter)}
           onConvertToGroup={!isGroupChatMode && selectedCharacter ? () => { setConvertGroupSelected([]); setIsConvertToGroupOpen(true); } : undefined}
+          onGenerateLorebook={nonSystemMessageCount >= 6 ? () => setIsGenLorebookOpen(true) : undefined}
           onRegenerate={hasAiMessage && !isGroupChatMode ? handleRegenerate : undefined}
           onContinue={hasAiMessage && !isGroupChatMode ? handleContinue : undefined}
           onImpersonate={!isGroupChatMode ? handleImpersonate : undefined}
@@ -1763,6 +1772,17 @@ export function ChatView() {
           onClearBackground={handleClearBg}
           hasBackground={!!vnBg}
           isGroupChat={isGroupChatMode}
+        />
+      )}
+
+      {/* Create lorebook from chat transcript */}
+      {selectedCharacter && (
+        <GenerateLorebookModal
+          isOpen={isGenLorebookOpen}
+          onClose={() => setIsGenLorebookOpen(false)}
+          messages={messages}
+          characterName={selectedCharacter.name}
+          defaultBookName={`${selectedCharacter.name} — Lore`}
         />
       )}
 

--- a/src/components/worldinfo/ChatPickerModal.tsx
+++ b/src/components/worldinfo/ChatPickerModal.tsx
@@ -1,0 +1,154 @@
+/**
+ * ChatPickerModal — two-step picker used by the World Info page to choose a
+ * saved chat to generate a lorebook from: character first, then one of that
+ * character's chat files. Emits the selection; the parent loads the messages.
+ */
+import { useEffect, useState } from 'react';
+import { ArrowLeft, Loader2, MessageSquare } from 'lucide-react';
+import { Modal } from '../ui';
+import { api } from '../../api/client';
+import { useCharacterStore } from '../../stores/characterStore';
+
+export interface ChatSelection {
+  avatar: string;
+  characterName: string;
+  fileName: string;
+}
+
+interface ChatFileMeta {
+  file_name: string;
+  message_count: number;
+  last_mes: string;
+}
+
+interface ChatPickerModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSelect: (selection: ChatSelection) => void;
+}
+
+export function ChatPickerModal({ isOpen, onClose, onSelect }: ChatPickerModalProps) {
+  const characters = useCharacterStore((s) => s.characters);
+
+  const [picked, setPicked] = useState<{ avatar: string; name: string } | null>(null);
+  const [chats, setChats] = useState<ChatFileMeta[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Reset to the character list whenever the modal (re)opens.
+  useEffect(() => {
+    if (isOpen) {
+      setPicked(null);
+      setChats([]);
+      setError(null);
+    }
+  }, [isOpen]);
+
+  const handlePickCharacter = async (avatar: string, name: string) => {
+    setPicked({ avatar, name });
+    setLoading(true);
+    setError(null);
+    try {
+      const list = await api.getChats(avatar);
+      setChats(Array.isArray(list) ? list : []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load chats.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={picked ? `Chats with ${picked.name}` : 'Choose a character'}
+      size="md"
+    >
+      {picked ? (
+        <div className="space-y-3">
+          <button
+            type="button"
+            onClick={() => setPicked(null)}
+            className="flex items-center gap-1.5 text-sm text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]"
+          >
+            <ArrowLeft size={16} />
+            Back to characters
+          </button>
+
+          {loading ? (
+            <div className="flex items-center gap-2 py-8 justify-center text-sm text-[var(--color-text-secondary)]">
+              <Loader2 size={16} className="animate-spin" />
+              Loading chats…
+            </div>
+          ) : error ? (
+            <p className="text-sm text-red-400 py-4">{error}</p>
+          ) : chats.length === 0 ? (
+            <p className="text-sm text-[var(--color-text-secondary)] py-6 text-center">
+              No saved chats for this character.
+            </p>
+          ) : (
+            <ul className="space-y-1.5 max-h-[50vh] overflow-y-auto">
+              {chats.map((chat) => (
+                <li key={chat.file_name}>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      onSelect({
+                        avatar: picked.avatar,
+                        characterName: picked.name,
+                        fileName: chat.file_name,
+                      })
+                    }
+                    className="w-full flex items-center gap-3 px-3 py-2 rounded-lg text-left text-[var(--color-text-primary)] hover:bg-[var(--color-bg-tertiary)] transition-colors"
+                  >
+                    <MessageSquare
+                      size={16}
+                      className="flex-shrink-0 text-[var(--color-text-secondary)]"
+                    />
+                    <span className="flex-1 min-w-0">
+                      <span className="block text-sm truncate">
+                        {chat.file_name.replace(/\.jsonl$/i, '')}
+                      </span>
+                      <span className="block text-xs text-[var(--color-text-secondary)] truncate">
+                        {chat.message_count} message
+                        {chat.message_count === 1 ? '' : 's'}
+                        {chat.last_mes ? ` · ${chat.last_mes}` : ''}
+                      </span>
+                    </span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      ) : characters.length === 0 ? (
+        <p className="text-sm text-[var(--color-text-secondary)] py-6 text-center">
+          You don't have any characters yet.
+        </p>
+      ) : (
+        <ul className="space-y-1.5 max-h-[60vh] overflow-y-auto">
+          {characters.map((c) => (
+            <li key={c.avatar}>
+              <button
+                type="button"
+                onClick={() => handlePickCharacter(c.avatar, c.name)}
+                className="w-full flex items-center gap-3 px-3 py-2 rounded-lg text-left text-[var(--color-text-primary)] hover:bg-[var(--color-bg-tertiary)] transition-colors"
+              >
+                <img
+                  src={`/api/avatar/${c.avatar}`}
+                  alt={c.name}
+                  className="w-8 h-8 rounded-full object-cover flex-shrink-0"
+                  onError={(e) => {
+                    (e.currentTarget as HTMLImageElement).style.visibility = 'hidden';
+                  }}
+                />
+                <span className="flex-1 truncate text-sm">{c.name}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </Modal>
+  );
+}

--- a/src/components/worldinfo/GenerateLorebookModal.tsx
+++ b/src/components/worldinfo/GenerateLorebookModal.tsx
@@ -1,0 +1,363 @@
+/**
+ * GenerateLorebookModal — distill a chat transcript into a new lorebook.
+ *
+ * Flow: pre-flight (shows the model-call count) → generating (progress + cancel)
+ * → review (edit/deselect drafts, name the book) → create. The actual extraction
+ * lives in `src/utils/lorebookFromTranscript.ts`; this component owns the UI and
+ * the final write into the world-info store.
+ *
+ * Shared by both entry points (in-chat options menu and the World Info page),
+ * so it takes already-prepared `TranscriptMsg[]` rather than reaching into a
+ * particular store for the active chat.
+ */
+import { useEffect, useRef, useState } from 'react';
+import { Loader2, Sparkles, Trash2, BookPlus } from 'lucide-react';
+import { Modal, Button, Input, TextArea, TagInput } from '../ui';
+import { useSettingsStore } from '../../stores/settingsStore';
+import {
+  useWorldInfoStore,
+  type WorldInfoBook,
+} from '../../stores/worldInfoStore';
+import {
+  planChunks,
+  extractLorebookEntries,
+  type TranscriptMsg,
+  type DraftLorebookEntry,
+} from '../../utils/lorebookFromTranscript';
+
+interface GenerateLorebookModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  messages: TranscriptMsg[];
+  characterName: string;
+  defaultBookName: string;
+  onCreated?: (book: WorldInfoBook) => void;
+}
+
+type Phase = 'preflight' | 'generating' | 'review' | 'error';
+
+interface EditableDraft extends DraftLorebookEntry {
+  uid: number;
+  enabled: boolean;
+}
+
+export function GenerateLorebookModal({
+  isOpen,
+  onClose,
+  messages,
+  characterName,
+  defaultBookName,
+  onCreated,
+}: GenerateLorebookModalProps) {
+  const createBook = useWorldInfoStore((s) => s.createBook);
+  const createEntry = useWorldInfoStore((s) => s.createEntry);
+
+  const [phase, setPhase] = useState<Phase>('preflight');
+  const [progress, setProgress] = useState({ done: 0, total: 0 });
+  const [drafts, setDrafts] = useState<EditableDraft[]>([]);
+  const [bookName, setBookName] = useState(defaultBookName);
+  const [error, setError] = useState<string | null>(null);
+  const [truncatedNote, setTruncatedNote] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const chunkCount = planChunks(messages, characterName).length;
+
+  // Reset everything each time the modal opens so a second run starts clean.
+  useEffect(() => {
+    if (!isOpen) return;
+    setPhase('preflight');
+    setProgress({ done: 0, total: chunkCount });
+    setDrafts([]);
+    setBookName(defaultBookName);
+    setError(null);
+    setTruncatedNote(null);
+    // chunkCount/defaultBookName are derived from props; intentionally only
+    // re-init on open.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen]);
+
+  // Abort any in-flight generation if the modal unmounts.
+  useEffect(() => {
+    return () => abortRef.current?.abort();
+  }, []);
+
+  const handleGenerate = async () => {
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setPhase('generating');
+    setError(null);
+    setProgress({ done: 0, total: chunkCount });
+
+    try {
+      const { activeProvider, activeModel } = useSettingsStore.getState();
+      const result = await extractLorebookEntries(messages, characterName, {
+        provider: activeProvider,
+        model: activeModel,
+        signal: controller.signal,
+        onProgress: (done, total) => setProgress({ done, total }),
+      });
+
+      if (result.truncated) {
+        setTruncatedNote(
+          `Chat was long — processed the first ${result.messagesProcessed} of ${result.messagesTotal} messages.`
+        );
+      }
+      setDrafts(
+        result.entries.map((e, i) => ({ ...e, uid: i, enabled: true }))
+      );
+      setPhase('review');
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') {
+        // User cancelled — return to the pre-flight screen.
+        setPhase('preflight');
+        return;
+      }
+      setError(err instanceof Error ? err.message : 'Generation failed.');
+      setPhase('error');
+    } finally {
+      abortRef.current = null;
+    }
+  };
+
+  const handleCancel = () => {
+    abortRef.current?.abort();
+  };
+
+  const updateDraft = (uid: number, patch: Partial<EditableDraft>) =>
+    setDrafts((cur) => cur.map((d) => (d.uid === uid ? { ...d, ...patch } : d)));
+
+  const removeDraft = (uid: number) =>
+    setDrafts((cur) => cur.filter((d) => d.uid !== uid));
+
+  const enabledDrafts = drafts.filter(
+    (d) => d.enabled && d.keys.length > 0 && d.content.trim().length > 0
+  );
+
+  const handleCreate = () => {
+    const name = bookName.trim() || defaultBookName;
+    const book = createBook(name);
+    for (const draft of enabledDrafts) {
+      createEntry(book.id, {
+        keys: draft.keys,
+        content: draft.content.trim(),
+        comment: draft.category,
+      });
+    }
+    // `book` is the snapshot from before entries were added — read the fresh
+    // copy so callers see the populated entry list.
+    const fresh =
+      useWorldInfoStore.getState().books.find((b) => b.id === book.id) ?? book;
+    onCreated?.(fresh);
+    onClose();
+  };
+
+  const allEnabled = drafts.length > 0 && drafts.every((d) => d.enabled);
+  const toggleAll = () =>
+    setDrafts((cur) => cur.map((d) => ({ ...d, enabled: !allEnabled })));
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Create lorebook from chat" size="lg">
+      {/* ---------------------------------------------------------------- */}
+      {/* Pre-flight */}
+      {/* ---------------------------------------------------------------- */}
+      {phase === 'preflight' && (
+        <div className="space-y-4">
+          <div className="flex items-start gap-3">
+            <div className="p-2 rounded-lg bg-[var(--color-primary)]/15 text-[var(--color-primary)] flex-shrink-0">
+              <Sparkles size={20} />
+            </div>
+            <div className="text-sm text-[var(--color-text-secondary)] leading-relaxed">
+              The active model will read the whole conversation and extract
+              characters, places, items, factions, events, and lore into draft
+              lorebook entries. You'll review and edit them before anything is
+              saved.
+            </div>
+          </div>
+
+          {chunkCount === 0 ? (
+            <p className="text-sm text-[var(--color-text-secondary)]">
+              There aren't enough messages in this chat to extract anything yet.
+            </p>
+          ) : (
+            <div className="p-3 rounded-lg bg-[var(--color-bg-tertiary)] text-xs text-[var(--color-text-secondary)]">
+              This will make{' '}
+              <span className="font-semibold text-[var(--color-text-primary)]">
+                {chunkCount} model call{chunkCount === 1 ? '' : 's'}
+              </span>{' '}
+              using your active provider/model.
+            </div>
+          )}
+
+          <div className="flex justify-end gap-2 pt-2">
+            <Button variant="ghost" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button onClick={handleGenerate} disabled={chunkCount === 0}>
+              <Sparkles size={16} className="mr-2" />
+              Generate
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {/* ---------------------------------------------------------------- */}
+      {/* Generating */}
+      {/* ---------------------------------------------------------------- */}
+      {phase === 'generating' && (
+        <div className="space-y-4 py-2">
+          <div className="flex items-center gap-3 text-[var(--color-text-primary)]">
+            <Loader2 size={20} className="animate-spin text-[var(--color-primary)]" />
+            <span className="text-sm">
+              Extracting lore… chunk {Math.min(progress.done + 1, progress.total)} of{' '}
+              {progress.total}
+            </span>
+          </div>
+          <div className="h-2 w-full rounded-full bg-[var(--color-bg-tertiary)] overflow-hidden">
+            <div
+              className="h-full bg-[var(--color-primary)] transition-all duration-300"
+              style={{
+                width: `${progress.total ? (progress.done / progress.total) * 100 : 0}%`,
+              }}
+            />
+          </div>
+          <div className="flex justify-end pt-2">
+            <Button variant="ghost" onClick={handleCancel}>
+              Cancel
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {/* ---------------------------------------------------------------- */}
+      {/* Error */}
+      {/* ---------------------------------------------------------------- */}
+      {phase === 'error' && (
+        <div className="space-y-4">
+          <p className="text-sm text-red-400">{error}</p>
+          <div className="flex justify-end gap-2">
+            <Button variant="ghost" onClick={onClose}>
+              Close
+            </Button>
+            <Button onClick={() => setPhase('preflight')}>Try again</Button>
+          </div>
+        </div>
+      )}
+
+      {/* ---------------------------------------------------------------- */}
+      {/* Review */}
+      {/* ---------------------------------------------------------------- */}
+      {phase === 'review' && (
+        <div className="space-y-4">
+          {truncatedNote && (
+            <div className="p-2.5 rounded-lg bg-amber-500/10 border border-amber-500/30 text-xs text-amber-400">
+              {truncatedNote}
+            </div>
+          )}
+
+          {drafts.length === 0 ? (
+            <div className="text-center py-8">
+              <BookPlus
+                size={40}
+                className="mx-auto text-[var(--color-text-secondary)] mb-3"
+              />
+              <p className="text-sm text-[var(--color-text-primary)] mb-1">
+                No lore found in this chat
+              </p>
+              <p className="text-xs text-[var(--color-text-secondary)]">
+                The model didn't find durable facts worth saving. Try a longer
+                conversation.
+              </p>
+            </div>
+          ) : (
+            <>
+              <Input
+                label="Lorebook name"
+                value={bookName}
+                onChange={(e) => setBookName(e.target.value)}
+              />
+
+              <div className="flex items-center justify-between text-xs text-[var(--color-text-secondary)]">
+                <span>
+                  {enabledDrafts.length} of {drafts.length} entr
+                  {drafts.length === 1 ? 'y' : 'ies'} selected
+                </span>
+                <button
+                  type="button"
+                  onClick={toggleAll}
+                  className="text-[var(--color-primary)] hover:underline"
+                >
+                  {allEnabled ? 'Deselect all' : 'Select all'}
+                </button>
+              </div>
+
+              <ul className="space-y-3">
+                {drafts.map((draft) => (
+                  <li
+                    key={draft.uid}
+                    className={`p-3 rounded-lg border transition-colors ${
+                      draft.enabled
+                        ? 'border-[var(--color-border)] bg-[var(--color-bg-tertiary)]'
+                        : 'border-[var(--color-border)] bg-transparent opacity-60'
+                    }`}
+                  >
+                    <div className="flex items-start gap-2 mb-2">
+                      <input
+                        type="checkbox"
+                        checked={draft.enabled}
+                        onChange={(e) =>
+                          updateDraft(draft.uid, { enabled: e.target.checked })
+                        }
+                        className="mt-1 w-4 h-4 accent-[var(--color-primary)] flex-shrink-0"
+                        aria-label="Include this entry"
+                      />
+                      <span className="px-2 py-0.5 rounded-full text-[10px] font-medium bg-[var(--color-primary)]/15 text-[var(--color-primary)] flex-shrink-0">
+                        {draft.category}
+                      </span>
+                      <div className="flex-1" />
+                      <button
+                        type="button"
+                        onClick={() => removeDraft(draft.uid)}
+                        className="p-1 rounded text-[var(--color-text-secondary)] hover:text-red-400 hover:bg-red-500/10 flex-shrink-0"
+                        aria-label="Remove entry"
+                      >
+                        <Trash2 size={14} />
+                      </button>
+                    </div>
+
+                    <div className="space-y-2 pl-6">
+                      <TagInput
+                        value={draft.keys}
+                        onChange={(keys) => updateDraft(draft.uid, { keys })}
+                        placeholder="Add keyword..."
+                      />
+                      <TextArea
+                        value={draft.content}
+                        onChange={(e) =>
+                          updateDraft(draft.uid, { content: e.target.value })
+                        }
+                        rows={2}
+                      />
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </>
+          )}
+
+          <div className="flex justify-end gap-2 pt-2 border-t border-[var(--color-border)]">
+            <Button variant="ghost" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button
+              onClick={handleCreate}
+              disabled={enabledDrafts.length === 0 || !bookName.trim()}
+            >
+              <BookPlus size={16} className="mr-2" />
+              Create lorebook ({enabledDrafts.length})
+            </Button>
+          </div>
+        </div>
+      )}
+    </Modal>
+  );
+}

--- a/src/components/worldinfo/WorldInfoPage.tsx
+++ b/src/components/worldinfo/WorldInfoPage.tsx
@@ -8,14 +8,20 @@ import {
   Upload,
   Copy,
   BookOpen,
+  Sparkles,
+  Loader2,
 } from 'lucide-react';
 import { useSettingsPanelStore } from '../../stores/settingsPanelStore';
 import {
   useWorldInfoStore,
   type WorldInfoBook,
 } from '../../stores/worldInfoStore';
-import { Button, Input, ConfirmDialog } from '../ui';
+import { Button, Input, ConfirmDialog, Modal } from '../ui';
 import { WorldInfoBookEditor } from './WorldInfoBookEditor';
+import { ChatPickerModal, type ChatSelection } from './ChatPickerModal';
+import { GenerateLorebookModal } from './GenerateLorebookModal';
+import { api } from '../../api/client';
+import type { TranscriptMsg } from '../../utils/lorebookFromTranscript';
 
 export function WorldInfoPage(_props?: { params?: Record<string, string> }) {
   const { goBack } = useSettingsPanelStore();
@@ -46,6 +52,41 @@ export function WorldInfoPage(_props?: { params?: Record<string, string> }) {
   const [confirmDelete, setConfirmDelete] = useState<WorldInfoBook | null>(null);
   const [importNotice, setImportNotice] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  // "Generate from chat" flow: pick a chat → load its messages → review modal.
+  const [isChatPickerOpen, setIsChatPickerOpen] = useState(false);
+  const [genLoading, setGenLoading] = useState(false);
+  const [genError, setGenError] = useState<string | null>(null);
+  const [pendingGen, setPendingGen] = useState<{
+    messages: TranscriptMsg[];
+    characterName: string;
+    defaultBookName: string;
+  } | null>(null);
+
+  const handleChatSelected = async (sel: ChatSelection) => {
+    setIsChatPickerOpen(false);
+    setGenError(null);
+    setGenLoading(true);
+    try {
+      const raw = await api.getChatMessages(sel.avatar, sel.fileName);
+      const messages: TranscriptMsg[] = raw.map((m) => ({
+        name: m.name,
+        isUser: m.is_user,
+        isSystem: m.is_system,
+        content: m.mes,
+      }));
+      setPendingGen({
+        messages,
+        characterName: sel.characterName,
+        defaultBookName: `${sel.characterName} — Lore`,
+      });
+    } catch (err) {
+      console.error('[WI] Failed to load chat for lorebook generation:', err);
+      setGenError('Could not load that chat. Please try again.');
+    } finally {
+      setGenLoading(false);
+    }
+  };
 
   // Character-embedded books are managed from the character editor; hide
   // them from the global lorebook list to avoid confusion.
@@ -144,6 +185,18 @@ export function WorldInfoPage(_props?: { params?: Record<string, string> }) {
         {importNotice && (
           <div className="p-3 bg-green-500/10 border border-green-500/30 rounded-lg">
             <p className="text-sm text-green-400">{importNotice}</p>
+          </div>
+        )}
+        {genError && (
+          <div className="p-3 bg-red-500/10 border border-red-500/30 rounded-lg flex items-center justify-between">
+            <p className="text-sm text-red-400">{genError}</p>
+            <button
+              onClick={() => setGenError(null)}
+              className="text-red-400 hover:text-red-300"
+              aria-label="Dismiss"
+            >
+              ×
+            </button>
           </div>
         )}
 
@@ -247,15 +300,29 @@ export function WorldInfoPage(_props?: { params?: Record<string, string> }) {
               onChange={handleFileSelected}
               className="hidden"
             />
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={handleImportClick}
-              className="text-xs"
-            >
-              <Upload size={14} className="mr-1" />
-              Import
-            </Button>
+            <div className="flex items-center gap-1">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => {
+                  setGenError(null);
+                  setIsChatPickerOpen(true);
+                }}
+                className="text-xs"
+              >
+                <Sparkles size={14} className="mr-1" />
+                Generate from chat
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={handleImportClick}
+                className="text-xs"
+              >
+                <Upload size={14} className="mr-1" />
+                Import
+              </Button>
+            </div>
           </div>
 
           <div className="flex gap-2 mb-3">
@@ -432,6 +499,37 @@ export function WorldInfoPage(_props?: { params?: Record<string, string> }) {
           message={`Delete "${confirmDelete.name}" and all its entries? This cannot be undone.`}
           confirmLabel="Delete"
           danger
+        />
+      )}
+
+      <ChatPickerModal
+        isOpen={isChatPickerOpen}
+        onClose={() => setIsChatPickerOpen(false)}
+        onSelect={handleChatSelected}
+      />
+
+      {genLoading && (
+        <Modal isOpen={genLoading} onClose={() => {}} title="Loading chat" size="sm">
+          <div className="flex items-center gap-2 py-2 text-sm text-[var(--color-text-secondary)]">
+            <Loader2 size={16} className="animate-spin" />
+            Loading chat messages…
+          </div>
+        </Modal>
+      )}
+
+      {pendingGen && (
+        <GenerateLorebookModal
+          isOpen={!!pendingGen}
+          onClose={() => setPendingGen(null)}
+          messages={pendingGen.messages}
+          characterName={pendingGen.characterName}
+          defaultBookName={pendingGen.defaultBookName}
+          onCreated={(book) => {
+            setImportNotice(
+              `Created "${book.name}" with ${book.entries.length} entr${book.entries.length === 1 ? 'y' : 'ies'}`
+            );
+            setTimeout(() => setImportNotice(null), 4000);
+          }}
         />
       )}
     </div>

--- a/src/utils/lorebookFromTranscript.ts
+++ b/src/utils/lorebookFromTranscript.ts
@@ -1,0 +1,383 @@
+/**
+ * Create-lorebook-from-transcript — distill an ENTIRE chat into a fresh set of
+ * standalone lorebook entries (characters, locations, items, factions, events,
+ * lore) for the user to review and save as a new World Info book.
+ *
+ * This is the one-shot, user-triggered cousin of the auto-memory extension
+ * (`src/stores/autoMemoryStore.ts`), which instead appends recent-window facts
+ * to a per-character book automatically. The prompt, SSE parsing, and dedupe
+ * rules deliberately mirror that store; the differences here are (1) the whole
+ * transcript is processed via token-budgeted chunks so early lore isn't lost,
+ * and (2) results are returned as drafts rather than written directly.
+ */
+
+import { api } from '../api/client';
+import { estimateTokens } from './tokenizer';
+
+export interface DraftLorebookEntry {
+  /** Primary keywords a future scan would look for to surface this entry. */
+  keys: string[];
+  /** The lore text. One or two sentences. */
+  content: string;
+  /** Coarse bucket used for grouping/badging in the review UI. */
+  category: string;
+}
+
+/** Minimal message shape the extractor needs. Decoupled from store types. */
+export type TranscriptMsg = {
+  name: string;
+  isUser: boolean;
+  isSystem: boolean;
+  content: string;
+};
+
+export interface ExtractOptions {
+  provider?: string;
+  model?: string;
+  signal?: AbortSignal;
+  /** Called after each chunk completes: (chunksDone, chunksTotal). */
+  onProgress?: (done: number, total: number) => void;
+}
+
+export interface ExtractResult {
+  entries: DraftLorebookEntry[];
+  /** Non-system messages actually fed to the model. */
+  messagesProcessed: number;
+  /** Total non-system messages in the transcript. */
+  messagesTotal: number;
+  /** True when the transcript was longer than the chunk cap allowed. */
+  truncated: boolean;
+}
+
+// Categories the model is asked to bucket entries into. Kept loose — the review
+// UI badges whatever string comes back, falling back to "Lore".
+export const LOREBOOK_CATEGORIES = [
+  'Character',
+  'Location',
+  'Item',
+  'Faction',
+  'Event',
+  'Lore',
+] as const;
+
+/** Roughly how many transcript tokens to feed the model per chunk. */
+const CHUNK_TOKEN_BUDGET = 2500;
+/** Hard cap on chunks so a giant log can't fan out into unbounded calls. */
+const MAX_CHUNKS = 20;
+
+function transcriptLine(m: TranscriptMsg, characterName: string): string {
+  // Use the message's own name for AI turns so group chats read correctly;
+  // fall back to the active character's name.
+  const speaker = m.isUser ? 'User' : m.name || characterName || 'Character';
+  return `${speaker}: ${m.content}`;
+}
+
+/**
+ * Split the (non-system) transcript into chunks bounded by `CHUNK_TOKEN_BUDGET`
+ * and `MAX_CHUNKS`. Returns the rendered transcript text for each chunk — the
+ * UI uses `.length` to show the pre-flight call count, and `extractLorebookEntries`
+ * reuses the same split so the count is exact.
+ */
+export function planChunks(
+  messages: TranscriptMsg[],
+  characterName: string
+): string[] {
+  const lines = messages
+    .filter((m) => !m.isSystem)
+    .map((m) => transcriptLine(m, characterName))
+    .filter((l) => l.trim().length > 0);
+
+  const chunks: string[] = [];
+  let current: string[] = [];
+  let currentTokens = 0;
+
+  for (const line of lines) {
+    const lineTokens = estimateTokens(line);
+    if (current.length > 0 && currentTokens + lineTokens > CHUNK_TOKEN_BUDGET) {
+      chunks.push(current.join('\n'));
+      current = [];
+      currentTokens = 0;
+    }
+    current.push(line);
+    currentTokens += lineTokens;
+  }
+  if (current.length > 0) chunks.push(current.join('\n'));
+
+  return chunks.slice(0, MAX_CHUNKS);
+}
+
+/**
+ * How many non-system messages the first `MAX_CHUNKS` worth of chunks cover.
+ * Used to report truncation without re-deriving the chunk boundaries.
+ */
+function countProcessedMessages(
+  messages: TranscriptMsg[],
+  characterName: string,
+  chunkCount: number
+): number {
+  // Re-walk with the same budgeting, stopping once we've emitted `chunkCount`
+  // chunks, and count how many real messages fell into them.
+  const nonSystem = messages.filter((m) => !m.isSystem);
+  let processed = 0;
+  let chunks = 0;
+  let currentTokens = 0;
+  let currentHasContent = false;
+
+  for (const m of nonSystem) {
+    const line = transcriptLine(m, characterName);
+    if (!line.trim()) continue;
+    const lineTokens = estimateTokens(line);
+    if (currentHasContent && currentTokens + lineTokens > CHUNK_TOKEN_BUDGET) {
+      chunks += 1;
+      if (chunks >= chunkCount) break;
+      currentTokens = 0;
+      currentHasContent = false;
+    }
+    currentTokens += lineTokens;
+    currentHasContent = true;
+    processed += 1;
+  }
+  return processed;
+}
+
+// ---------------------------------------------------------------------------
+// SSE stream parsing — copied to match the convention already used by
+// summarizeStore and autoMemoryStore (both keep a local copy). Kept identical
+// so behavior matches the rest of the app's generation paths.
+// ---------------------------------------------------------------------------
+
+async function* parseSSEStream(
+  stream: ReadableStream<Uint8Array>
+): AsyncGenerator<string> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop() || '';
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed === 'data: [DONE]') continue;
+        if (trimmed.startsWith('data: ')) {
+          const data = trimmed.slice(6);
+          if (!data || data === '[DONE]') continue;
+          let json;
+          try {
+            json = JSON.parse(data);
+          } catch {
+            if (data.length > 0 && data !== 'undefined') yield data;
+            continue;
+          }
+          // Surface backend/provider errors that arrive mid-stream (e.g.
+          // "temperature is deprecated for this model") instead of silently
+          // yielding nothing — otherwise the caller mistakes a failed
+          // generation for an empty result ("No lore found").
+          if (json?.error) {
+            const msg =
+              typeof json.error === 'string'
+                ? json.error
+                : json.error.message || 'Generation failed';
+            throw new Error(msg);
+          }
+          const content =
+            json.choices?.[0]?.delta?.content ||
+            json.choices?.[0]?.text ||
+            json.delta?.text ||
+            (json.type === 'content_block_delta' ? json.delta?.text : null) ||
+            json.content ||
+            json.message?.content?.[0]?.text ||
+            '';
+          if (content) yield content;
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function normalizeCategory(raw: unknown): string {
+  if (typeof raw !== 'string') return 'Lore';
+  const trimmed = raw.trim();
+  if (!trimmed) return 'Lore';
+  const match = LOREBOOK_CATEGORIES.find(
+    (c) => c.toLowerCase() === trimmed.toLowerCase()
+  );
+  return match ?? 'Lore';
+}
+
+function entryFromObject(obj: Record<string, unknown>): DraftLorebookEntry | null {
+  const rawKeys = Array.isArray(obj.keys)
+    ? obj.keys.filter((k): k is string => typeof k === 'string')
+    : typeof obj.keys === 'string'
+      ? [obj.keys]
+      : [];
+  const content = typeof obj.content === 'string' ? obj.content.trim() : '';
+  const keys = rawKeys.map((k) => k.trim()).filter(Boolean);
+  if (keys.length === 0 || !content) return null;
+  return { keys, content, category: normalizeCategory(obj.category) };
+}
+
+/**
+ * Pull complete top-level `{...}` objects out of arbitrary text via brace
+ * matching (string/escape aware). Unlike a single `JSON.parse` of the whole
+ * array, this survives truncated output (finish_reason "length") — a cut-off
+ * final object is simply skipped instead of discarding everything before it.
+ */
+function extractJsonObjects(text: string): string[] {
+  const objs: string[] = [];
+  let depth = 0;
+  let start = -1;
+  let inStr = false;
+  let esc = false;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (inStr) {
+      if (esc) esc = false;
+      else if (ch === '\\') esc = true;
+      else if (ch === '"') inStr = false;
+      continue;
+    }
+    if (ch === '"') inStr = true;
+    else if (ch === '{') {
+      if (depth === 0) start = i;
+      depth++;
+    } else if (ch === '}') {
+      if (depth > 0) {
+        depth--;
+        if (depth === 0 && start >= 0) {
+          objs.push(text.slice(start, i + 1));
+          start = -1;
+        }
+      }
+    }
+  }
+  return objs;
+}
+
+/**
+ * Parse draft entries from an LLM response. Tolerant of fenced/prose-wrapped
+ * output AND of truncation: each complete entry object is recovered and parsed
+ * independently.
+ */
+function parseEntriesFromResponse(text: string): DraftLorebookEntry[] {
+  const out: DraftLorebookEntry[] = [];
+  for (const chunk of extractJsonObjects(text)) {
+    let obj: unknown;
+    try {
+      obj = JSON.parse(chunk);
+    } catch {
+      continue;
+    }
+    if (!obj || typeof obj !== 'object') continue;
+    const entry = entryFromObject(obj as Record<string, unknown>);
+    if (entry) out.push(entry);
+  }
+  return out;
+}
+
+const SYSTEM_PROMPT = `You are an information-extraction assistant building a reusable lorebook from a roleplay chat transcript. Extract durable, canonical world facts worth remembering across future sessions — named characters, locations, items, factions/groups, key events, and established lore or concepts.
+
+Output rules:
+- Return ONLY a JSON array. No prose, no markdown fences.
+- Each item: {"keys": ["keyword1", "keyword2"], "content": "fact in one or two sentences", "category": "Character"}.
+- "category" must be one of: Character, Location, Item, Faction, Event, Lore.
+- "keys" are short trigger words a future keyword scan would look for to surface this fact (names, aliases, place names, object names).
+- Skip facts already covered by the "Already extracted" list.
+- Skip transient chatter (greetings, small talk, weather flavor, one-off reactions).
+- Prefer durable world-state over moment-to-moment action.
+- If nothing new is worth recording, return [].`;
+
+function buildUserPrompt(chunk: string, knownDigest: string): string {
+  return `Already extracted (do not repeat these):
+${knownDigest || '(none yet)'}
+
+Chat transcript excerpt:
+${chunk}
+
+New lorebook entries (JSON array):`;
+}
+
+/**
+ * Run the full extraction across all chunks sequentially, deduping as it goes.
+ * Resolves with the collected drafts plus coverage metadata. Honors `signal`
+ * for cancellation (throws the standard AbortError, like fetch).
+ */
+export async function extractLorebookEntries(
+  messages: TranscriptMsg[],
+  characterName: string,
+  opts: ExtractOptions = {}
+): Promise<ExtractResult> {
+  const { provider, model, signal, onProgress } = opts;
+  const messagesTotal = messages.filter((m) => !m.isSystem).length;
+  const chunks = planChunks(messages, characterName);
+  const total = chunks.length;
+
+  const messagesProcessed = countProcessedMessages(
+    messages,
+    characterName,
+    total
+  );
+
+  const entries: DraftLorebookEntry[] = [];
+  // Cheap dedupe key, matching autoMemory: normalized content prefix.
+  const seenContent = new Set<string>();
+
+  for (let i = 0; i < chunks.length; i++) {
+    if (signal?.aborted) {
+      throw new DOMException('Aborted', 'AbortError');
+    }
+
+    // Digest of already-found entries so later chunks don't repeat themselves.
+    const knownDigest = entries
+      .slice(-40)
+      .map((e) => `- (${e.keys.join(', ')}) ${e.content}`)
+      .join('\n');
+
+    const stream = await api.generateMessage(
+      [
+        { role: 'system', content: SYSTEM_PROMPT },
+        { role: 'user', content: buildUserPrompt(chunks[i], knownDigest) },
+      ],
+      characterName,
+      provider,
+      model,
+      signal,
+      // Entry lists are long; the default 1024 truncates mid-array and the
+      // whole chunk's output is lost. Give the model room to finish.
+      { maxTokens: 8192 }
+    );
+
+    if (!stream) {
+      throw new Error('No response from the model during extraction.');
+    }
+
+    let raw = '';
+    for await (const token of parseSSEStream(stream)) {
+      raw += token;
+    }
+
+    for (const entry of parseEntriesFromResponse(raw)) {
+      const norm = entry.content.trim().toLowerCase().slice(0, 80);
+      if (seenContent.has(norm)) continue;
+      seenContent.add(norm);
+      entries.push(entry);
+    }
+
+    onProgress?.(i + 1, total);
+  }
+
+  return {
+    entries,
+    messagesProcessed,
+    messagesTotal,
+    truncated: messagesProcessed < messagesTotal,
+  };
+}


### PR DESCRIPTION
## Summary
Adds a one-shot, user-triggered flow that distills an entire chat into a new standalone **lorebook** (characters, locations, items, factions, events, lore). The active model extracts entries in token-budgeted chunks; they're shown in an **editable review modal**, then written as a new World Info book.

**Two entry points:**
- In-chat options menu → "Create lorebook from chat" (current chat; shown once the chat has ≥6 messages).
- World Info page → "Generate from chat" → pick any character + saved chat.

**Also fixes generation for models that reject the `temperature` sampler (Claude 4.7+).** `api.generateMessage` was sending `temperature` unconditionally; newer models 400 on it, which silently broke *all* generation (chat included) for those models. Now omitted via `modelRejectsSamplers()`.

## Files
- New: `src/utils/lorebookFromTranscript.ts` (chunking, extraction, truncation-tolerant JSON parsing), `src/components/worldinfo/GenerateLorebookModal.tsx`, `src/components/worldinfo/ChatPickerModal.tsx`
- Edited: `src/api/client.ts`, `src/components/chat/ChatOptionsMenu.tsx`, `src/components/chat/ChatView.tsx`, `src/components/worldinfo/WorldInfoPage.tsx`

## Testing
Verified end-to-end against a live Claude generation: extracted 17 categorized entries from a sample chat → reviewed/edited → created a new World Info book. `npm run build` and `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)