### PR TITLE
feat(character-preview): show only creator notes in the info modal

### DIFF
--- a/src/components/character/CharacterPreviewModal.tsx
+++ b/src/components/character/CharacterPreviewModal.tsx
@@ -11,9 +11,11 @@ interface CharacterPreviewModalProps {
 }
 
 /**
- * Read-only preview of a character's details — surfaced before the user
- * commits to opening a chat. Lets users browse the description, scenario,
- * personality, first message and tags without entering the chat view first.
+ * Read-only preview of a character — surfaced before the user commits to
+ * opening a chat. Shows the avatar, tags, and the creator's notes (the
+ * author-written, user-facing blurb) only — deliberately NOT the prompt
+ * internals (description, personality, scenario, first message), which are
+ * model-facing and not meant as preview reading.
  *
  * Triggered from the character list (sidebar) by the per-row info button;
  * not used from any flow that already has the character loaded.
@@ -28,14 +30,6 @@ export function CharacterPreviewModal({
 
   // Prefer the canonical CharacterInfo fields, falling back to nested
   // `data.*` for V2 cards that only populated the spec-shape copy.
-  const description =
-    character.description?.trim() || character.data?.description?.trim() || '';
-  const personality =
-    character.personality?.trim() || character.data?.personality?.trim() || '';
-  const scenario =
-    character.scenario?.trim() || character.data?.scenario?.trim() || '';
-  const firstMessage =
-    character.first_mes?.trim() || character.data?.first_mes?.trim() || '';
   const creator =
     character.creator?.trim() || character.data?.creator?.trim() || '';
   const creatorNotes =
@@ -83,39 +77,17 @@ export function CharacterPreviewModal({
           </div>
         )}
 
-        {/* Description */}
-        {description && (
-          <PreviewSection label="Description" body={description} />
-        )}
-
-        {/* Personality */}
-        {personality && (
-          <PreviewSection label="Personality" body={personality} />
-        )}
-
-        {/* Scenario */}
-        {scenario && <PreviewSection label="Scenario" body={scenario} />}
-
-        {/* First message */}
-        {firstMessage && (
-          <PreviewSection label="First message" body={firstMessage} />
-        )}
-
-        {/* Creator notes */}
+        {/* Creator notes — the only detail surfaced here */}
         {creatorNotes && (
           <PreviewSection label="Creator notes" body={creatorNotes} />
         )}
 
-        {/* Empty-state — nothing meaningful to show */}
-        {!description &&
-          !personality &&
-          !scenario &&
-          !firstMessage &&
-          !creatorNotes && (
-            <p className="text-sm text-[var(--color-text-secondary)] italic text-center py-6">
-              This character doesn&apos;t have a description yet.
-            </p>
-          )}
+        {/* Empty-state — no creator notes to show */}
+        {!creatorNotes && (
+          <p className="text-sm text-[var(--color-text-secondary)] italic text-center py-6">
+            This character doesn&apos;t have any creator notes yet.
+          </p>
+        )}
 
         {/* Actions */}
         <div className="flex gap-3 pt-4 border-t border-[var(--color-border)]">


### PR DESCRIPTION
## Summary

The character preview modal (opened by the per-row **info** icon in the sidebar) showed the character's **description, personality, scenario, and first message** — all model-facing prompt material, not meant as user-facing preview reading, and often long or spoilery.

It now surfaces **only the creator's notes** (the author-written, user-facing blurb), alongside the avatar, "by creator" line, and tags that were already there. The empty state changes from "doesn't have a description yet" to "doesn't have any creator notes yet."

## Verification

Drove the real modal in a browser against a fixture whose prompt fields and creator notes were distinctly labeled:

| Check | Result |
|---|---|
| Creator notes shown | ✅ |
| Description / Personality / Scenario / First message | ✅ all removed (no leak) |
| Section headers in modal | only `Creator notes` |
| Avatar / "by Sammy" / tags / Chat button | ✅ kept |
| Empty state (no creator notes) | ✅ "doesn't have any creator notes yet", no prompt-field leak, chrome preserved |

`npm run build` (matches CI) green; eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)