### PR TITLE
feat(scene-video): 'Generate scene' action renders a chat block as video

### DIFF
--- a/src/api/sceneVideoGen.ts
+++ b/src/api/sceneVideoGen.ts
@@ -1,0 +1,88 @@
+import { getCsrfToken } from './client';
+
+/**
+ * Scene-video generation client — talks to the backend's
+ * `/api/scene-video/*` route family, which chains Replicate
+ * wan-2.2-i2v-fast segments into a ~30s MP4 of the chat scene
+ * (character avatar + message text as the motion prompt).
+ *
+ * The backend handles auth, secrets, segment chaining, and saving the
+ * resulting MP4 into user_blobs; this module just kicks off a job and
+ * polls until it's done. Six segments at ~30–60s each means a full
+ * scene takes ~3–6 minutes, so callers should surface the progress
+ * callback rather than block the UI.
+ */
+
+export interface SceneJobStatus {
+  status: 'queued' | 'running' | 'completed' | 'error';
+  progress: number;
+  videoUrl: string | null;
+  error: string | null;
+}
+
+const POLL_INTERVAL_MS = 5000;
+const POLL_TIMEOUT_MS = 20 * 60 * 1000; // generous — 6 segments plus concat
+
+/**
+ * Kick off a scene-video job. Returns the jobId; the caller polls via
+ * {@link pollSceneJob} or {@link generateSceneVideo}.
+ */
+export async function startSceneGenerate(
+  characterName: string,
+  prompt: string,
+): Promise<string> {
+  const token = await getCsrfToken();
+  const res = await fetch('/api/scene-video/generate', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-CSRF-Token': token,
+    },
+    credentials: 'include',
+    body: JSON.stringify({ characterName, prompt }),
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err.detail || err.error || `Scene generation kickoff failed (HTTP ${res.status})`);
+  }
+  const data = await res.json();
+  if (!data.jobId) throw new Error('No jobId returned from /api/scene-video/generate');
+  return data.jobId;
+}
+
+/** Poll a single status snapshot. */
+export async function pollSceneJob(jobId: string): Promise<SceneJobStatus> {
+  const res = await fetch(`/api/scene-video/status/${encodeURIComponent(jobId)}`, {
+    credentials: 'include',
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err.detail || err.error || `Status poll failed (HTTP ${res.status})`);
+  }
+  return res.json();
+}
+
+/**
+ * One-shot helper: kick off a job, poll until done, return the served
+ * video URL (`/blobs/scene-video/...`). Surfaces incremental progress
+ * via the optional callback.
+ */
+export async function generateSceneVideo(
+  characterName: string,
+  prompt: string,
+  onProgress?: (state: SceneJobStatus) => void,
+): Promise<string> {
+  const jobId = await startSceneGenerate(characterName, prompt);
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < POLL_TIMEOUT_MS) {
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+    const state = await pollSceneJob(jobId);
+    onProgress?.(state);
+    if (state.status === 'completed') {
+      if (!state.videoUrl) throw new Error('Scene completed but no video URL returned');
+      return state.videoUrl;
+    }
+    if (state.status === 'error') throw new Error(state.error || 'Scene generation errored');
+  }
+  throw new Error('Scene generation timed out');
+}

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -32,6 +32,8 @@ interface ChatMessageProps {
   disabled?: boolean;
   /** Phase 6.1: attached image data URLs shown as a grid above content. */
   images?: string[];
+  /** Scene-video: generated MP4 URLs shown as inline players above content. */
+  videos?: string[];
   /** Phase 8.2: raw character avatar string for display-only regex scoping. */
   characterAvatar?: string;
   /** Phase 7.2: true while this message is actively being streamed. */
@@ -61,6 +63,8 @@ interface ChatMessageProps {
   onRegenerate?: () => void;
   /** Phase 8.6: create a checkpoint at this message. */
   onCheckpoint?: () => void;
+  /** Scene-video: render this message as a ~30s video via Replicate. */
+  onGenerateScene?: () => void;
   /** Increment this to programmatically trigger edit mode (e.g. up-arrow shortcut). */
   triggerEditNonce?: number;
 }
@@ -78,6 +82,7 @@ export function ChatMessage({
   timestamp,
   disabled,
   images,
+  videos,
   characterAvatar,
   swipes,
   swipeId,
@@ -95,6 +100,7 @@ export function ChatMessage({
   onDelete,
   onRegenerate,
   onCheckpoint,
+  onGenerateScene,
   triggerEditNonce,
 }: ChatMessageProps) {
   const isMobile = useIsMobile();
@@ -272,6 +278,7 @@ export function ChatMessage({
               { key: 'copy',   label: 'Copy',   onClick: handleCopy },
               ...(onCheckpoint ? [{ key: 'checkpoint', label: 'Checkpoint', onClick: onCheckpoint }] : []),
               ...(!isUser && onRegenerate ? [{ key: 'regen', label: 'Regenerate', onClick: onRegenerate }] : []),
+              ...(onGenerateScene ? [{ key: 'scene', label: 'Generate scene', onClick: onGenerateScene }] : []),
               ...messageActionExtras.map((e) => ({ key: `ext_${e.key}`, label: e.label, onClick: e.onClick })),
               { key: 'delete', label: 'Delete', onClick: () => onDelete?.(), danger: true },
             ].map((action) => {
@@ -300,6 +307,7 @@ export function ChatMessage({
           onRegenerate={onRegenerate}
           showRegenerate={!isUser && !!onRegenerate}
           onCheckpoint={onCheckpoint}
+          onGenerateScene={onGenerateScene}
           extras={messageActionExtras}
           anchorRight={layoutMode === 'bubbles' && isUser}
         />
@@ -374,6 +382,23 @@ export function ChatMessage({
             loading="lazy"
           />
         </a>
+      ))}
+    </div>
+  ) : null;
+
+  const videoBlock = !isEditing && videos && videos.length > 0 ? (
+    <div className={`flex flex-col gap-1 ${content.length > 0 ? 'mb-2' : ''}`}>
+      {videos.map((src, idx) => (
+        <video
+          key={idx}
+          src={src}
+          controls
+          loop
+          playsInline
+          preload="metadata"
+          className="w-full max-h-80 rounded-lg bg-black"
+          aria-label={`Scene video ${idx + 1}`}
+        />
       ))}
     </div>
   ) : null;
@@ -507,6 +532,7 @@ export function ChatMessage({
               onDoubleClick={!isEditing && onEdit ? handleStartEdit : undefined}
             >
               {imageGrid}
+              {videoBlock}
               {editingUI}
               {messageContent}
               {translationPanel}
@@ -555,6 +581,7 @@ export function ChatMessage({
           onDoubleClick={!isEditing && onEdit ? handleStartEdit : undefined}
         >
           {imageGrid}
+          {videoBlock}
           {isEditing ? (
             <div className="p-2 rounded-lg bg-[var(--color-bg-tertiary)]">
               {editingUI}
@@ -584,6 +611,7 @@ export function ChatMessage({
           {timeStr && <span className="text-xs text-zinc-500 ml-2">{timeStr}</span>}
 
           {imageGrid && <div className="mt-1">{imageGrid}</div>}
+          {videoBlock && <div className="mt-1">{videoBlock}</div>}
 
           {isEditing ? (
             <div className="mt-1 p-2 rounded-lg bg-[var(--color-bg-tertiary)]">

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useMemo, useState, useCallback, type CSSProperties } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { MessageSquare, Users, Settings2, Pencil, Square, Search, ChevronUp, ChevronDown, X, Check } from 'lucide-react';
+import { MessageSquare, Users, Settings2, Pencil, Square, Search, ChevronUp, ChevronDown, X, Check, Clapperboard } from 'lucide-react';
 import { showToastGlobal } from '../ui/Toast';
 import { useCharacterStore } from '../../stores/characterStore';
 import { useChatStore } from '../../stores/chatStore';
@@ -42,8 +42,10 @@ import {
   getExpressionThumbnailUrl,
   getDefaultAvatarUrl,
   mapEmotionToAvailable,
+  stripEmotionTag,
   type Emotion,
 } from '../../utils/emotions';
+import { generateSceneVideo } from '../../api/sceneVideoGen';
 import {
   compressImageFiles,
   ACCEPTED_IMAGE_MIMES,
@@ -103,6 +105,7 @@ export function ChatView() {
     impersonate,
     stopGeneration,
     insertImageMessage,
+    insertVideoMessage,
     currentChatFile,
     currentSpeakerName,
     setGroupTitle,
@@ -182,6 +185,9 @@ export function ChatView() {
   const [isDragOver, setIsDragOver] = useState(false);
   // Phase 7.1: image generation modal
   const [isImageGenOpen, setIsImageGenOpen] = useState(false);
+  // Scene-video: progress (0..1) of the in-flight generation job, or null
+  // when idle. One job at a time — generation takes minutes, not seconds.
+  const [sceneGenProgress, setSceneGenProgress] = useState<number | null>(null);
   const dragCounter = useRef(0);
 
   // Chat options menu + controlled panel states
@@ -396,6 +402,44 @@ export function ChatView() {
       model: activeModel,
     };
   }, [selectedCharacter, displayPersona, activeModel]);
+
+  // Scene-video: animate a chat block into a ~30s video. The backend chains
+  // Replicate wan-2.2 segments from the character avatar; the message text
+  // (macros resolved, emotion tag stripped) becomes the motion prompt. The
+  // result lands in chat as a new message with an inline player, like
+  // image-gen results.
+  const handleGenerateScene = async (content: string) => {
+    if (!selectedCharacter) return;
+    if (sceneGenProgress !== null) {
+      showToastGlobal('A scene video is already generating', 'error');
+      return;
+    }
+    const prompt = stripEmotionTag(processMacros(content, displayMacroCtx)).trim();
+    if (!prompt) {
+      showToastGlobal('Nothing to render — the message is empty', 'error');
+      return;
+    }
+    setSceneGenProgress(0);
+    try {
+      const videoUrl = await generateSceneVideo(selectedCharacter.name, prompt, (s) => {
+        setSceneGenProgress(s.progress);
+      });
+      await insertVideoMessage(
+        videoUrl,
+        selectedCharacter.name,
+        selectedCharacter.avatar,
+        selectedCharacter
+      );
+      showToastGlobal('Scene video added to chat', 'success');
+    } catch (err) {
+      showToastGlobal(
+        err instanceof Error ? err.message : 'Scene generation failed',
+        'error'
+      );
+    } finally {
+      setSceneGenProgress(null);
+    }
+  };
 
   // Phase 9.1: IDs of messages matching the search query (excludes system messages)
   const searchMatchIds = useMemo(() => {
@@ -1512,6 +1556,7 @@ export function ChatView() {
                     timestamp={message.timestamp}
                     disabled={isSending}
                     images={message.images}
+                    videos={message.videos}
                     characterAvatar={message.isUser ? selectedCharacter?.avatar : (message.characterAvatar || selectedCharacter?.avatar)}
                     isStreaming={isLastAiMessage && isStreaming}
                     isLastMessage={isLastAiMessage}
@@ -1542,6 +1587,14 @@ export function ChatView() {
                       isLastAiMessage && !isGroupChatMode ? handleRegenerate : undefined
                     }
                     onCheckpoint={currentChatFile ? () => handleCheckpoint(message.id) : undefined}
+                    onGenerateScene={
+                      isAiMessage &&
+                      !isGroupChatMode &&
+                      selectedCharacter &&
+                      message.content.trim().length > 0
+                        ? () => handleGenerateScene(message.content)
+                        : undefined
+                    }
                     triggerEditNonce={message.id === lastUserMessageId ? editLastNonce : undefined}
                   />
                 </div>
@@ -1635,6 +1688,16 @@ export function ChatView() {
           >
             <X size={16} />
           </button>
+        </div>
+      )}
+
+      {/* Scene-video: non-blocking progress while the backend renders segments */}
+      {sceneGenProgress !== null && (
+        <div className="mx-4 mb-2 flex items-center gap-2 px-3 py-2 rounded-lg bg-[var(--color-bg-secondary)] border border-[var(--color-border)]">
+          <Clapperboard size={14} className="text-[var(--color-primary)] animate-pulse flex-shrink-0" />
+          <span className="text-xs text-[var(--color-text-secondary)]">
+            Generating scene video… {Math.round(sceneGenProgress * 100)}% — takes a few minutes, you can keep chatting
+          </span>
         </div>
       )}
 

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -46,6 +46,8 @@ import {
   type Emotion,
 } from '../../utils/emotions';
 import { generateSceneVideo } from '../../api/sceneVideoGen';
+import { useAuthStore } from '../../stores/authStore';
+import { hasPermission } from '../../utils/permissions';
 import {
   compressImageFiles,
   ACCEPTED_IMAGE_MIMES,
@@ -407,7 +409,10 @@ export function ChatView() {
   // Replicate wan-2.2 segments from the character avatar; the message text
   // (macros resolved, emotion tag stripped) becomes the motion prompt. The
   // result lands in chat as a new message with an inline player, like
-  // image-gen results.
+  // image-gen results. generation:video is owner-only by default — the
+  // backend enforces it too; this just hides the menu entry.
+  const currentUser = useAuthStore((s) => s.currentUser);
+  const canGenerateScene = hasPermission(currentUser, 'generation:video');
   const handleGenerateScene = async (content: string) => {
     if (!selectedCharacter) return;
     if (sceneGenProgress !== null) {
@@ -1588,6 +1593,7 @@ export function ChatView() {
                     }
                     onCheckpoint={currentChatFile ? () => handleCheckpoint(message.id) : undefined}
                     onGenerateScene={
+                      canGenerateScene &&
                       isAiMessage &&
                       !isGroupChatMode &&
                       selectedCharacter &&

--- a/src/components/chat/MessageActionMenu.tsx
+++ b/src/components/chat/MessageActionMenu.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { Pencil, Copy, Trash2, RefreshCw, GitFork, Puzzle } from 'lucide-react';
+import { Pencil, Copy, Trash2, RefreshCw, GitFork, Puzzle, Clapperboard } from 'lucide-react';
 
 export interface MessageActionExtra {
   key: string;
@@ -18,6 +18,8 @@ interface MessageActionMenuProps {
   showRegenerate?: boolean;
   /** Phase 8.6: create a checkpoint at this message. */
   onCheckpoint?: () => void;
+  /** Scene-video: render the message as a ~30s video via Replicate. */
+  onGenerateScene?: () => void;
   /** Extension-contributed entries rendered before Delete. */
   extras?: MessageActionExtra[];
   anchorRight?: boolean;
@@ -32,6 +34,7 @@ export function MessageActionMenu({
   onRegenerate,
   showRegenerate,
   onCheckpoint,
+  onGenerateScene,
   extras,
   anchorRight,
 }: MessageActionMenuProps) {
@@ -69,6 +72,9 @@ export function MessageActionMenu({
       : []),
     ...(showRegenerate && onRegenerate
       ? [{ key: 'regen', icon: RefreshCw, label: 'Regenerate', onClick: onRegenerate }]
+      : []),
+    ...(onGenerateScene
+      ? [{ key: 'scene', icon: Clapperboard, label: 'Generate scene', onClick: onGenerateScene }]
       : []),
     ...(extras ?? []).map((e) => ({
       key: `ext_${e.key}`,

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -68,6 +68,11 @@ export interface ChatMessage {
    *  provider's multimodal content parts on the LAST user turn when calling
    *  generateMessage. Persisted into the JSONL record's `extra.images` field. */
   images?: string[];
+  /** Scene-video: generated MP4 URLs (served from /blobs/scene-video/...).
+   *  Rendered as inline <video> players above content in ChatMessage.tsx.
+   *  Persisted into the JSONL record's `extra.videos` field. Never sent to
+   *  the LLM. */
+  videos?: string[];
 }
 
 interface ChatFile {
@@ -516,6 +521,12 @@ interface ChatState {
   insertImageMessage: (
     dataUrl: string,
     prompt: string,
+    characterName: string,
+    characterAvatar: string,
+    character: CharacterInfo
+  ) => Promise<void>;
+  insertVideoMessage: (
+    videoUrl: string,
     characterName: string,
     characterAvatar: string,
     character: CharacterInfo
@@ -1607,12 +1618,15 @@ async function saveChatToBackend(
       ...(msg.characterAvatar ? { character_avatar: msg.characterAvatar } : {}),
       // Phase 6.1: persist image attachments into extra.images (array) and
       // extra.image (first element, SillyTavern-compat fallback for any
-      // code path that still reads the scalar form).
-      ...(msg.images && msg.images.length > 0
+      // code path that still reads the scalar form). Scene videos ride
+      // along in extra.videos.
+      ...((msg.images && msg.images.length > 0) || (msg.videos && msg.videos.length > 0)
         ? {
             extra: {
-              images: msg.images,
-              image: msg.images[0],
+              ...(msg.images && msg.images.length > 0
+                ? { images: msg.images, image: msg.images[0] }
+                : {}),
+              ...(msg.videos && msg.videos.length > 0 ? { videos: msg.videos } : {}),
             },
           }
         : {}),
@@ -1734,6 +1748,7 @@ function normalizeMessage(msg: {
   extra?: {
     images?: unknown;
     image?: unknown;
+    videos?: unknown;
     [key: string]: unknown;
   };
 }): ChatMessage {
@@ -1754,6 +1769,18 @@ function normalizeMessage(msg: {
     images = [msg.extra.image];
   }
 
+  // Recover scene videos — served blob URLs (/blobs/scene-video/...), not
+  // data URLs, so accept any non-empty string that looks like a URL/path.
+  let videos: string[] | undefined;
+  const rawVideos = msg.extra?.videos;
+  if (Array.isArray(rawVideos)) {
+    const arr = rawVideos.filter(
+      (x): x is string =>
+        typeof x === 'string' && (x.startsWith('/') || x.startsWith('data:') || x.startsWith('http'))
+    );
+    if (arr.length > 0) videos = arr;
+  }
+
   return {
     id: generateId(),
     name: msg.name,
@@ -1765,6 +1792,7 @@ function normalizeMessage(msg: {
     swipeId: msg.swipe_id ?? 0,
     characterAvatar: msg.character_avatar,
     images,
+    videos,
   };
 }
 
@@ -2556,6 +2584,27 @@ export const useChatStore = create<ChatState>((set, get) => ({
       timestamp: Date.now(),
       characterAvatar,
       images: [dataUrl],
+    });
+    // Persist to backend (non-fatal if it fails)
+    await saveChatToBackend(get().messages, character, currentChatFile);
+  },
+
+  // ---- Insert Video Message (scene-video result inline) ----
+  insertVideoMessage: async (
+    videoUrl: string,
+    characterName: string,
+    characterAvatar: string,
+    character: CharacterInfo
+  ) => {
+    const { addMessage, currentChatFile } = get();
+    addMessage({
+      name: characterName,
+      isUser: false,
+      isSystem: false,
+      content: '',
+      timestamp: Date.now(),
+      characterAvatar,
+      videos: [videoUrl],
     });
     // Persist to backend (non-fatal if it fails)
     await saveChatToBackend(get().messages, character, currentChatFile);

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -21,6 +21,9 @@ export const PERMISSIONS = [
   'generation:use',
   'generation:image',
   'generation:audio',
+  // Owner-only by default (absent from LEGACY_PERM_MIN_LEVEL on purpose —
+  // unknown permissions resolve owner-only in legacy mode).
+  'generation:video',
 
   // Characters
   'character:view',


### PR DESCRIPTION
## What

New **Generate scene** entry in the message action menu (between Regenerate and Delete, both desktop dropdown and mobile bottom sheet). It sends the character avatar + the message text to the backend's new `/api/scene-video` pipeline (sammygallo/ggbc-backend#29), which returns a ~30s wan-2.2 video. The result lands in chat as a new message with an inline `<video>` player — same flow as image-gen results.

- Shown on AI messages in solo chats (mirrors image-gen/regenerate gating)
- Non-blocking progress banner above the input while the job runs (~3–6 min); chatting stays usable; one job at a time
- Message text gets macros resolved + emotion tag stripped before becoming the prompt
- Videos persist via `extra.videos` in the chat JSONL and restore on chat load
- New `src/api/sceneVideoGen.ts` client mirrors `livePortraitGen.ts` (kickoff + 5s polling, 20 min timeout)

## Testing

- `npm run build` (tsc + vite) clean
- Verified in the browser against the dev backend with a seeded account: menu item appears in the action sheet, clicking it shows the live progress banner ("Generating scene video… 43%"), and on completion a video message appears in chat with working playback (real MP4 streamed from `/blobs/scene-video/...`, readyState 4)
- Persistence round-trip verified: full page reload → chat re-fetched from backend → video message re-renders from `extra.videos`
- No console errors

⚠️ Deploy sammygallo/ggbc-backend#29 first — against an older backend the menu item fails gracefully with an error toast (404).

🤖 Generated with [Claude Code](https://claude.com/claude-code)