### PR TITLE
feat(scene-video): summarize transcript into an editable scene prompt

### DIFF
--- a/src/api/sceneVideoGen.ts
+++ b/src/api/sceneVideoGen.ts
@@ -2,14 +2,15 @@ import { getCsrfToken } from './client';
 
 /**
  * Scene-video generation client — talks to the backend's
- * `/api/scene-video/*` route family, which chains Replicate
- * wan-2.2-i2v-fast segments into a ~30s MP4 of the chat scene
- * (character avatar + message text as the motion prompt).
+ * `/api/scene-video/*` route family, which renders Replicate
+ * wan-2.7-r2v segments (character avatar as the identity reference,
+ * scene prompt from the transcript summarizer) and concatenates them
+ * into a ~30s MP4.
  *
- * The backend handles auth, secrets, segment chaining, and saving the
+ * The backend handles auth, secrets, segment rendering, and saving the
  * resulting MP4 into user_blobs; this module just kicks off a job and
- * polls until it's done. Six segments at ~30–60s each means a full
- * scene takes ~3–6 minutes, so callers should surface the progress
+ * polls until it's done. Three 10s segments at minutes each means a
+ * full scene can take a while, so callers should surface the progress
  * callback rather than block the UI.
  */
 
@@ -21,7 +22,8 @@ export interface SceneJobStatus {
 }
 
 const POLL_INTERVAL_MS = 5000;
-const POLL_TIMEOUT_MS = 20 * 60 * 1000; // generous — 6 segments plus concat
+// Generous — matches the backend's 10-min-per-segment budget (×3) + concat.
+const POLL_TIMEOUT_MS = 35 * 60 * 1000;
 
 /**
  * Kick off a scene-video job. Returns the jobId; the caller polls via

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -14,6 +14,8 @@ import { BottomSheet } from '../ui/BottomSheet';
 import { ChatHistoryPanel } from './ChatHistoryPanel';
 import { ChatLorebookModal } from './ChatLorebookModal';
 import { GenerateLorebookModal } from '../worldinfo/GenerateLorebookModal';
+import { GenerateSceneModal } from './GenerateSceneModal';
+import type { TranscriptMsg } from '../../utils/lorebookFromTranscript';
 import { useWorldInfoStore } from '../../stores/worldInfoStore';
 import { GroupChatControls } from './GroupChatControls';
 import { AuthorNote } from './AuthorNote';
@@ -405,25 +407,48 @@ export function ChatView() {
     };
   }, [selectedCharacter, displayPersona, activeModel]);
 
-  // Scene-video: animate a chat block into a ~30s video. The backend chains
-  // Replicate wan-2.2 segments from the character avatar; the message text
-  // (macros resolved, emotion tag stripped) becomes the motion prompt. The
-  // result lands in chat as a new message with an inline player, like
-  // image-gen results. generation:video is owner-only by default — the
-  // backend enforces it too; this just hides the menu entry.
+  // Scene-video: render the current chat moment as a ~30s video. Tapping
+  // "Generate scene" opens GenerateSceneModal, which distills the recent
+  // transcript into an editable scene prompt via the active text model;
+  // on confirm the backend renders wan-2.7-r2v segments with the character
+  // avatar as an identity reference (not the first frame). The result lands
+  // in chat as a new message with an inline player, like image-gen results.
+  // generation:video is owner-only by default — the backend enforces it
+  // too; this just hides the menu entry.
   const currentUser = useAuthStore((s) => s.currentUser);
   const canGenerateScene = hasPermission(currentUser, 'generation:video');
-  const handleGenerateScene = async (content: string) => {
+  const [sceneModal, setSceneModal] = useState<{
+    transcript: TranscriptMsg[];
+    fallbackPrompt: string;
+  } | null>(null);
+  const handleGenerateScene = (messageId: string, content: string) => {
     if (!selectedCharacter) return;
     if (sceneGenProgress !== null) {
       showToastGlobal('A scene video is already generating', 'error');
       return;
     }
-    const prompt = stripEmotionTag(processMacros(content, displayMacroCtx)).trim();
-    if (!prompt) {
+    const fallbackPrompt = stripEmotionTag(processMacros(content, displayMacroCtx)).trim();
+    if (!fallbackPrompt) {
       showToastGlobal('Nothing to render — the message is empty', 'error');
       return;
     }
+    // Summarize only the transcript up to the chosen message — later
+    // messages would leak a scene the user didn't pick.
+    const idx = messages.findIndex((m) => m.id === messageId);
+    const transcript = (idx >= 0 ? messages.slice(0, idx + 1) : messages)
+      .filter((m) => !m.isSystem)
+      .map((m) => ({
+        name: m.name,
+        isUser: m.isUser,
+        isSystem: m.isSystem,
+        content: stripEmotionTag(processMacros(m.content, displayMacroCtx)).trim(),
+      }))
+      .filter((m) => m.content.length > 0);
+    setSceneModal({ transcript, fallbackPrompt });
+  };
+
+  const startSceneRender = async (prompt: string) => {
+    if (!selectedCharacter) return;
     setSceneGenProgress(0);
     try {
       const videoUrl = await generateSceneVideo(selectedCharacter.name, prompt, (s) => {
@@ -1598,7 +1623,7 @@ export function ChatView() {
                       !isGroupChatMode &&
                       selectedCharacter &&
                       message.content.trim().length > 0
-                        ? () => handleGenerateScene(message.content)
+                        ? () => handleGenerateScene(message.id, message.content)
                         : undefined
                     }
                     triggerEditNonce={message.id === lastUserMessageId ? editLastNonce : undefined}
@@ -1852,6 +1877,22 @@ export function ChatView() {
           messages={messages}
           characterName={selectedCharacter.name}
           defaultBookName={`${selectedCharacter.name} — Lore`}
+        />
+      )}
+
+      {/* Scene-video: summarize transcript → editable prompt → paid render */}
+      {selectedCharacter && (
+        <GenerateSceneModal
+          isOpen={sceneModal !== null}
+          onClose={() => setSceneModal(null)}
+          messages={sceneModal?.transcript ?? []}
+          characterName={selectedCharacter.name}
+          characterDescription={displayMacroCtx.characterDescription}
+          fallbackPrompt={sceneModal?.fallbackPrompt ?? ''}
+          onGenerate={(p) => {
+            setSceneModal(null);
+            void startSceneRender(p);
+          }}
         />
       )}
 

--- a/src/components/chat/GenerateSceneModal.tsx
+++ b/src/components/chat/GenerateSceneModal.tsx
@@ -1,0 +1,171 @@
+/**
+ * GenerateSceneModal — review/edit the scene prompt before a paid render.
+ *
+ * Flow: on open, the active text model summarizes the recent transcript into
+ * a video prompt (one call, a few seconds) → the user edits or rewrites it →
+ * Generate hands the final prompt back to ChatView, which runs the existing
+ * scene-video job. If summarization fails (no provider, stream error), the
+ * raw message text is prefilled instead so the feature still works.
+ *
+ * The render itself is real Replicate spend (~30s of per-second-billed video),
+ * which is why a confirm step sits between the menu tap and the job.
+ */
+import { useEffect, useRef, useState } from 'react';
+import { Clapperboard, Loader2, Sparkles } from 'lucide-react';
+import { Modal, Button, TextArea } from '../ui';
+import { useSettingsStore } from '../../stores/settingsStore';
+import { summarizeScene } from '../../utils/sceneFromTranscript';
+import type { TranscriptMsg } from '../../utils/lorebookFromTranscript';
+
+interface GenerateSceneModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  /** Transcript tail ending at the chosen message, macros already resolved. */
+  messages: TranscriptMsg[];
+  characterName: string;
+  characterDescription?: string;
+  /** The chosen message's processed text — used when summarization fails. */
+  fallbackPrompt: string;
+  onGenerate: (prompt: string) => void;
+}
+
+type Phase = 'summarizing' | 'review';
+
+export function GenerateSceneModal({
+  isOpen,
+  onClose,
+  messages,
+  characterName,
+  characterDescription,
+  fallbackPrompt,
+  onGenerate,
+}: GenerateSceneModalProps) {
+  const [phase, setPhase] = useState<Phase>('summarizing');
+  const [prompt, setPrompt] = useState('');
+  const [notice, setNotice] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const runSummarize = async () => {
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setPhase('summarizing');
+    setNotice(null);
+
+    try {
+      const { activeProvider, activeModel } = useSettingsStore.getState();
+      const result = await summarizeScene(messages, characterName, {
+        characterDescription,
+        provider: activeProvider,
+        model: activeModel,
+        signal: controller.signal,
+      });
+      setPrompt(result);
+      setPhase('review');
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') return;
+      setNotice(
+        `Scene summary failed: ${
+          err instanceof Error ? err.message : 'unknown error'
+        }. Starting from the message text instead — edit freely.`
+      );
+      setPrompt(fallbackPrompt);
+      setPhase('review');
+    } finally {
+      if (abortRef.current === controller) abortRef.current = null;
+    }
+  };
+
+  // Fresh summary each time the modal opens.
+  useEffect(() => {
+    if (!isOpen) return;
+    setPrompt('');
+    void runSummarize();
+    // Inputs are snapshotted by ChatView when it opens the modal;
+    // intentionally only re-run on open.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen]);
+
+  // Abort any in-flight summary if the modal unmounts.
+  useEffect(() => {
+    return () => abortRef.current?.abort();
+  }, []);
+
+  const handleClose = () => {
+    abortRef.current?.abort();
+    onClose();
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={handleClose} title="Generate scene video" size="lg">
+      {phase === 'summarizing' && (
+        <div className="space-y-4 py-2">
+          <div className="flex items-center gap-3 text-[var(--color-text-primary)]">
+            <Loader2 size={20} className="animate-spin text-[var(--color-primary)]" />
+            <span className="text-sm">
+              Summarizing the scene from the last {messages.length} message
+              {messages.length === 1 ? '' : 's'}…
+            </span>
+          </div>
+          <div className="flex justify-end gap-2 pt-2">
+            <Button variant="ghost" onClick={handleClose}>
+              Cancel
+            </Button>
+            <Button
+              variant="ghost"
+              onClick={() => {
+                abortRef.current?.abort();
+                setNotice(null);
+                setPrompt(fallbackPrompt);
+                setPhase('review');
+              }}
+            >
+              Skip — use message text
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {phase === 'review' && (
+        <div className="space-y-4">
+          {notice && (
+            <div className="p-2.5 rounded-lg bg-amber-500/10 border border-amber-500/30 text-xs text-amber-400">
+              {notice}
+            </div>
+          )}
+
+          <TextArea
+            label="Scene prompt"
+            value={prompt}
+            onChange={(e) => setPrompt(e.target.value)}
+            rows={7}
+          />
+
+          <div className="p-3 rounded-lg bg-[var(--color-bg-tertiary)] text-xs text-[var(--color-text-secondary)] leading-relaxed">
+            Renders three 10-second segments (~30s total) with {characterName}
+            's portrait as the identity reference. Replicate bills per second
+            of video output (currently ≈$3 per scene) and the render takes a
+            few minutes — you can keep chatting while it runs.
+          </div>
+
+          <div className="flex justify-end gap-2 pt-2">
+            <Button variant="ghost" onClick={handleClose}>
+              Cancel
+            </Button>
+            <Button variant="ghost" onClick={() => void runSummarize()}>
+              <Sparkles size={16} className="mr-2" />
+              Re-summarize
+            </Button>
+            <Button
+              onClick={() => onGenerate(prompt.trim())}
+              disabled={prompt.trim().length === 0}
+            >
+              <Clapperboard size={16} className="mr-2" />
+              Generate
+            </Button>
+          </div>
+        </div>
+      )}
+    </Modal>
+  );
+}

--- a/src/utils/sceneFromTranscript.ts
+++ b/src/utils/sceneFromTranscript.ts
@@ -1,0 +1,203 @@
+/**
+ * Scene-from-transcript — distill the tail of a chat into a single
+ * video-generation prompt for the scene-video pipeline.
+ *
+ * One model call via the user's active provider (same `api.generateMessage`
+ * SSE path as lorebookFromTranscript). The output is plain text: a compact
+ * visual description (setting, light, what the character is doing, mood)
+ * that the backend forwards to Replicate's reference-to-video model. The
+ * character's avatar travels separately as an identity reference, so the
+ * prompt describes the scene, not the character's face.
+ */
+
+import { api } from '../api/client';
+import { estimateTokens } from './tokenizer';
+import type { TranscriptMsg } from './lorebookFromTranscript';
+
+/** Transcript tokens fed to the summarizer — roughly the last scene's worth. */
+const TAIL_TOKEN_BUDGET = 2500;
+/** Hard cap on messages so token estimation never walks a giant log. */
+const MAX_TAIL_MESSAGES = 30;
+/** Cap on the returned prompt; the backend trims again at 1500. */
+const MAX_SCENE_PROMPT_CHARS = 1200;
+/** Cap on the character-description excerpt included for context. */
+const MAX_DESCRIPTION_CHARS = 600;
+
+export interface SceneSummaryOptions {
+  /** Character card description — wardrobe/setting context for the model. */
+  characterDescription?: string;
+  provider?: string;
+  model?: string;
+  signal?: AbortSignal;
+}
+
+// ---------------------------------------------------------------------------
+// SSE stream parsing — copied to match the convention already used by
+// summarizeStore, autoMemoryStore, and lorebookFromTranscript (each keeps a
+// local copy). Kept identical so behavior matches the rest of the app's
+// generation paths.
+// ---------------------------------------------------------------------------
+
+async function* parseSSEStream(
+  stream: ReadableStream<Uint8Array>
+): AsyncGenerator<string> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop() || '';
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed === 'data: [DONE]') continue;
+        if (trimmed.startsWith('data: ')) {
+          const data = trimmed.slice(6);
+          if (!data || data === '[DONE]') continue;
+          let json;
+          try {
+            json = JSON.parse(data);
+          } catch {
+            if (data.length > 0 && data !== 'undefined') yield data;
+            continue;
+          }
+          if (json?.error) {
+            const msg =
+              typeof json.error === 'string'
+                ? json.error
+                : json.error.message || 'Generation failed';
+            throw new Error(msg);
+          }
+          const content =
+            json.choices?.[0]?.delta?.content ||
+            json.choices?.[0]?.text ||
+            json.delta?.text ||
+            (json.type === 'content_block_delta' ? json.delta?.text : null) ||
+            json.content ||
+            json.message?.content?.[0]?.text ||
+            '';
+          if (content) yield content;
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+/**
+ * The non-system tail of the transcript that fits `TAIL_TOKEN_BUDGET`,
+ * rendered as "Speaker: text" lines. Walks backwards so the most recent
+ * messages always make the cut.
+ */
+function transcriptTail(messages: TranscriptMsg[], characterName: string): string {
+  const lines: string[] = [];
+  let tokens = 0;
+  const usable = messages.filter((m) => !m.isSystem && m.content.trim().length > 0);
+  for (let i = usable.length - 1; i >= 0 && lines.length < MAX_TAIL_MESSAGES; i--) {
+    const m = usable[i];
+    const speaker = m.isUser ? 'User' : m.name || characterName || 'Character';
+    const line = `${speaker}: ${m.content}`;
+    const lineTokens = estimateTokens(line);
+    if (lines.length > 0 && tokens + lineTokens > TAIL_TOKEN_BUDGET) break;
+    lines.push(line);
+    tokens += lineTokens;
+  }
+  return lines.reverse().join('\n');
+}
+
+/** Strip fences/labels/quotes the model may wrap around the prompt. */
+function cleanPromptText(raw: string): string {
+  let t = raw.trim();
+  t = t.replace(/^```[a-z]*\s*/i, '').replace(/```\s*$/, '').trim();
+  t = t.replace(/^(?:video\s*prompt|prompt|scene)\s*[:-]\s*/i, '').trim();
+  if (
+    (t.startsWith('"') && t.endsWith('"')) ||
+    (t.startsWith("'") && t.endsWith("'"))
+  ) {
+    t = t.slice(1, -1);
+  }
+  t = t.replace(/\s+/g, ' ').trim();
+  if (t.length > MAX_SCENE_PROMPT_CHARS) {
+    const cut = t.slice(0, MAX_SCENE_PROMPT_CHARS);
+    const sp = cut.lastIndexOf(' ');
+    t = sp > 0 ? cut.slice(0, sp) : cut;
+  }
+  return t;
+}
+
+function systemPrompt(characterName: string): string {
+  return `You are a prompt writer for an AI video model. From the tail of a roleplay chat, write ONE prompt describing the current moment as a short cinematic scene.
+
+Rules:
+- Output ONLY the prompt text — no preamble, no quotes, no markdown, no lists.
+- 60–120 words, present tense, third person.
+- Cover: the setting and time of day, lighting and atmosphere, what ${characterName} is physically doing (movement, posture, expression, gestures), and the mood. At most one camera hint (e.g. slow push-in).
+- ${characterName}'s face and body come from a separate reference image — do not invent facial features, hair, or body details; mention wardrobe only if the chat establishes it.
+- No dialogue or quotation marks. No inner thoughts. Only what a camera could film.`;
+}
+
+function userPrompt(
+  transcript: string,
+  characterName: string,
+  characterDescription?: string
+): string {
+  const desc = (characterDescription || '').trim().slice(0, MAX_DESCRIPTION_CHARS);
+  const descBlock = desc
+    ? `Character notes for ${characterName} (context only):\n${desc}\n\n`
+    : '';
+  return `${descBlock}Recent chat transcript:\n${transcript}\n\nVideo prompt:`;
+}
+
+/**
+ * Summarize the recent transcript into a scene prompt. Throws on provider
+ * errors or an empty result — callers fall back to the raw message text.
+ * Honors `signal` for cancellation (throws the standard AbortError).
+ */
+export async function summarizeScene(
+  messages: TranscriptMsg[],
+  characterName: string,
+  opts: SceneSummaryOptions = {}
+): Promise<string> {
+  const { characterDescription, provider, model, signal } = opts;
+
+  const transcript = transcriptTail(messages, characterName);
+  if (!transcript) {
+    throw new Error('No usable messages to summarize.');
+  }
+
+  const stream = await api.generateMessage(
+    [
+      { role: 'system', content: systemPrompt(characterName) },
+      { role: 'user', content: userPrompt(transcript, characterName, characterDescription) },
+    ],
+    characterName,
+    provider,
+    model,
+    signal,
+    // A scene prompt is ~120 words; 400 tokens leaves slack without
+    // letting a rambling model run long.
+    { maxTokens: 400 }
+  );
+
+  if (!stream) {
+    throw new Error('No response from the model.');
+  }
+
+  let raw = '';
+  for await (const token of parseSSEStream(stream)) {
+    raw += token;
+  }
+
+  const prompt = cleanPromptText(raw);
+  if (!prompt) {
+    throw new Error('The model returned an empty scene prompt.');
+  }
+  return prompt;
+}


### PR DESCRIPTION
## What

Phase 1 of the scene-video upgrade: "Generate scene" no longer fires a render straight from one message's text. It now opens **GenerateSceneModal**, which:

1. **Summarizes the transcript** up to the chosen message (token-budgeted tail, ~last 30 messages) into a ~100-word cinematic scene prompt via the active text provider — one `api.generateMessage` call, same SSE pattern as `lorebookFromTranscript`. Character-card description is passed as context; the prompt is told the face/body come from a reference image so it describes the *scene*, not the character.
2. **Shows the prompt in an editable textarea** with a cost/time note before any Replicate spend — a bad summary caught in 5 seconds beats a wasted multi-minute, ~$3 render.
3. **Falls back to the raw message text** (old behavior) if summarization fails or the user hits "Skip", so the feature works without a text provider.

Also raises the job poll timeout 20→35 min to match the backend's wan-2.7-r2v per-segment budget.

Pairs with [ggbc-backend#30](https://github.com/sammygallo/ggbc-backend/pull/30) (avatar as identity reference). The `{characterName, prompt}` wire contract is unchanged — either PR can deploy first.

## New files
- `src/utils/sceneFromTranscript.ts` — transcript tail → scene prompt
- `src/components/chat/GenerateSceneModal.tsx` — summarize → review/edit → confirm

## Verification
- `tsc -b && vite build` green; `eslint` clean on touched files (remaining ChatView warnings pre-date this PR).
- Booted the app in a preview browser from this branch: renders cleanly, zero console errors.
- **Not verified in-browser:** the modal flow itself — it needs an owner login plus a seeded AI chat, and full end-to-end needs a real ~$3 render. Worth one manual pass before deploy: tap Generate scene → check the summary quality → Cancel (no spend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)